### PR TITLE
Add a repo view beside the chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,9 @@ That = real entry point — build and run Rust app, start Vite via `beforeDevCom
 
 - `pnpm dev` — frontend only, port 1420 (`strictPort: true`, so busy port = hard failure, no fallback). `invoke` calls do nothing in plain browser, so only useful for pure-CSS/layout work.
 - `pnpm build` — `tsc && vite build`. `pnpm tauri build` for bundled app.
-- `cd apps/desktop/src-tauri && cargo test` — Rust tests (186: parser + mapper + event-model compatibility, plus git and file index). Single test: `cargo test parses_complex_fixture`.
+- `cd apps/desktop/src-tauri && cargo test` — Rust tests (223: parser + mapper + event-model compatibility, plus git and file index). Single test: `cargo test parses_complex_fixture`.
 - `cd apps/desktop/src-tauri && cargo check` — fast type check, no linking whole app.
-- `pnpm test` — frontend tests (vitest, 88, node environment, no DOM). Scoped to pure logic where being wrong invisible on screen: [streaming.ts](apps/desktop/src/lib/streaming.ts), which have wire format to get wrong and read same committed fixtures Rust tests do rather than keep own captures; and composer's caret arithmetic ([slash.ts](apps/desktop/src/lib/slash.ts), [mention.ts](apps/desktop/src/lib/mention.ts), [highlight.ts](apps/desktop/src/lib/highlight.ts)), where same string open picker or not depending only on cursor position. Components not tested — no DOM here.
+- `pnpm test` — frontend tests (vitest, 126, node environment, no DOM). Scoped to pure logic where being wrong invisible on screen: [streaming.ts](apps/desktop/src/lib/streaming.ts), which have wire format to get wrong and read same committed fixtures Rust tests do rather than keep own captures; and composer's caret arithmetic ([slash.ts](apps/desktop/src/lib/slash.ts), [mention.ts](apps/desktop/src/lib/mention.ts), [highlight.ts](apps/desktop/src/lib/highlight.ts)), where same string open picker or not depending only on cursor position. Components not tested — no DOM here.
 
 ## Architecture: the event pipeline
 
@@ -313,6 +313,48 @@ Only **tip commit's** rollup asked for (`commits(last:1)`) — check reported ag
 **Collapsed preview = plain text, so markup come off first.** `firstLine` strip heading marks, emphasis, and link syntax keeping only its text — `(https://…)` half usually longer than words around it and not clickable in truncating span anyway. Vercel comment's opener otherwise read as raw markdown.
 
 **PR body deliberately unrendered.** It one thing on panel reader wrote themselves, usually longest thing there, and it push checks — part that change — below fold. Title link out for rest. Bot comments *are* rendered as markdown: Vercel comment carry table of deploy links, and flattened to text it wall of pipe characters. `stripBotMarkers` drop `[vc]: #<base64>` line and HTML comments first — both addressed to GitHub rather than to reader, and both survive into rendered markdown as stray line at top of card.
+
+## The repo view
+
+**Main column have tabs now, and Chat = one of them.** [ViewTabs](apps/desktop/src/components/layout/ViewTabs.tsx) sit in header row between session name and `PanelToggle`; `VIEW_TABS` = set *and* order, so Terminal later = one array entry plus one body. Accelerator read off array position (⌘1, ⌘2), not stored per tab — reorder array and keys move with it. Bodies use `TabBody` from `RightPanel`, so transcript **hide, not unmount**: scroll position, follow pin and every highlighted diff survive flip.
+
+**Tab per session, and not persisted.** `panelTab` = standing preference; this = working context for one session. Record keyed by session id in `App`, `?? "chat"` on read. Reopening app onto repo view for every session wrong more often than right.
+
+**Composer hidden off Chat.** Other views not conversations, and composer under them send into session reader can't see. Safe to unmount because `useDraft`/`useAttachments` module-level already — same reason they module-level for empty-state crossing.
+
+**Right panel's changes tab stay, and answer different question.** Panel = "what did this turn do", turn-scoped, beside transcript. View = whole repository. Two surfaces, not duplicate: one follow turns, other follow branch.
+
+**Uncommitted list = HEAD tree against live snapshot**, and that whole trick. `head_tree` = `rev-parse HEAD^{tree}`, paired with `changes_since(cwd, headTree, None)` which snapshot working tree to answer. Commit move HEAD → new tree id → cache key roll onto new baseline by itself. **Nothing invalidate anything** — same bargain frozen turn ranges already make.
+
+**Commit SHA pass `is_tree_id` and every diff path take them unchanged.** ≤64 hex, so `git diff <sha> <sha> --` and `{sha}:{path}` cat-file rev work as-is — commit's own diff = `useChanges(cwd, commit.parent ?? EMPTY_TREE, commit.sha)`. Non-null head = frozen key = read once, cached forever. Root commit's `parent` = `None`, and `EMPTY_TREE` (`4b825dc…`) stand in, so first commit in history open like any other instead of being one row that can't.
+
+**Log record framed on NUL, field on `%x1f`, body last.** `git log -z` separate *commits* with NUL — one byte message cannot carry. Fields = unit separator, and body **last** so `splitn(6)` let it hold anything, separator included. `%P` space-separated, first parent only: merge read as what it brought onto branch, not as everything both side ever did.
+
+**View read, never write — and that not "not yet".** Conversation next door = where work get made and committed, so second place to write commit = second way to do thing reader already asking agent for. No checkbox, no message box, no push button, no discard.
+
+Backend keep `commit_files` and `push_branch` anyway, registered and tested, and `commit.ts` keep checkbox arithmetic beside them. Deliberate: hard part of commit surface = *which* path go in (rename need both name, `--only` promise, literal pathspec), and that reasoning expensive to rediscover. Kept where it can be picked back up, not scattered. **UI absent, capability parked.**
+
+If it come back: commit = `add -A -- <paths>` then `commit -m … -- <paths>`, both `GIT_LITERAL_PATHSPECS=1`. `add` = what make untracked file committable at all (`commit -- <path>` refuse path git never heard of) and what record deletion. Pathspec on `commit` imply `--only`, so **anything staged for unchecked file stay staged and uncommitted** — pinned by test. Porcelain, not temp-index plumbing `snapshot_tree` use: this *meant* to move HEAD, and `commit-tree` leaving real index untouched make every just-committed file read as staged revert after. Checkbox set stored **inverted** (`unchecked`), so file agent write while view open arrive *in* commit like every other change.
+
+**History open in place, and nothing open on arrival.** Not drill-in, not third column: column leave diff narrowest of three, drill-in hide history behind whichever commit open. Row expand under itself instead, both stay on screen. Follow from that: **no default selection** — first commit touching thirty file would push rest of history off screen before reader pick anything. Click open, click again close. **No chevron**: row = control, highlight say which open, second click prove it — arrow only label what row already demonstrate. Commit's *first file* selected on open, which is different question and safe, since file list already bounded by commit reader chose.
+
+**Live file list sort newest edit first; frozen one keep git's order.** Git list path alphabetically, so file just written sit wherever its name fall and reader hunt for it. `sort_by_recency` stat each path and sort descending — but **only when `head` = `None`**, since frozen range name *trees* and what file say on disk today have nothing to do with what it said then (both direction pinned by test). Deletion have no file left to stamp, so it sort bottom; tie break on path so refresh don't shuffle list.
+
+**Face on commit come from email, because git carry no account.** Two route, certain first: GitHub's noreply address (`12345+login@users.noreply.github.com`) *contain* account id, so it resolve exactly — where guessing login from name would not, same 404 trap PR panel already document. Everything else = **Gravatar over SHA-256**, which `crypto.subtle` do, so no hashing dep come with it. `d=404` deliberate: missing account must fail request and leave initial standing, not cover it with generated pattern reading as real person. Both cached per address in module map (`useAvatar`), `null` cached too — address resolving to nothing = settled answer, not retry. `Avatar` now shared with PR panel, since two copy drift on fallback and fallback = part actually seen.
+
+**Filename win the truncation.** One `truncate` span holding `dir + name` clip from *end*, which = filename — exact opposite of intent, and worse in deep tree where path long. So name draw first and `shrink-0`, directory after it and truncating. Right panel's rows keep old order for now.
+
+**Diff in pane, and `diffStyle` = prop on same `DiffView`.** `@pierre/diffs` carry `diffStyle: "split" | "unified"` natively — split = library's own default and what anyone arriving from another git client expect. Toggle = prop change repainting same instance, **never re-tokenize**: layout client-side, worker pool cache keyed on text. Split must travel with `overflow: "scroll"` — library only wire two columns' scroll together when line can overflow. Prop rather than second component because highlighter gate = part easy to get wrong and must exist once. Pref = `ade.diffStyle`, one surface so `useLocalStorage` not singleton.
+
+**Toggle draw both option, not one glyph that swap.** Swapping glyph tried first and read as *picture of current state* — nothing about it say it can be pressed, and split/unified not convention reader arrive expecting. Two segment make choice visible before it made.
+
+**Channel between split halves = reserved scrollbar gutter, not gap.** Each column own horizontally-scrolling box carrying `scrollbar-gutter: stable`, so WebKit reserve classic scrollbar's width at its **inline end** — even though library zero that scrollbar (`::-webkit-scrollbar { width: 0 }`) and only ever *measure* horizontal one. Leave strip of dead background down right of each column: on left column it read as channel between two side, on right as diff stopping short of pane. Also what make two look lopsided — left inset = library's own spacing, right = this. No variable expose it, so `unsafeCSS` (library's own escape hatch, inject into `@layer unsafe` = last in its layer order, so no `!important` needed) carry `[data-code] { scrollbar-gutter: auto; }`. Nothing lost: gutter only ever reserve room for scrollbar drawn at zero width. **Don't reach for `--diffs-gap-inline` here** — that inset "N unmodified lines" bar only, so tightening it shrink bar and leave channel, making asymmetry worse not better.
+
+**Library spacing dialled down from outside, through its shadow root.** `--diffs-gap-block` (8px padding above/below code) and `--diffs-gap-style` (2px rule between gutter and code, which in split view draw channel down middle wide enough to read as two halve drifting apart) both read *inside* shadow DOM with those name — and custom property cross that boundary, so setting them on any ancestor = whole override. `DIFF_SPACING` in [DiffPane](apps/desktop/src/components/changes/DiffPane.tsx). Pane itself carry no padding either: its border = frame, and inset only make code narrower than window it was given.
+
+**History drill in, not third column.** Window can't hold commit list, file list *and* split diff without diff becoming narrowest of three. Selecting commit replace list with its files under back-header; selection kept on step back, so long history don't lose reader's place.
+
+**Selected file derived, never stored.** `find(path) ?? files[0]` — file that stop being changed can't leave pane pointing at nothing, and first-by-position right here where turn panel refuse it: diff have own pane, so opening one hide nothing.
 
 ## Persistence
 
@@ -568,6 +610,12 @@ Several things deliberately unfinished — don't mistake for bugs:
 - **PR panel read and act, never write prose.** No commenting, no replying to review, no requesting review, no closing. Every action there = state change moving work toward landing; anything wanting text box, or ending PR, belong to GitHub for now.
 
 - **Branch left behind after merge.** `--delete-branch` deliberately not passed (see above), and nothing else clean up worktree or its branch — so merged worktree session leave tree at `.claude/worktrees/<name>` and branch beside it. Wanted as own thing, driven by session lifecycle rather than by merge button.
+
+- **Repo view read, commit and push — no fetch, no pull, no discard.** Ahead count against *last known* upstream, so branch someone else pushed to read as level until push itself fail. Discard-changes and stage-hunk deliberately absent: both destroy work, and neither belong in first pass of surface agent also writing to.
+
+- **No count on Changes view tab.** Working-tree file count would force snapshot on every event even while reader sit on Chat — exactly what `active` gate exist to prevent. Sub-tab carry count, since by then reads already running.
+
+- **Blocked commit name no session either.** Same shape as blocked install: button dim while turn run and say nothing about when it free. Turn end unblock it, but nothing tell reader that.
 
 - **No PR indicator in sidebar.** Row show nothing about whether session's branch have open PR — deliberately parked, since answering it for every visible row need per-repo cache and refresh rule panel's own 30s freshness window don't cover.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,10 @@ Only **tip commit's** rollup asked for (`commits(last:1)`) — check reported ag
 
 **Right panel's changes tab stay, and answer different question.** Panel = "what did this turn do", turn-scoped, beside transcript. View = whole repository. Two surfaces, not duplicate: one follow turns, other follow branch.
 
+**`head_tree` answer `None` for one thing only: not a repository.** Repo with **unborn** branch (`git init`, nothing committed) answer **empty tree** instead — honest baseline there, since with no commit behind it every file = addition, exact thing diff against empty tree say. Folding it into `None` made real repo indistinguishable from plain directory and hid its file until first commit. Empty tree need no object in database: git know that id built in (verified by test diffing against it in fresh repo).
+
+**And `null` alone still say two thing — "no repo" and "not asked yet".** View paint before first read land, so testing id alone announce every real repository as plain directory for frame or two. `useHeadTree` carry `settled` for that, and empty state wait on it.
+
 **Uncommitted list = HEAD tree against live snapshot**, and that whole trick. `head_tree` = `rev-parse HEAD^{tree}`, paired with `changes_since(cwd, headTree, None)` which snapshot working tree to answer. Commit move HEAD → new tree id → cache key roll onto new baseline by itself. **Nothing invalidate anything** — same bargain frozen turn ranges already make.
 
 **Commit SHA pass `is_tree_id` and every diff path take them unchanged.** ≤64 hex, so `git diff <sha> <sha> --` and `{sha}:{path}` cat-file rev work as-is — commit's own diff = `useChanges(cwd, commit.parent ?? EMPTY_TREE, commit.sha)`. Non-null head = frozen key = read once, cached forever. Root commit's `parent` = `None`, and `EMPTY_TREE` (`4b825dc…`) stand in, so first commit in history open like any other instead of being one row that can't.

--- a/apps/desktop/src-tauri/src/git.rs
+++ b/apps/desktop/src-tauri/src/git.rs
@@ -291,18 +291,41 @@ pub async fn base_ref_tree(cwd: &str) -> Option<String> {
     (!tree.is_empty()).then_some(tree)
 }
 
+/// Git's empty tree, which every repository can resolve whether or not
+/// anything was ever written into it. Hardcoded rather than looked up: git
+/// knows this id built in, so it needs no object in the database to answer for.
+pub const EMPTY_TREE: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
 /// The tree HEAD points at — the committed side of "what have I changed but
 /// not committed".
 ///
 /// Paired with a `None` head in [`changes_since`], which snapshots the working
 /// tree at read time, so the two together are the repo view's uncommitted list.
-/// `None` for a directory that isn't a repo and for an unborn branch, where
-/// there is no commit yet; both are ordinary states the view draws as empty.
+///
+/// A repository whose branch is **unborn** — `git init` with nothing committed
+/// yet — answers with the empty tree rather than `None`. It is the honest
+/// baseline there: with no commit behind it, every file in the tree is an
+/// addition, which is exactly what a diff against the empty tree says. Folding
+/// it into `None` instead would have made a real repository indistinguishable
+/// from a plain directory, and hidden its files until the first commit.
+///
+/// So `None` means one thing only: this is not a repository.
 pub async fn head_tree(cwd: &str) -> Option<String> {
-    let tree = git(cwd, &["rev-parse", "--verify", "-q", "HEAD^{tree}"]).await?;
+    if let Some(tree) = git(cwd, &["rev-parse", "--verify", "-q", "HEAD^{tree}"])
+        .await
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+    {
+        return Some(tree);
+    }
 
-    let tree = tree.trim().to_string();
-    (!tree.is_empty()).then_some(tree)
+    is_repo(cwd).await.then(|| EMPTY_TREE.to_string())
+}
+
+/// Whether git recognises this directory at all, which is the question `HEAD`
+/// cannot answer on its own — a fresh `git init` has no HEAD to resolve.
+async fn is_repo(cwd: &str) -> bool {
+    git(cwd, &["rev-parse", "--git-dir"]).await.is_some()
 }
 
 /// How one path differs between two snapshots. `added`/`removed` are git's own
@@ -1610,6 +1633,30 @@ mod tests {
 
         assert_eq!(commits[0].subject, "subject");
         assert_eq!(commits[0].body, "a\x1fb");
+    }
+
+    #[tokio::test]
+    async fn a_repo_with_no_commit_yet_diffs_against_the_empty_tree() {
+        let dir = std::env::temp_dir().join(format!("dray-unborn-{}", Uuid::now_v7()));
+        fs::create_dir_all(&dir).await.unwrap();
+        let at = dir.to_str().unwrap();
+        run(at, &["init", "-q", "."]).await.unwrap();
+        fs::write(dir.join("first.txt"), "hello\n").await.unwrap();
+
+        // A real repository, so it must not read as a plain directory — and its
+        // one file has to be listed, which is the whole point of not folding
+        // this into `None`.
+        let base = head_tree(at).await.expect("an unborn branch still has a repo");
+        assert_eq!(base, EMPTY_TREE);
+
+        let changes = changes_since(at, &base, None).await.unwrap();
+        assert_eq!(
+            changes.files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
+            ["first.txt"],
+        );
+        assert_eq!(changes.files[0].status, ChangeStatus::Added);
+
+        fs::remove_dir_all(&dir).await.ok();
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/git.rs
+++ b/apps/desktop/src-tauri/src/git.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     process::Stdio,
+    time::SystemTime,
 };
 
 use anyhow::{bail, Context, Result};
@@ -147,11 +148,19 @@ pub async fn checkout_branch(cwd: &str, branch: &str, stash: bool) -> Result<()>
 /// Runs git and turns a non-zero exit into an error carrying git's own stderr,
 /// which names the conflicting files — the part the user needs to act on.
 async fn run(cwd: &str, args: &[&str]) -> Result<()> {
-    let out = Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .await?;
+    run_with(cwd, &[], args).await
+}
+
+/// [`run`] with environment overrides. Split out for `GIT_LITERAL_PATHSPECS`,
+/// which the commit path sets and nothing else wants.
+async fn run_with(cwd: &str, envs: &[(&str, &str)], args: &[&str]) -> Result<()> {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(cwd);
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+
+    let out = cmd.output().await?;
 
     if !out.status.success() {
         let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
@@ -282,6 +291,20 @@ pub async fn base_ref_tree(cwd: &str) -> Option<String> {
     (!tree.is_empty()).then_some(tree)
 }
 
+/// The tree HEAD points at — the committed side of "what have I changed but
+/// not committed".
+///
+/// Paired with a `None` head in [`changes_since`], which snapshots the working
+/// tree at read time, so the two together are the repo view's uncommitted list.
+/// `None` for a directory that isn't a repo and for an unborn branch, where
+/// there is no commit yet; both are ordinary states the view draws as empty.
+pub async fn head_tree(cwd: &str) -> Option<String> {
+    let tree = git(cwd, &["rev-parse", "--verify", "-q", "HEAD^{tree}"]).await?;
+
+    let tree = tree.trim().to_string();
+    (!tree.is_empty()).then_some(tree)
+}
+
 /// How one path differs between two snapshots. `added`/`removed` are git's own
 /// numstat figures, so the row and the diff it opens cannot disagree.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
@@ -364,6 +387,11 @@ pub async fn changes_since(cwd: &str, base: &str, head: Option<&str>) -> Result<
         bail!("invalid baseline id");
     }
 
+    // Whether the far side is the working tree as it stands, which is the only
+    // case where the listed paths name files still on disk — and so the only
+    // one that can be ordered by when they were touched.
+    let live = head.is_none();
+
     let head = match head {
         Some(h) => {
             if !is_tree_id(h) {
@@ -376,7 +404,7 @@ pub async fn changes_since(cwd: &str, base: &str, head: Option<&str>) -> Result<
             .context("could not snapshot the working tree")?,
     };
 
-    let files = match diff_trees(cwd, base, &head).await {
+    let mut files = match diff_trees(cwd, base, &head).await {
         Ok(files) => files,
         Err(e) => {
             // A snapshot is persisted forever but its tree object is not: the
@@ -391,6 +419,10 @@ pub async fn changes_since(cwd: &str, base: &str, head: Option<&str>) -> Result<
         }
     };
 
+    if live {
+        sort_by_recency(cwd, &mut files).await;
+    }
+
     let added = files.iter().map(|f| f.added).sum();
     let removed = files.iter().map(|f| f.removed).sum();
 
@@ -401,6 +433,35 @@ pub async fn changes_since(cwd: &str, base: &str, head: Option<&str>) -> Result<
         added,
         removed,
     })
+}
+
+/// Newest edit first, which is the order the working tree is actually read in:
+/// git lists paths alphabetically, so the file just written sits wherever its
+/// name happens to fall and the reader has to hunt for it.
+///
+/// Only ever applied to a live diff — a frozen range names trees, and what a
+/// path's file says on disk today has nothing to do with what it said then.
+/// A deletion has no file left to stamp and sorts to the bottom; ties break on
+/// path so the order is stable between reads rather than shuffling on refresh.
+async fn sort_by_recency(cwd: &str, files: &mut [ChangedFile]) {
+    let mut stamps: HashMap<String, SystemTime> = HashMap::new();
+    for file in files.iter() {
+        let at = fs::metadata(Path::new(cwd).join(&file.path))
+            .await
+            .ok()
+            .and_then(|meta| meta.modified().ok())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        stamps.insert(file.path.clone(), at);
+    }
+
+    let at = |file: &ChangedFile| {
+        stamps
+            .get(&file.path)
+            .copied()
+            .unwrap_or(SystemTime::UNIX_EPOCH)
+    };
+
+    files.sort_by(|a, b| at(b).cmp(&at(a)).then_with(|| a.path.cmp(&b.path)));
 }
 
 /// Whether the object database still holds this id.
@@ -774,6 +835,222 @@ fn parse_batch(mut bytes: &[u8], count: usize) -> Vec<Side> {
         out.push(Side::Missing);
     }
     out
+}
+
+/// One commit, as the history list draws it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Commit {
+    pub sha: String,
+    /// First parent — the side this commit's own diff is taken against. `None`
+    /// on the root commit, where the caller substitutes git's empty tree. A
+    /// merge keeps only its first parent, so it reads as what the merge brought
+    /// onto this branch rather than as everything both sides ever did.
+    pub parent: Option<String>,
+    pub subject: String,
+    pub body: String,
+    pub author: String,
+    /// What the history list draws a face from. Git has no account behind a
+    /// commit — only whatever the author configured — so this is the only
+    /// identity here, and the frontend resolves it to a picture or to a letter.
+    pub author_email: String,
+    /// RFC 3339, matching every other timestamp that reaches the frontend.
+    pub authored_at: String,
+}
+
+/// Fields separated by unit separators rather than by anything a human types,
+/// with the body **last**: a commit message can contain any character at all,
+/// so only the final field is allowed to be ambiguous, and taking the rest of
+/// the record is exactly what a limited split does with it.
+const LOG_FORMAT: &str = "--format=%H%x1f%P%x1f%an%x1f%ae%x1f%aI%x1f%s%x1f%b";
+
+/// Far above what the list pages at. A ceiling rather than a page size: this is
+/// argv, and an unbounded `-n` from the frontend is one typo from reading the
+/// whole history into memory.
+const MAX_LOG_PAGE: u32 = 200;
+
+/// A page of the current branch's history, newest first.
+///
+/// Empty for a directory that isn't a repo and for a branch with no commits
+/// yet — the same "not an error, just nothing to draw" the branch list takes.
+pub async fn log_commits(cwd: &str, limit: u32, skip: u32) -> Result<Vec<Commit>> {
+    let limit = limit.clamp(1, MAX_LOG_PAGE).to_string();
+    let skip = format!("--skip={skip}");
+
+    // `-z` separates whole commits with NUL, which is the one byte a message
+    // cannot carry — so record framing survives any message, and the `--`
+    // closes the same rev-or-path ambiguity every diff here closes.
+    let Some(raw) = git(
+        cwd,
+        &["log", "-z", LOG_FORMAT, "-n", &limit, &skip, "HEAD", "--"],
+    )
+    .await
+    else {
+        return Ok(Vec::new());
+    };
+
+    Ok(parse_log(&raw))
+}
+
+fn parse_log(raw: &str) -> Vec<Commit> {
+    raw.split('\0')
+        .filter(|record| !record.trim().is_empty())
+        .filter_map(|record| {
+            // The previous record's body ends in a newline, which lands at the
+            // front of this one.
+            let mut fields = record.trim_start().splitn(7, '\x1f');
+            let sha = fields.next()?.trim().to_string();
+            let parents = fields.next()?;
+            let author = fields.next()?.to_string();
+            let author_email = fields.next()?.trim().to_string();
+            let authored_at = fields.next()?.trim().to_string();
+            let subject = fields.next()?.to_string();
+            let body = fields.next().unwrap_or_default().trim().to_string();
+
+            (!sha.is_empty()).then(|| Commit {
+                sha,
+                parent: parents.split_whitespace().next().map(str::to_string),
+                subject,
+                body,
+                author,
+                author_email,
+                authored_at,
+            })
+        })
+        .collect()
+}
+
+/// Where the current branch stands against its upstream — everything the push
+/// button needs to name itself.
+#[derive(Debug, Clone, Default, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct SyncStatus {
+    /// `None` on a detached HEAD and for a directory that isn't a repo, which
+    /// is how the row hides itself rather than offering a push it can't do.
+    pub branch: Option<String>,
+    /// `None` for a branch that has never been pushed — the "publish" case.
+    pub upstream: Option<String>,
+    /// Commits the upstream doesn't have. Zero when there is no upstream: the
+    /// button reads "Publish branch" there, and a count would be answering a
+    /// question nobody asked yet.
+    pub ahead: u32,
+}
+
+/// Infallible by design, like [`list_branches`]: a directory that isn't a repo
+/// answers with the default rather than an error the reader can't act on.
+///
+/// Nothing here fetches. The count is against the *last known* upstream, so a
+/// branch someone else has pushed to reads as fewer commits behind than it is —
+/// the push itself is what surfaces that, as git's own rejection.
+pub async fn sync_status(cwd: &str) -> SyncStatus {
+    let branch = git(cwd, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .await
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && s != "HEAD");
+
+    let Some(branch) = branch else {
+        return SyncStatus::default();
+    };
+
+    let upstream = git(cwd, &["rev-parse", "--abbrev-ref", "@{u}"])
+        .await
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let ahead = if upstream.is_some() {
+        git(cwd, &["rev-list", "--count", "@{u}..HEAD"])
+            .await
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    SyncStatus {
+        branch: Some(branch),
+        upstream,
+        ahead,
+    }
+}
+
+/// Git resolves a pathspec as a glob and reads leading `:` as magic, so a file
+/// genuinely named `a*.txt` or `:weird` would stage its neighbours or nothing
+/// at all. These paths come from our own change list and name real files, so
+/// literal is not a restriction — it is what the caller already meant.
+const LITERAL_PATHSPECS: &[(&str, &str)] = &[("GIT_LITERAL_PATHSPECS", "1")];
+
+/// Commits exactly `paths` — the files the reader left checked — and nothing
+/// else.
+///
+/// Two commands rather than one. `add -A` is what makes an untracked file
+/// committable at all (`commit -- <path>` refuses a path git has never heard
+/// of) and what records a deletion. The pathspec on `commit` then implies
+/// `--only`, so the commit is built from HEAD plus these paths: anything the
+/// user had staged for an *unchecked* file stays staged and uncommitted, which
+/// is the promise the checkboxes make.
+///
+/// Porcelain rather than the temp-index plumbing [`snapshot_tree`] uses,
+/// deliberately: this is meant to move HEAD, and a `commit-tree` that left the
+/// real index untouched would leave every just-committed file reading as a
+/// staged revert afterwards.
+pub async fn commit_files(
+    cwd: &str,
+    summary: &str,
+    description: Option<&str>,
+    paths: &[String],
+) -> Result<()> {
+    let summary = summary.trim();
+    if summary.is_empty() {
+        bail!("a commit needs a summary");
+    }
+    if paths.is_empty() {
+        bail!("no files are selected to commit");
+    }
+    // A `-` leading path is already closed by the `--` both commands carry;
+    // this is the empty and NUL case, which would silently widen the pathspec.
+    if paths.iter().any(|p| p.is_empty() || p.contains('\0')) {
+        bail!("invalid path in the selection");
+    }
+
+    let mut add = vec!["add", "-A", "--"];
+    add.extend(paths.iter().map(String::as_str));
+    run_with(cwd, LITERAL_PATHSPECS, &add).await?;
+
+    let description = description.map(str::trim).filter(|d| !d.is_empty());
+
+    let mut commit = vec!["commit", "-m", summary];
+    // A second `-m` rather than a joined string: git's own blank line between
+    // subject and body is the convention every tool reading this expects.
+    if let Some(description) = description {
+        commit.push("-m");
+        commit.push(description);
+    }
+    commit.push("--");
+    commit.extend(paths.iter().map(String::as_str));
+
+    run_with(cwd, LITERAL_PATHSPECS, &commit).await
+}
+
+/// Pushes the current branch, publishing it when it has no upstream yet.
+///
+/// No force, ever: a rejected non-fast-forward comes back as git's own stderr
+/// for the reader to deal with, which for a session's own branch usually means
+/// someone else pushed to it.
+pub async fn push_branch(cwd: &str) -> Result<()> {
+    let branch = git(cwd, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .await
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && s != "HEAD")
+        .context("not on a branch, so there is nothing to push")?;
+
+    if git(cwd, &["rev-parse", "--abbrev-ref", "@{u}"]).await.is_some() {
+        return run(cwd, &["push"]).await;
+    }
+
+    // Git's own output for the name, and a branch name cannot begin with `-`.
+    run(cwd, &["push", "-u", "origin", &branch]).await
 }
 
 #[cfg(test)]
@@ -1286,5 +1563,305 @@ mod tests {
         assert_eq!(count_changes(raw), 3);
         assert_eq!(count_changes(""), 0);
         assert_eq!(count_changes("\n"), 0);
+    }
+
+    /// One record in the shape [`LOG_FORMAT`] produces.
+    fn log_record(sha: &str, parents: &str, subject: &str, body: &str) -> String {
+        format!(
+            "{sha}\x1f{parents}\x1fTest\x1ft@example.com\x1f2026-08-22T10:00:00+05:45\x1f{subject}\x1f{body}"
+        )
+    }
+
+    #[test]
+    fn parses_a_log_page_into_commits() {
+        let raw = format!(
+            "{}\0{}\0",
+            log_record("aaa1", "bbb2", "second", "why it happened\n"),
+            log_record("bbb2", "", "init", ""),
+        );
+
+        let commits = parse_log(&raw);
+
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].sha, "aaa1");
+        assert_eq!(commits[0].parent.as_deref(), Some("bbb2"));
+        assert_eq!(commits[0].subject, "second");
+        assert_eq!(commits[0].body, "why it happened");
+        assert_eq!(commits[0].author, "Test");
+        assert_eq!(commits[0].author_email, "t@example.com");
+        assert_eq!(commits[0].authored_at, "2026-08-22T10:00:00+05:45");
+        // The root commit has no parent to diff against — the caller stands
+        // git's empty tree in for it.
+        assert_eq!(commits[1].parent, None);
+        assert_eq!(commits[1].body, "");
+    }
+
+    #[test]
+    fn a_merge_reads_only_its_first_parent() {
+        let commits = parse_log(&log_record("aaa1", "bbb2 ccc3", "merge", ""));
+
+        assert_eq!(commits[0].parent.as_deref(), Some("bbb2"));
+    }
+
+    #[test]
+    fn a_message_carrying_the_field_separator_keeps_its_body_whole() {
+        // The body is the last field precisely so this cannot shift the others.
+        let commits = parse_log(&log_record("aaa1", "bbb2", "subject", "a\x1fb"));
+
+        assert_eq!(commits[0].subject, "subject");
+        assert_eq!(commits[0].body, "a\x1fb");
+    }
+
+    #[tokio::test]
+    async fn head_tree_names_the_committed_side_and_a_non_repo_has_none() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        let head = head_tree(at).await.expect("a repo with a commit has a tree");
+
+        // Clean tree, so the working-tree snapshot agrees with HEAD — which is
+        // what makes an empty uncommitted list empty.
+        assert_eq!(snapshot_tree(at).await.as_deref(), Some(head.as_str()));
+
+        let empty = std::env::temp_dir().join(format!("dray-nonrepo-{}", Uuid::now_v7()));
+        fs::create_dir_all(&empty).await.unwrap();
+        assert_eq!(head_tree(empty.to_str().unwrap()).await, None);
+
+        fs::remove_dir_all(&dir).await.ok();
+        fs::remove_dir_all(&empty).await.ok();
+    }
+
+    #[tokio::test]
+    async fn logs_pages_newest_first() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        fs::write(dir.join("keep.txt"), "a\nb\nc\nd\n").await.unwrap();
+        run(at, &["commit", "-aqm", "second"]).await.unwrap();
+        fs::write(dir.join("keep.txt"), "a\nb\nc\nd\ne\n").await.unwrap();
+        run(at, &["commit", "-aqm", "third"]).await.unwrap();
+
+        let page = log_commits(at, 2, 0).await.unwrap();
+        assert_eq!(
+            page.iter().map(|c| c.subject.as_str()).collect::<Vec<_>>(),
+            ["third", "second"],
+        );
+        // The page's own commits chain, which is what lets a row diff against
+        // its parent without a second read.
+        assert_eq!(page[0].parent.as_deref(), Some(page[1].sha.as_str()));
+
+        let next = log_commits(at, 2, 2).await.unwrap();
+        assert_eq!(next.len(), 1);
+        assert_eq!(next[0].subject, "init");
+        assert_eq!(next[0].parent, None);
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn a_directory_that_is_not_a_repo_has_no_history() {
+        let dir = std::env::temp_dir().join(format!("dray-nonrepo-{}", Uuid::now_v7()));
+        fs::create_dir_all(&dir).await.unwrap();
+
+        assert!(log_commits(dir.to_str().unwrap(), 50, 0).await.unwrap().is_empty());
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn commits_only_the_checked_paths() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        fs::write(dir.join("keep.txt"), "a\nb\nc\nedited\n").await.unwrap();
+        fs::write(dir.join("gone.txt"), "x\ny\nedited\n").await.unwrap();
+        // Untracked, and checked — `commit -- <path>` alone refuses a path git
+        // has never heard of, so this is what proves the `add` is doing work.
+        fs::write(dir.join("new.txt"), "fresh\n").await.unwrap();
+
+        commit_files(
+            at,
+            "commit two of three",
+            None,
+            &["keep.txt".into(), "new.txt".into()],
+        )
+        .await
+        .unwrap();
+
+        let committed = git(at, &["show", "--name-only", "--format=", "HEAD"])
+            .await
+            .unwrap();
+        assert!(committed.contains("keep.txt"));
+        assert!(committed.contains("new.txt"));
+        assert!(!committed.contains("gone.txt"));
+
+        // The unchecked file is still dirty, which is the whole promise the
+        // checkboxes make.
+        let dirty = git(at, &["status", "--porcelain"]).await.unwrap();
+        assert!(dirty.contains("gone.txt"));
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn the_working_tree_lists_the_newest_edit_first() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+        let base = head_tree(at).await.unwrap();
+
+        // `gone.txt` sorts first alphabetically, so a list still in git's own
+        // order would put it on top whichever was edited last.
+        fs::write(dir.join("gone.txt"), "x\ny\nfirst\n").await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        fs::write(dir.join("keep.txt"), "a\nb\nc\nsecond\n").await.unwrap();
+
+        let live = changes_since(at, &base, None).await.unwrap();
+        assert_eq!(
+            live.files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
+            ["keep.txt", "gone.txt"],
+        );
+
+        // A frozen range describes trees, not the disk, so it keeps git's order
+        // however the files have been touched since.
+        let frozen = snapshot_tree(at).await.unwrap();
+        let then = changes_since(at, &base, Some(&frozen)).await.unwrap();
+        assert_eq!(
+            then.files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
+            ["gone.txt", "keep.txt"],
+        );
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn an_unchecked_file_keeps_what_was_staged_for_it() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        // Someone staged part of `gone.txt` by hand and then left it out of the
+        // commit. The pathspec form of `commit` implies `--only`, so that work
+        // has to survive — otherwise unchecking a file would quietly discard
+        // whatever was already staged for it.
+        fs::write(dir.join("gone.txt"), "x\ny\nstaged\n").await.unwrap();
+        run(at, &["add", "gone.txt"]).await.unwrap();
+        fs::write(dir.join("keep.txt"), "a\nb\nc\nedited\n").await.unwrap();
+
+        commit_files(at, "keep only", None, &["keep.txt".into()])
+            .await
+            .unwrap();
+
+        let staged = git(at, &["show", ":gone.txt"]).await.unwrap();
+        assert_eq!(staged, "x\ny\nstaged\n");
+        // Staged, and still uncommitted — the commit took only `keep.txt`.
+        let committed = git(at, &["show", "HEAD:gone.txt"]).await.unwrap();
+        assert!(!committed.contains("staged"));
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn a_checked_deletion_is_committed_as_one() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        fs::remove_file(dir.join("gone.txt")).await.unwrap();
+
+        commit_files(at, "drop it", None, &["gone.txt".into()])
+            .await
+            .unwrap();
+
+        assert!(git(at, &["cat-file", "-e", "HEAD:gone.txt"]).await.is_none());
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn a_glob_named_file_stages_only_itself() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        // Without GIT_LITERAL_PATHSPECS this pathspec would sweep up every
+        // `a…txt` in the tree — including the decoy.
+        fs::write(dir.join("a*.txt"), "literal\n").await.unwrap();
+        fs::write(dir.join("also.txt"), "decoy\n").await.unwrap();
+
+        commit_files(at, "literal path", None, &["a*.txt".into()])
+            .await
+            .unwrap();
+
+        let committed = git(at, &["show", "--name-only", "--format=", "HEAD"])
+            .await
+            .unwrap();
+        assert!(committed.contains("a*.txt"));
+        assert!(!committed.contains("also.txt"));
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn a_description_lands_under_a_blank_line() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        fs::write(dir.join("keep.txt"), "a\nb\nc\nedited\n").await.unwrap();
+
+        commit_files(at, "subject line", Some("why it happened"), &["keep.txt".into()])
+            .await
+            .unwrap();
+
+        let message = git(at, &["log", "-1", "--format=%B"]).await.unwrap();
+        assert_eq!(message.trim_end(), "subject line\n\nwhy it happened");
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn an_empty_summary_or_selection_is_refused() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        assert!(commit_files(at, "   ", None, &["keep.txt".into()]).await.is_err());
+        assert!(commit_files(at, "fine", None, &[]).await.is_err());
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn a_branch_publishes_then_pushes() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        let remote = std::env::temp_dir().join(format!("dray-remote-{}", Uuid::now_v7()));
+        fs::create_dir_all(&remote).await.unwrap();
+        run(remote.to_str().unwrap(), &["init", "-q", "--bare", "."])
+            .await
+            .unwrap();
+        run(at, &["remote", "add", "origin", remote.to_str().unwrap()])
+            .await
+            .unwrap();
+
+        // Unpublished: no upstream, and no count to report against one.
+        let before = sync_status(at).await;
+        assert!(before.branch.is_some());
+        assert_eq!(before.upstream, None);
+        assert_eq!(before.ahead, 0);
+
+        push_branch(at).await.unwrap();
+
+        let published = sync_status(at).await;
+        assert!(published.upstream.is_some());
+        assert_eq!(published.ahead, 0);
+
+        fs::write(dir.join("keep.txt"), "a\nb\nc\nmore\n").await.unwrap();
+        commit_files(at, "one more", None, &["keep.txt".into()])
+            .await
+            .unwrap();
+        assert_eq!(sync_status(at).await.ahead, 1);
+
+        push_branch(at).await.unwrap();
+        assert_eq!(sync_status(at).await.ahead, 0);
+
+        fs::remove_dir_all(&dir).await.ok();
+        fs::remove_dir_all(&remote).await.ok();
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -219,6 +219,52 @@ async fn file_change(
         .map_err(|e| e.to_string())
 }
 
+/// The committed side of the repo view's uncommitted list. Paired with a `None`
+/// head on [`changes_since`], which snapshots the working tree to answer — so
+/// the two together are "what have I changed but not committed".
+///
+/// Takes an owned `cwd` where every command around it borrows: an async command
+/// with a borrowed argument has to return `Result`, and neither this nor
+/// [`sync_status`] can fail — a `Result` here would be a lie the caller then has
+/// to handle.
+#[tauri::command]
+async fn head_tree(cwd: String) -> Option<String> {
+    git::head_tree(&cwd).await
+}
+
+/// A page of the current branch's history, newest first. `skip` is what the
+/// list's "load more" advances; the page size is the caller's, capped in `git`.
+#[tauri::command]
+async fn log_commits(cwd: &str, limit: u32, skip: u32) -> Result<Vec<git::Commit>, String> {
+    git::log_commits(cwd, limit, skip)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn sync_status(cwd: String) -> git::SyncStatus {
+    git::sync_status(&cwd).await
+}
+
+/// Commits the checked files alone. `paths` are this session's own change list,
+/// so a path the reader unchecked is one this never sees.
+#[tauri::command]
+async fn commit_files(
+    cwd: &str,
+    summary: &str,
+    description: Option<&str>,
+    paths: Vec<String>,
+) -> Result<(), String> {
+    git::commit_files(cwd, summary, description, &paths)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn push_branch(cwd: &str) -> Result<(), String> {
+    git::push_branch(cwd).await.map_err(|e| e.to_string())
+}
+
 /// Returns the entry as written so the sidebar re-renders from the stored value
 /// rather than its own guess at it. `None` for an unknown id.
 #[tauri::command]
@@ -392,6 +438,11 @@ pub fn run() {
             checkout_branch,
             changes_since,
             file_change,
+            head_tree,
+            log_commits,
+            sync_status,
+            commit_files,
+            push_branch,
             set_session_flags,
             delete_session,
             mark_session_idle,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 import Chat from "@/components/Chat";
 import ChangesPanel from "@/components/ChangesPanel";
+import ChangesView from "@/components/changes/ChangesView";
 import ChatInput from "@/components/ChatInput";
 import DiffWorkerPool from "@/components/DiffWorkerPool";
 import NoticeStack from "@/components/NoticeStack";
@@ -17,6 +18,7 @@ import ComposerToolbar from "@/components/composer/ComposerToolbar";
 import { nextPermissionMode } from "@/components/composer/PermissionSelector";
 import AppShell from "@/components/layout/AppShell";
 import SessionHeader from "@/components/layout/SessionHeader";
+import ViewTabs, { type ViewTab } from "@/components/layout/ViewTabs";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { pickAttachments } from "@/hooks/useAttachments";
 import { useCodeTheme } from "@/hooks/useCodeTheme";
@@ -106,6 +108,16 @@ function App() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [panelTab, setPanelTab] = useLocalStorage<PanelTab>("ade.panelTab", "changes");
   const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
+
+  // Per session, and deliberately not persisted the way `panelTab` is: which
+  // view you were last on is working context for one session rather than a
+  // standing preference, and reopening the app onto a repo view for every
+  // session would be wrong more often than right.
+  const [viewTabs, setViewTabs] = useState<Record<string, ViewTab>>({});
+  const viewTab: ViewTab = selectedSessionId ? viewTabs[selectedSessionId] ?? "chat" : "chat";
+  const setViewTab = (tab: ViewTab) => {
+    if (selectedSessionId) setViewTabs((prev) => ({ ...prev, [selectedSessionId]: tab }));
+  };
 
   // Themes and Shiki's engine are shared by every code surface, so they load
   // once here instead of on the first diff the user happens to open.
@@ -261,6 +273,10 @@ function App() {
   useHotkey("ArrowDown", () => stepSession(1), { shift: true });
   // ⌘E for the right pane against ⌘B for the left.
   useHotkey("e", togglePanel);
+  // By position in the tab row, so a third view needs only a third line here.
+  // No-ops without a session, where there is no row to switch.
+  useHotkey("1", () => setViewTab("chat"));
+  useHotkey("2", () => setViewTab("changes"));
   // No accelerator: Shift+Tab on its own, matching the CLI's own chord for this.
   useHotkey("Tab", () => setPermissionMode(nextPermissionMode(permissionMode)), {
     meta: false,
@@ -349,6 +365,8 @@ function App() {
 
           <SessionHeader session={selectedSession} className="flex-1" />
 
+          {selectedSession && <ViewTabs tab={viewTab} onChange={setViewTab} />}
+
           {selectedSession && (
             <PanelToggle
               onToggle={handleTogglePanel}
@@ -394,6 +412,12 @@ function App() {
         ) : null
       }
       footer={
+        // Only under the transcript it writes into. The other views are not
+        // conversations, and a composer under them would send into a session
+        // the reader can't see. Safe to unmount: the draft and the attachment
+        // tray are module-level stores precisely because the composer already
+        // unmounts crossing the empty state.
+        selectedSession && viewTab !== "chat" ? null : (
         <ChatInput
           onSend={handleSendMsg}
           commands={slashCommands}
@@ -438,8 +462,13 @@ function App() {
             />
           }
         />
+        )
       }
     >
+      {/* Hidden rather than unmounted, the same bargain the right panel's tabs
+          make: the transcript keeps its scroll position and its highlighted
+          diffs, and the repo view keeps its selection and its reads. */}
+      <TabBody active={viewTab === "chat"}>
       <Chat
         session={selectedSession}
         streamingBlock={
@@ -456,6 +485,21 @@ function App() {
         working={working}
         crowded={!collapsed && panelOpen}
       />
+      </TabBody>
+
+      {selectedSession && (
+        // Keyed by session so the selection, the sub-tab and the commit box
+        // reset with it. Cheap to remount: the reads behind it are cached by
+        // tree id at module level and survive the unmount.
+        <TabBody active={viewTab === "changes"}>
+          <ChangesView
+            key={selectedSession.sessionId}
+            cwd={selectedSession.cwd}
+            active={viewTab === "changes"}
+            revision={revision}
+          />
+        </TabBody>
+      )}
     </AppShell>
     {/* Outside `AppShell` on purpose: it is fixed to the window rather than
         placed in the layout, and the shell has no slot that isn't a pane. */}

--- a/apps/desktop/src/components/Avatar.tsx
+++ b/apps/desktop/src/components/Avatar.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+/// Someone's picture, falling back to their initial.
+///
+/// The image is remote and the account may have none, so the letter is the
+/// resting state and the image covers it once it loads — that way a slow or
+/// missing avatar never leaves a hole where a row's left edge should be.
+///
+/// Shared by the PR panel and the commit history: both draw a person beside a
+/// line of theirs, and two copies would drift on the fallback, which is the
+/// part that actually gets seen.
+export default function Avatar({
+  src,
+  name,
+  className,
+}: {
+  src: string | null;
+  name: string;
+  className?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "relative flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-[9px] uppercase text-muted-foreground",
+        className,
+      )}
+    >
+      {name.slice(0, 1)}
+      {src && !failed && (
+        <img
+          src={src}
+          alt=""
+          loading="lazy"
+          onError={() => setFailed(true)}
+          className="absolute inset-0 size-full object-cover"
+        />
+      )}
+    </span>
+  );
+}

--- a/apps/desktop/src/components/ChangesPanel.tsx
+++ b/apps/desktop/src/components/ChangesPanel.tsx
@@ -2,6 +2,7 @@ import { memo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 import FileIcon from "@/components/FileIcon";
+import Counts from "@/components/changes/Counts";
 import DiffView from "@/components/chat/DiffView";
 import { useFileVersions, type useChanges } from "@/hooks/useChanges";
 import { splitPath } from "@/lib/changes";
@@ -79,16 +80,6 @@ function Empty({ children, tone }: { children: React.ReactNode; tone?: "error" }
     >
       {children}
     </p>
-  );
-}
-
-function Counts({ added, removed }: { added: number; removed: number }) {
-  return (
-    <span className="font-mono text-ui">
-      {added > 0 && <span className="text-emerald-500">+{added}</span>}
-      {added > 0 && removed > 0 && " "}
-      {removed > 0 && <span className="text-destructive">−{removed}</span>}
-    </span>
   );
 }
 

--- a/apps/desktop/src/components/PrPanel.tsx
+++ b/apps/desktop/src/components/PrPanel.tsx
@@ -17,6 +17,7 @@ import {
   X,
 } from "lucide-react";
 
+import Avatar from "@/components/Avatar";
 import { Markdown } from "@/components/chat/Markdown";
 import { Button } from "@/components/ui/button";
 import {
@@ -287,33 +288,6 @@ function StateIcon({ pr }: { pr: PullRequest }) {
           : ([GitPullRequest, "text-emerald-500", "Open"] as const);
 
   return <Icon className={cn("size-3.5 shrink-0", tone)} aria-label={label} />;
-}
-
-/// A commenter's or a check reporter's picture, falling back to their initial.
-///
-/// The image is remote and its account may have none, so the letter is the
-/// resting state and the image covers it once it loads — that way a slow or
-/// missing avatar never leaves a hole where a row's left edge should be.
-function Avatar({ src, name }: { src: string | null; name: string }) {
-  const [failed, setFailed] = useState(false);
-
-  return (
-    <span
-      aria-hidden
-      className="relative flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-[9px] uppercase text-muted-foreground"
-    >
-      {name.slice(0, 1)}
-      {src && !failed && (
-        <img
-          src={src}
-          alt=""
-          loading="lazy"
-          onError={() => setFailed(true)}
-          className="absolute inset-0 size-full object-cover"
-        />
-      )}
-    </span>
-  );
 }
 
 /// GitHub's green, on both halves of the split button.

--- a/apps/desktop/src/components/changes/ChangesView.tsx
+++ b/apps/desktop/src/components/changes/ChangesView.tsx
@@ -86,10 +86,14 @@ export default function ChangesView({
   const showing = subTab === "uncommitted" ? working : commitChanges;
   const selectedFile = subTab === "uncommitted" ? selectedWorking : selectedCommitFile;
 
-  // A directory that isn't a repository has no HEAD to diff against. Said
-  // plainly rather than drawn as an empty change list, which would read as a
-  // clean tree.
-  if (head.tree === null && !working.changes) {
+  // A directory that isn't a repository has nothing to diff. Said plainly
+  // rather than drawn as an empty change list, which would read as a clean
+  // tree — but only once the read has actually answered. Before that `null` is
+  // just "not asked yet", and this view paints before the first read lands, so
+  // testing the id alone announced every real repository as a plain directory
+  // for a frame or two. A repository with no commit yet is not this case: it
+  // answers with the empty tree, so its files list as additions.
+  if (head.settled && head.tree === null && !working.changes) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center border-t border-border px-6 text-ui text-muted-foreground">
         This session is not in a git repository.

--- a/apps/desktop/src/components/changes/ChangesView.tsx
+++ b/apps/desktop/src/components/changes/ChangesView.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+
+import DiffPane from "@/components/changes/DiffPane";
+import FileList from "@/components/changes/FileList";
+import HistoryList from "@/components/changes/HistoryList";
+import { useChanges } from "@/hooks/useChanges";
+import { useCommitLog, useHeadTree } from "@/hooks/useRepo";
+import { commitBase } from "@/lib/commit";
+import { cn } from "@/lib/utils";
+import type { ChangedFile, Commit } from "@/types/events";
+
+const SUB_TABS = [
+  // "Uncommitted" rather than "Changes": the view is already called Changes,
+  // and a tab repeating its parent's name says nothing about what sets it apart
+  // from the tab beside it.
+  { value: "uncommitted", label: "Uncommitted" },
+  { value: "history", label: "History" },
+] as const;
+
+type SubTab = (typeof SUB_TABS)[number]["value"];
+
+/// Holds identity for the two lists' `files` when a read hasn't landed, so the
+/// selection below doesn't churn on a fresh array every render.
+const NO_FILES: readonly ChangedFile[] = [];
+
+/// The session's repository: what is uncommitted, what has been committed, and
+/// the diff for whichever file is selected.
+///
+/// Read-only, deliberately. The conversation next door is where work gets made
+/// and committed — a second place to write commits would be a second way to do
+/// the thing the reader is already asking the agent for. The backend keeps
+/// `commit_files` and `push_branch` for when a surface for them earns its way
+/// back; nothing in the UI calls them today.
+///
+/// Scoped to the whole tree, unlike the right panel's changes tab, which
+/// answers "what did this turn do" and stays as it is. Everything runs against
+/// `cwd` rather than the project root — a worktree session has its own tree.
+export default function ChangesView({
+  cwd,
+  active,
+  revision,
+}: {
+  cwd: string;
+  /// False while another view is showing. The component stays mounted so its
+  /// selection and its rendered diffs survive, but a hidden view must not keep
+  /// snapshotting the working tree on every event.
+  active: boolean;
+  revision: string;
+}) {
+  const [subTab, setSubTab] = useState<SubTab>("uncommitted");
+  const [commit, setCommit] = useState<Commit | null>(null);
+  const [workingPath, setWorkingPath] = useState<string | null>(null);
+  const [commitPath, setCommitPath] = useState<string | null>(null);
+
+  const head = useHeadTree(cwd, revision, active);
+  const log = useCommitLog(cwd, revision, active && subTab === "history");
+
+  // The uncommitted range: HEAD's tree against the working tree as it stands,
+  // which `changes_since` snapshots to answer. A commit moves HEAD, so the key
+  // rolls onto the new baseline on its own — nothing has to invalidate a cache.
+  const working = useChanges(cwd, head.tree, null, revision, active && subTab === "uncommitted");
+
+  // A commit's own range is two fixed ids, so this is read once and cached
+  // forever — reopening one costs nothing after the first time.
+  const commitChanges = useChanges(
+    cwd,
+    commit ? commitBase(commit) : null,
+    commit?.sha ?? null,
+    "",
+    active && subTab === "history" && !!commit,
+  );
+
+  const workingFiles = working.changes?.files ?? NO_FILES;
+  const commitFiles = commitChanges.changes?.files ?? NO_FILES;
+
+  // Derived rather than stored, so a file that stops being changed cannot leave
+  // the pane pointing at nothing. First by position when there is no pick: the
+  // diff has its own pane here, so opening one hides nothing the way it would
+  // in the turn panel's single column.
+  const pick = (files: readonly ChangedFile[], path: string | null) =>
+    files.find((f) => f.path === path) ?? files[0] ?? null;
+
+  const selectedWorking = pick(workingFiles, workingPath);
+  const selectedCommitFile = pick(commitFiles, commitPath);
+
+  const showing = subTab === "uncommitted" ? working : commitChanges;
+  const selectedFile = subTab === "uncommitted" ? selectedWorking : selectedCommitFile;
+
+  // A directory that isn't a repository has no HEAD to diff against. Said
+  // plainly rather than drawn as an empty change list, which would read as a
+  // clean tree.
+  if (head.tree === null && !working.changes) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center border-t border-border px-6 text-ui text-muted-foreground">
+        This session is not in a git repository.
+      </div>
+    );
+  }
+
+  return (
+    // The top border is what parts this from the titlebar. Without it the
+    // sub-tab row and the pane's file header float directly under the window's
+    // own controls and read as part of them.
+    <div className="flex min-h-0 flex-1 border-t border-border">
+      <div className="flex w-72 shrink-0 flex-col border-r border-border">
+        {/* `px-1` against the right panel's `px-2`, because the tabs here have
+            a list under them rather than a panel body: the button's own `px-2`
+            lands its label at 12px, level with the filenames below it. */}
+        <div className="flex h-9 shrink-0 items-center gap-0.5 border-b border-border px-1">
+          {SUB_TABS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setSubTab(value)}
+              className={cn(
+                "rounded-md px-2 py-1 text-ui transition-colors",
+                subTab === value
+                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {label}
+              {value === "uncommitted" && workingFiles.length > 0 && (
+                <span className="ml-1 text-muted-foreground">{workingFiles.length}</span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {subTab === "uncommitted" ? (
+          workingFiles.length === 0 ? (
+            <p className="min-h-0 flex-1 px-3 py-6 text-ui text-muted-foreground">
+              {working.changes ? "No uncommitted changes." : "Reading the working tree…"}
+            </p>
+          ) : (
+            <FileList
+              files={workingFiles}
+              selected={selectedWorking?.path ?? null}
+              onSelect={setWorkingPath}
+              className="min-h-0 flex-1 overflow-y-auto"
+            />
+          )
+        ) : (
+          <HistoryList
+            commits={log.commits}
+            selected={commit?.sha ?? null}
+            // Clicking the open commit closes it, which is also the only way
+            // back to a list with nothing expanded in it.
+            onToggle={(next) => {
+              setCommit((prev) => (prev?.sha === next.sha ? null : next));
+              setCommitPath(null);
+            }}
+            files={commitFiles}
+            selectedFile={selectedCommitFile?.path ?? null}
+            onSelectFile={setCommitPath}
+            hasMore={log.hasMore}
+            onLoadMore={log.loadMore}
+            loading={log.loading}
+            error={log.error}
+          />
+        )}
+      </div>
+
+      <DiffPane
+        cwd={cwd}
+        base={showing.changes?.base ?? ""}
+        head={showing.changes?.head ?? ""}
+        file={showing.changes ? selectedFile : null}
+        empty={
+          subTab === "history" && !commit
+            ? "Open a commit to see what it changed."
+            : "Select a file to see what changed."
+        }
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/components/changes/Counts.tsx
+++ b/apps/desktop/src/components/changes/Counts.tsx
@@ -1,0 +1,16 @@
+/// Git's own numstat figures for one file or one range, in the one pair of
+/// colours the app uses for added and removed.
+///
+/// Shared rather than copied: the turn panel, the repo view's lists and the
+/// diff pane's header all draw this, and three versions would eventually
+/// disagree about which minus sign or which green.
+export default function Counts({ added, removed }: { added: number; removed: number }) {
+  return (
+    <span className="font-mono text-ui">
+      {added > 0 && <span className="text-emerald-500">+{added}</span>}
+      {added > 0 && removed > 0 && " "}
+      {/* U+2212, not a hyphen: it matches the plus's weight and width. */}
+      {removed > 0 && <span className="text-destructive">−{removed}</span>}
+    </span>
+  );
+}

--- a/apps/desktop/src/components/changes/DiffPane.tsx
+++ b/apps/desktop/src/components/changes/DiffPane.tsx
@@ -227,6 +227,9 @@ function Body({
       // this travels with it rather than being a taste choice.
       overflow={diffStyle === "split" ? "scroll" : "wrap"}
       unsafeCSS={DIFF_CSS}
+      // The stand-in shown while the grammar loads fills the pane rather than
+      // sitting as a short box in an empty window.
+      fill
       // The pane is the frame, so the diff brings none of its own.
       className="rounded-none border-0"
     />

--- a/apps/desktop/src/components/changes/DiffPane.tsx
+++ b/apps/desktop/src/components/changes/DiffPane.tsx
@@ -1,0 +1,234 @@
+import type { CSSProperties } from "react";
+import { Columns2, Rows3 } from "lucide-react";
+
+import FileIcon from "@/components/FileIcon";
+import Counts from "@/components/changes/Counts";
+import DiffView from "@/components/chat/DiffView";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useFileVersions } from "@/hooks/useChanges";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { splitPath } from "@/lib/changes";
+import { cn } from "@/lib/utils";
+import type { ChangedFile } from "@/types/events";
+
+type DiffStyle = "split" | "unified";
+
+/// The library's own spacing, dialled down for a pane rather than a card.
+///
+/// Both are read from inside its shadow root with these names, and custom
+/// properties cross that boundary — so setting them on any ancestor is the
+/// whole of the override. `gap-block` is the padding above and below the code:
+/// the stock 8px reads as a margin when the diff runs edge to edge, but taking
+/// it to nothing presses the first hunk against the file header, so 6px is the
+/// gap that parts them without looking like an inset. `gap-style` is the rule
+/// between a gutter and its code, and at the stock 2px it draws a channel down
+/// the middle of a split view wide enough to look like the two halves are
+/// drifting apart.
+const DIFF_SPACING = {
+  "--diffs-gap-block": "6px",
+  "--diffs-gap-style": "1px solid var(--diffs-bg)",
+} as CSSProperties;
+
+/// What actually parts the two halves of a split view, and it is not a gap.
+///
+/// Each column is its own horizontally scrolling box carrying
+/// `scrollbar-gutter: stable`, so WebKit reserves a classic scrollbar's width
+/// at its **inline end** — even though the library zeroes that scrollbar and
+/// only ever measures the horizontal one. The result is a strip of dead
+/// background down the right of each column: on the left column it reads as the
+/// channel between the two sides, and on the right it reads as the whole diff
+/// stopping short of the pane. It is also why the two looked lopsided — the
+/// left inset is the library's own spacing, the right one is this.
+///
+/// `@layer unsafe` is last in the library's own layer order, so this wins
+/// without `!important`. Nothing is lost by dropping it: the gutter only ever
+/// reserved room for a scrollbar that is drawn at zero width.
+const DIFF_CSS = `[data-code] { scrollbar-gutter: auto; }`;
+
+/// The selected file's diff, filling the rest of the view.
+///
+/// A pane rather than the expanding row the turn panel uses: with a list beside
+/// it instead of above it, opening a file costs the reader no scroll position
+/// and the diff gets the window's whole height.
+export default function DiffPane({
+  cwd,
+  base,
+  head,
+  file,
+  empty,
+}: {
+  cwd: string;
+  base: string;
+  head: string;
+  /// Null before anything is picked, and while a list is still loading.
+  file: ChangedFile | null;
+  /// What to say in that state. The two sub-tabs need different sentences: one
+  /// wants a file picked, the other wants a commit opened first.
+  empty: string;
+}) {
+  // Split by default, which is also the library's own default and what anyone
+  // arriving from another git client expects. Stored, because it is a way of
+  // reading rather than a property of the file being read.
+  const [diffStyle, setDiffStyle] = useLocalStorage<DiffStyle>("ade.diffStyle", "split");
+
+  const readable = !!file && !file.binary;
+  const { versions, error } = useFileVersions(
+    cwd,
+    base,
+    head,
+    // The hook needs a file to key on; `readable` is what stops it fetching.
+    file ?? EMPTY_FILE,
+    readable,
+  );
+
+  if (!file) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-ui text-muted-foreground">
+        {empty}
+      </div>
+    );
+  }
+
+  const { dir, name } = splitPath(file.path);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border px-3 text-ui">
+        <FileIcon path={file.path} />
+        {/* Name first, directory truncating after it — same reason as the list:
+            the filename is what has to survive a narrow pane. */}
+        <span className="flex min-w-0 flex-1 items-center gap-1.5" title={file.path}>
+          <span className="shrink-0 text-sidebar-foreground">{name}</span>
+          {dir && (
+            <span className="min-w-0 truncate text-muted-foreground">
+              {dir.replace(/\/$/, "")}
+            </span>
+          )}
+        </span>
+
+        {file.binary ? (
+          <span className="text-muted-foreground">binary</span>
+        ) : (
+          <Counts added={file.added} removed={file.removed} />
+        )}
+
+        <StyleToggle value={diffStyle} onChange={setDiffStyle} />
+      </div>
+
+      {/* No padding: the pane's own border is the frame, and an inset would
+          only make the code narrower than the window it was given. */}
+      <div className="min-h-0 flex-1 overflow-auto" style={DIFF_SPACING}>
+        <Body file={file} versions={versions} error={error} diffStyle={diffStyle} />
+      </div>
+    </div>
+  );
+}
+
+/// Keeps `useFileVersions`' key stable when nothing is selected. Never fetched
+/// — `enabled` is false in that state — so the path only has to be one no real
+/// file collides with.
+const EMPTY_FILE: ChangedFile = {
+  path: "",
+  oldPath: null,
+  status: "modified",
+  added: 0,
+  removed: 0,
+  binary: false,
+};
+
+const STYLES: { value: DiffStyle; label: string; Icon: typeof Columns2 }[] = [
+  { value: "split", label: "Split", Icon: Columns2 },
+  { value: "unified", label: "Unified", Icon: Rows3 },
+];
+
+/// Both options drawn side by side, with the active one filled.
+///
+/// A single glyph that swapped on click was tried first and read as a picture
+/// of the current state rather than as a control — nothing about it said it
+/// could be pressed. Two segments make the choice visible before it is made,
+/// which is worth the extra width on a row this wide.
+function StyleToggle({
+  value,
+  onChange,
+}: {
+  value: DiffStyle;
+  onChange: (next: DiffStyle) => void;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-muted/50 p-0.5">
+      {STYLES.map(({ value: style, label, Icon }) => (
+        <Tooltip key={style}>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => onChange(style)}
+              aria-label={`${label} view`}
+              aria-pressed={value === style}
+              className={cn(
+                "rounded-[min(var(--radius-md),6px)] p-1 transition-colors",
+                value === style
+                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Icon className="size-3.5" strokeWidth={1.5} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">{label} view</TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}
+
+function Body({
+  file,
+  versions,
+  error,
+  diffStyle,
+}: {
+  file: ChangedFile;
+  versions: ReturnType<typeof useFileVersions>["versions"];
+  error: string | null;
+  diffStyle: DiffStyle;
+}) {
+  const note = (text: string, tone?: "error") => (
+    <p
+      className={cn(
+        "px-3 py-2 text-ui",
+        tone === "error" ? "text-destructive" : "text-muted-foreground",
+      )}
+    >
+      {text}
+    </p>
+  );
+
+  // Same wording as the turn panel's rows: git's binary test is NUL-based, so
+  // a Latin-1 file passes it while the counts beside it stay real.
+  if (file.binary) return note("Not UTF-8 text — no diff to show.");
+  if (error) return note(error, "error");
+  if (!versions) return note("Loading…");
+  if (versions.unreadable) {
+    return note(
+      versions.unreadable === "binary"
+        ? "Not UTF-8 text — no diff to show."
+        : "File is too large to diff here.",
+    );
+  }
+
+  // A deletion's new side is null, which the viewer reads as an empty file and
+  // renders as a full removal; an addition keeps a null old side and draws as
+  // new rather than as a diff against nothing.
+  return (
+    <DiffView
+      sides={{ path: file.path, oldText: versions.oldText, newText: versions.newText ?? "" }}
+      diffStyle={diffStyle}
+      // Split only syncs its two columns' scrolling when lines can overflow, so
+      // this travels with it rather than being a taste choice.
+      overflow={diffStyle === "split" ? "scroll" : "wrap"}
+      unsafeCSS={DIFF_CSS}
+      // The pane is the frame, so the diff brings none of its own.
+      className="rounded-none border-0"
+    />
+  );
+}

--- a/apps/desktop/src/components/changes/FileList.tsx
+++ b/apps/desktop/src/components/changes/FileList.tsx
@@ -1,0 +1,99 @@
+import { memo } from "react";
+
+import FileIcon from "@/components/FileIcon";
+import Counts from "@/components/changes/Counts";
+import { splitPath } from "@/lib/changes";
+import { cn } from "@/lib/utils";
+import type { ChangedFile } from "@/types/events";
+
+/// A list of changed files, with the selected one leading to the diff pane.
+///
+/// One component for both sub-tabs: the working tree's files and a commit's
+/// read the same and are picked from the same way, so a second version would
+/// only be a chance for the two to drift apart.
+export default function FileList({
+  files,
+  selected,
+  onSelect,
+  className,
+  indent = false,
+}: {
+  files: readonly ChangedFile[];
+  selected: string | null;
+  onSelect: (path: string) => void;
+  className?: string;
+  /// Set under an expanded commit, where the rows belong to the row above them
+  /// and the step in is what says so.
+  indent?: boolean;
+}) {
+  return (
+    <div className={className}>
+      {files.map((file) => (
+        <Row
+          key={file.path}
+          file={file}
+          selected={file.path === selected}
+          onSelect={onSelect}
+          indent={indent}
+        />
+      ))}
+    </div>
+  );
+}
+
+/// `splitPath` keeps the separator on the directory, which reads as a dangling
+/// slash once the directory is drawn *after* the name.
+const trimSlash = (dir: string) => dir.replace(/\/$/, "");
+
+/// Memoized for [ChangesPanel]'s reason: the view re-renders on every session
+/// event, while a row's props only move when a read finds different trees.
+const Row = memo(function Row({
+  file,
+  selected,
+  onSelect,
+  indent,
+}: {
+  file: ChangedFile;
+  selected: boolean;
+  onSelect: (path: string) => void;
+  indent: boolean;
+}) {
+  const { dir, name } = splitPath(file.path);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(file.path)}
+      title={file.path}
+      className={cn(
+        "flex w-full items-center gap-2 py-1.5 pr-3 text-left text-ui",
+        indent ? "pl-6" : "pl-3",
+        selected ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/50",
+      )}
+    >
+      <FileIcon path={file.path} />
+
+      {/* Name first and never shrinking, directory after it and truncating.
+          One truncating span holding `dir + name` clips from the *end*, which
+          is the filename — the one part of a path that has to be readable, and
+          the part a deep tree is most likely to have cost. */}
+      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+        <span className="shrink-0 text-sidebar-foreground">{name}</span>
+        {dir && (
+          <span className="min-w-0 truncate text-muted-foreground">{trimSlash(dir)}</span>
+        )}
+        {file.oldPath && (
+          <span className="shrink-0 text-muted-foreground">
+            ← {splitPath(file.oldPath).name}
+          </span>
+        )}
+      </span>
+
+      {file.binary ? (
+        <span className="shrink-0 text-muted-foreground">binary</span>
+      ) : (
+        <Counts added={file.added} removed={file.removed} />
+      )}
+    </button>
+  );
+});

--- a/apps/desktop/src/components/changes/HistoryList.tsx
+++ b/apps/desktop/src/components/changes/HistoryList.tsx
@@ -1,0 +1,130 @@
+import Avatar from "@/components/Avatar";
+import FileList from "@/components/changes/FileList";
+import { useAvatar } from "@/hooks/useAvatar";
+import { relativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { ChangedFile, Commit } from "@/types/events";
+
+/// The branch's commits, newest first, each opening in place to show what it
+/// touched.
+///
+/// In place rather than as a second column or a drill-in. A column would leave
+/// the diff the narrowest of three panes, and replacing the list would hide the
+/// history behind whichever commit was open. Opening in place keeps both on
+/// screen — and it is why **nothing is selected on arrival**: a first commit
+/// touching thirty files would push the rest of the history off screen before
+/// the reader had picked anything.
+///
+/// No chevron. The row is the control, its highlight says which is open, and a
+/// second click closes it — an arrow would only label what the row already
+/// demonstrates.
+export default function HistoryList({
+  commits,
+  selected,
+  onToggle,
+  files,
+  selectedFile,
+  onSelectFile,
+  hasMore,
+  onLoadMore,
+  loading,
+  error,
+}: {
+  commits: readonly Commit[];
+  /// The open commit, or null when the list is closed up.
+  selected: string | null;
+  onToggle: (commit: Commit) => void;
+  /// The open commit's files. Empty while its read is in flight.
+  files: readonly ChangedFile[];
+  selectedFile: string | null;
+  onSelectFile: (path: string) => void;
+  hasMore: boolean;
+  onLoadMore: () => void;
+  loading: boolean;
+  error: string | null;
+}) {
+  if (error) return <p className="px-3 py-6 text-ui text-destructive">{error}</p>;
+  if (!commits.length) {
+    return (
+      <p className="px-3 py-6 text-ui text-muted-foreground">
+        {loading ? "Reading the history…" : "No commits yet."}
+      </p>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {commits.map((commit) => {
+        const open = commit.sha === selected;
+
+        return (
+          <div key={commit.sha}>
+            <CommitRow commit={commit} open={open} onToggle={onToggle} />
+
+            {open && (
+              <FileList
+                files={files}
+                selected={selectedFile}
+                onSelect={onSelectFile}
+                indent
+                className="border-y border-border bg-sidebar-accent/20"
+              />
+            )}
+          </div>
+        );
+      })}
+
+      {/* A row rather than a scroll sentinel: the list is a record being read
+          deliberately, and pulling in more of it on scroll makes the end of the
+          history impossible to reach. */}
+      {hasMore && (
+        <button
+          type="button"
+          onClick={onLoadMore}
+          className="w-full px-3 py-2 text-left text-ui text-muted-foreground hover:text-foreground"
+        >
+          Load more
+        </button>
+      )}
+    </div>
+  );
+}
+
+/// One commit's row: who, what, and when.
+///
+/// Its own component so the avatar's lookup is scoped to the row that needs it
+/// — the hook resolves one address, and a list of thirty would otherwise run
+/// thirty effects in the parent.
+function CommitRow({
+  commit,
+  open,
+  onToggle,
+}: {
+  commit: Commit;
+  open: boolean;
+  onToggle: (commit: Commit) => void;
+}) {
+  const avatar = useAvatar(commit.authorEmail);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(commit)}
+      className={cn(
+        "flex w-full flex-col gap-0.5 px-3 py-2 text-left text-ui",
+        open ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/50",
+      )}
+    >
+      <span className="w-full truncate text-sidebar-foreground">{commit.subject}</span>
+      {/* The picture sits on the byline rather than out at the row's left edge:
+          it says *who*, so it belongs next to the name, and a column of faces
+          beside the subjects would compete with the subjects for the eye. */}
+      <span className="flex w-full items-center gap-1.5 text-muted-foreground">
+        <Avatar src={avatar} name={commit.author} className="size-3.5 text-[8px]" />
+        <span className="truncate">{commit.author}</span>
+        <span>·</span>
+        <span className="shrink-0">{relativeTime(commit.authoredAt)}</span>
+      </span>
+    </button>
+  );
+}

--- a/apps/desktop/src/components/chat/DiffView.tsx
+++ b/apps/desktop/src/components/chat/DiffView.tsx
@@ -13,9 +13,32 @@ import { cn } from "@/lib/utils";
 export default function DiffView({
   sides,
   className,
+  diffStyle = "unified",
+  overflow = "wrap",
+  fill = false,
+  unsafeCSS,
 }: {
   sides: EditSides;
   className?: string;
+  /// Side by side, or one column. Only the repo view's own pane asks for
+  /// `split`, and it must pass `overflow: "scroll"` with it — the library only
+  /// wires the two columns' scrolling together when lines can overflow, so a
+  /// wrapping split view scrolls its halves independently.
+  ///
+  /// A prop rather than a second component: the highlighter gate below is the
+  /// part that is easy to get wrong, and it should exist once. Changing it
+  /// repaints the same instance and never re-tokenizes — the layout is the
+  /// client's, while the worker pool's cache is keyed on the text.
+  diffStyle?: "unified" | "split";
+  overflow?: "wrap" | "scroll";
+  /// Grow to the height of the container instead of capping. For a pane whose
+  /// whole job is this diff, where the cap the transcript needs would leave
+  /// most of the window empty.
+  fill?: boolean;
+  /// Rules injected into the viewer's shadow root, in the library's own
+  /// `unsafe` layer. Its escape hatch for the handful of things it styles but
+  /// exposes no variable for — see `DIFF_CSS` in `DiffPane`.
+  unsafeCSS?: string;
 }) {
   // Read here rather than threaded down from the transcript: nothing else
   // between here and the app root cares about either value, and props for them
@@ -38,20 +61,26 @@ export default function DiffView({
     () => ({
       theme: pair,
       themeType: resolvedMode,
-      // Unified: the transcript column is far too narrow for two gutters plus
-      // two code columns, and a side-by-side view there wraps into noise.
-      diffStyle: "unified" as const,
+      // Unified by default: the transcript column is far too narrow for two
+      // gutters plus two code columns, and a side-by-side view there wraps into
+      // noise. A dedicated pane has the width and asks for `split`.
+      diffStyle,
       // The row above already names the file, so a second header would repeat
       // it directly under itself.
       disableFileHeader: true,
-      // Long lines wrap instead of scrolling. A horizontal scrollbar inside a
-      // vertically scrolling transcript traps the wheel and is easy to miss.
-      overflow: "wrap" as const,
+      // Wrapping by default: a horizontal scrollbar inside a vertically
+      // scrolling transcript traps the wheel and is easy to miss.
+      overflow,
+      unsafeCSS,
     }),
-    [pair, resolvedMode],
+    [pair, resolvedMode, diffStyle, overflow, unsafeCSS],
   );
 
-  const frame = cn("overflow-hidden rounded-md border border-border/60 text-code", className);
+  const frame = cn(
+    "overflow-hidden rounded-md border border-border/60 text-code",
+    fill && "h-full",
+    className,
+  );
 
   // An unhighlighted stand-in rather than an empty box: a grammar fetch runs
   // from ~10ms to several hundred, and a blank frame that long reads as a
@@ -59,7 +88,13 @@ export default function DiffView({
   // line is on — legible before any syntax color arrives.
   if (!ready) {
     return (
-      <pre className={cn(frame, "max-h-96 overflow-auto px-2.5 py-2 font-mono")}>
+      <pre
+        className={cn(
+          frame,
+          "overflow-auto px-2.5 py-2 font-mono",
+          fill ? "h-full" : "max-h-96",
+        )}
+      >
         {sides.oldText !== null &&
           sides.oldText.split("\n").map((line, i) => (
             <div key={`-${i}`} className="text-destructive">

--- a/apps/desktop/src/components/chat/DiffView.tsx
+++ b/apps/desktop/src/components/chat/DiffView.tsx
@@ -31,9 +31,11 @@ export default function DiffView({
   /// client's, while the worker pool's cache is keyed on the text.
   diffStyle?: "unified" | "split";
   overflow?: "wrap" | "scroll";
-  /// Grow to the height of the container instead of capping. For a pane whose
-  /// whole job is this diff, where the cap the transcript needs would leave
-  /// most of the window empty.
+  /// Let the **loading stand-in** grow to its container instead of capping at
+  /// 96. For a pane whose whole job is this one diff, where the transcript's
+  /// cap leaves a short box floating in an empty window until the grammar
+  /// lands. Only the stand-in: the frame itself clips what overflows it, so a
+  /// full height there would cut long diffs off at the fold.
   fill?: boolean;
   /// Rules injected into the viewer's shadow root, in the library's own
   /// `unsafe` layer. Its escape hatch for the handful of things it styles but
@@ -76,11 +78,7 @@ export default function DiffView({
     [pair, resolvedMode, diffStyle, overflow, unsafeCSS],
   );
 
-  const frame = cn(
-    "overflow-hidden rounded-md border border-border/60 text-code",
-    fill && "h-full",
-    className,
-  );
+  const frame = cn("overflow-hidden rounded-md border border-border/60 text-code", className);
 
   // An unhighlighted stand-in rather than an empty box: a grammar fetch runs
   // from ~10ms to several hundred, and a blank frame that long reads as a

--- a/apps/desktop/src/components/layout/AppShell.tsx
+++ b/apps/desktop/src/components/layout/AppShell.tsx
@@ -51,7 +51,10 @@ export default function AppShell({
           </div>
         ) : (
           <>
-            <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+            {/* `flex flex-col` so the view tabs' bodies, which size themselves
+                with `flex-1` the way the right panel's do, have a column to
+                grow in. */}
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
             <div className="shrink-0">{footer}</div>
           </>
         )}

--- a/apps/desktop/src/components/layout/SessionHeader.tsx
+++ b/apps/desktop/src/components/layout/SessionHeader.tsx
@@ -1,5 +1,4 @@
 import GitBranchIcon from "@/components/icons/GitBranchIcon";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { basename } from "@/lib/format";
 import { sessionBranch } from "@/lib/pr";
 import { cn } from "@/lib/utils";
@@ -10,9 +9,13 @@ type SessionHeaderProps = {
   className?: string;
 };
 
-/// One line: `project / title`, then the branch. The sidebar clips titles at
-/// 240px, so this is the one place the full one is legible — hence the tooltip,
-/// and hence the title being the only part that gives way to truncation.
+/// One line: `project / title`, then the branch. The title is the only part
+/// that gives way to truncation, since it is the one thing here the reader
+/// wrote and can recognise from its opening words.
+///
+/// No tooltip on it. It fired on every hover of a title that was not clipped,
+/// which is most of them, and repeated back text already on screen — the one
+/// thing the app's tooltip rule says a tooltip must not do.
 export default function SessionHeader({ session, className }: SessionHeaderProps) {
   if (!session) {
     return (
@@ -35,14 +38,7 @@ export default function SessionHeader({ session, className }: SessionHeaderProps
           /
         </span>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="truncate font-medium text-foreground">{session.title}</span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" className="max-w-80 text-balance">
-            {session.title}
-          </TooltipContent>
-        </Tooltip>
+        <span className="truncate font-medium text-foreground">{session.title}</span>
       </span>
 
       {branch && (

--- a/apps/desktop/src/components/layout/ViewTabs.tsx
+++ b/apps/desktop/src/components/layout/ViewTabs.tsx
@@ -1,0 +1,64 @@
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { IS_MAC } from "@/lib/platform";
+import { cn } from "@/lib/utils";
+
+/// Which view fills the main column. Set and order in one, unlike the right
+/// panel's tabs: none of these are conditional, so a Terminal view joins by
+/// being added here and given a body.
+export const VIEW_TABS = ["chat", "changes"] as const;
+
+export type ViewTab = (typeof VIEW_TABS)[number];
+
+const LABELS: Record<ViewTab, string> = {
+  chat: "Chat",
+  changes: "Changes",
+};
+
+/// The main column's tab row, drawn in the titlebar beside the session's name.
+///
+/// Styled as the right panel's tab row rather than as buttons, because they are
+/// the same control: one row where exactly one entry is on. The accelerator is
+/// the tab's position, so it is read off the array rather than stored per tab —
+/// reordering `VIEW_TABS` moves the keys with it.
+export default function ViewTabs({
+  tab,
+  onChange,
+}: {
+  tab: ViewTab;
+  onChange: (tab: ViewTab) => void;
+}) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {VIEW_TABS.map((value, i) => (
+        <Tooltip key={value}>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => onChange(value)}
+              className={cn(
+                "rounded-md px-2 py-1 text-ui transition-colors",
+                tab === value
+                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {LABELS[value]}
+            </button>
+          </TooltipTrigger>
+          {/* The name is already on the button, so the tooltip carries the
+              keycaps alone rather than repeating it back — and with nothing to
+              read, the default `px-3` is a margin around one small chip. The
+              base style already tightens the *right* side for a trailing
+              keycap; this matches the left to it. */}
+          <TooltipContent side="bottom" className="px-1.5">
+            <KbdGroup>
+              <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+              <Kbd>{i + 1}</Kbd>
+            </KbdGroup>
+          </TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/hooks/useAvatar.ts
+++ b/apps/desktop/src/hooks/useAvatar.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+
+import { githubAvatar, gravatarUrl } from "@/lib/avatar";
+
+/// Resolved addresses, kept for the process.
+///
+/// Module-level for the reason the changes caches are: a history list re-renders
+/// on every session event and the same handful of authors repeat down it, so
+/// the digest should be computed once per address rather than once per row per
+/// render. `null` is cached too — an address that resolves to nothing is a
+/// settled answer, not a retry.
+const resolved = new Map<string, string | null>();
+
+/// A picture for a commit author's email, once one is known.
+///
+/// Returns null until it resolves, which is the whole of the loading state:
+/// [Avatar] is already drawing the initial, so there is nothing to hold back.
+export function useAvatar(email: string): string | null {
+  // Seeded from the cache so a repeat author paints with the picture already
+  // there rather than flashing the letter first.
+  const [url, setUrl] = useState<string | null>(() => resolved.get(email) ?? null);
+
+  useEffect(() => {
+    if (!email) return;
+
+    if (resolved.has(email)) {
+      setUrl(resolved.get(email) ?? null);
+      return;
+    }
+
+    // Exact before probable: the noreply address names an account outright,
+    // and hashing it for Gravatar would ask a second service about an address
+    // that was never a real mailbox.
+    const direct = githubAvatar(email);
+    if (direct) {
+      resolved.set(email, direct);
+      setUrl(direct);
+      return;
+    }
+
+    let live = true;
+    void gravatarUrl(email).then((next) => {
+      resolved.set(email, next);
+      if (live) setUrl(next);
+    });
+
+    return () => {
+      live = false;
+    };
+  }, [email]);
+
+  return url;
+}

--- a/apps/desktop/src/hooks/useRepo.ts
+++ b/apps/desktop/src/hooks/useRepo.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+import { reconcileLog } from "@/lib/commit";
+import type { Commit, SyncStatus } from "@/types/events";
+
+/// Same bargain [useChanges](./useChanges.ts) makes: a turn's events arrive in
+/// bursts, and only *refreshes* wait them out — the first read of a directory
+/// is immediate, since there is nothing on screen for waiting to protect.
+const REFRESH_DEBOUNCE = 300;
+
+/// One page of history. Deep enough that most readers never reach the end of
+/// it, short enough that opening the tab costs one small read.
+export const LOG_PAGE = 50;
+
+/// Runs `read` once on activation and then on every `revision` bump behind the
+/// debounce, and hands back a `refresh` that skips it.
+///
+/// Shared by all three reads below because they want the same rhythm and each
+/// getting its own would be three places for the debounce to drift apart.
+/// `active` sits in the deps for [useChanges]' reason: events that landed while
+/// the view was hidden bumped `revision` with the effect off, so coming back on
+/// screen has to count as a reason to re-read.
+function usePolledRead(cwd: string, revision: string, active: boolean, read: () => void) {
+  const started = useRef(false);
+
+  // A new directory is a different repository, so whatever was read for the old
+  // one says nothing about this one.
+  const [seeded, setSeeded] = useState(cwd);
+  if (seeded !== cwd) {
+    setSeeded(cwd);
+    started.current = false;
+  }
+
+  useEffect(() => {
+    if (!cwd || !active) return;
+
+    if (!started.current) {
+      started.current = true;
+      read();
+      return;
+    }
+
+    const timer = setTimeout(read, REFRESH_DEBOUNCE);
+    return () => clearTimeout(timer);
+  }, [cwd, active, revision, read]);
+}
+
+/// The tree HEAD points at — the baseline the uncommitted list diffs against.
+///
+/// Its own read rather than a field on the change set, because it is what makes
+/// the range: a commit moves HEAD, the id changes, and the working-tree diff
+/// re-keys itself onto the new baseline without anything having to invalidate a
+/// cache.
+export function useHeadTree(
+  cwd: string,
+  revision: string,
+  active: boolean,
+): { tree: string | null; refresh: () => void } {
+  const [tree, setTree] = useState<string | null>(null);
+
+  const issued = useRef(0);
+
+  const read = useCallback(() => {
+    const token = ++issued.current;
+    void invoke<string | null>("head_tree", { cwd })
+      .then((next) => {
+        if (issued.current !== token) return;
+        // Identity held on an unchanged id: this feeds a cache key, and a new
+        // string with the same characters would re-key it every read.
+        setTree((prev) => (prev === next ? prev : next ?? null));
+      })
+      // A directory that isn't a repository answers `null`, so there is no
+      // error here worth showing — the view draws its empty state either way.
+      .catch(() => issued.current === token && setTree(null));
+  }, [cwd]);
+
+  const [seeded, setSeeded] = useState(cwd);
+  if (seeded !== cwd) {
+    setSeeded(cwd);
+    setTree(null);
+  }
+
+  usePolledRead(cwd, revision, active, read);
+
+  return { tree, refresh: read };
+}
+
+export type CommitLog = {
+  commits: readonly Commit[];
+  error: string | null;
+  loading: boolean;
+  /// The last page came back full, so there is probably another behind it.
+  hasMore: boolean;
+  loadMore: () => void;
+  refresh: () => void;
+};
+
+/// The branch's history, a page at a time.
+export function useCommitLog(cwd: string, revision: string, active: boolean): CommitLog {
+  const [commits, setCommits] = useState<readonly Commit[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+
+  // Read by `loadMore`, which must not close over a stale length: it is called
+  // from a click, arbitrarily long after the render that defined it.
+  const commitsRef = useRef<readonly Commit[]>(commits);
+  commitsRef.current = commits;
+
+  const issued = useRef(0);
+  const paging = useRef(false);
+
+  const read = useCallback(() => {
+    const token = ++issued.current;
+    setLoading(true);
+    void invoke<Commit[]>("log_commits", { cwd, limit: LOG_PAGE, skip: 0 })
+      .then((page) => {
+        if (issued.current !== token) return;
+        setCommits((prev) => reconcileLog(prev, page));
+        setHasMore(page.length === LOG_PAGE);
+        setError(null);
+      })
+      .catch((e) => issued.current === token && setError(String(e)))
+      .finally(() => issued.current === token && setLoading(false));
+  }, [cwd]);
+
+  const loadMore = useCallback(() => {
+    if (paging.current) return;
+    paging.current = true;
+
+    const token = issued.current;
+    void invoke<Commit[]>("log_commits", {
+      cwd,
+      limit: LOG_PAGE,
+      skip: commitsRef.current.length,
+    })
+      .then((page) => {
+        // A refresh that landed mid-page has replaced the list this page was
+        // counted against, so appending it would interleave two histories.
+        if (issued.current !== token) return;
+        setCommits((prev) => {
+          const held = new Set(prev.map((c) => c.sha));
+          // A commit landing between the two reads shifts the window, so the
+          // page can repeat a row already on screen.
+          return [...prev, ...page.filter((c) => !held.has(c.sha))];
+        });
+        setHasMore(page.length === LOG_PAGE);
+      })
+      .catch((e) => setError(String(e)))
+      .finally(() => {
+        paging.current = false;
+      });
+  }, [cwd]);
+
+  const [seeded, setSeeded] = useState(cwd);
+  if (seeded !== cwd) {
+    setSeeded(cwd);
+    setCommits([]);
+    setError(null);
+    setHasMore(false);
+  }
+
+  usePolledRead(cwd, revision, active, read);
+
+  return { commits, error, loading, hasMore, loadMore, refresh: read };
+}
+
+/// Where the branch stands against its upstream, for the push button.
+export function useSyncStatus(
+  cwd: string,
+  revision: string,
+  active: boolean,
+): { status: SyncStatus | null; refresh: () => void } {
+  const [status, setStatus] = useState<SyncStatus | null>(null);
+
+  const issued = useRef(0);
+
+  const read = useCallback(() => {
+    const token = ++issued.current;
+    void invoke<SyncStatus>("sync_status", { cwd })
+      .then((next) => issued.current === token && setStatus(next))
+      .catch(() => issued.current === token && setStatus(null));
+  }, [cwd]);
+
+  const [seeded, setSeeded] = useState(cwd);
+  if (seeded !== cwd) {
+    setSeeded(cwd);
+    setStatus(null);
+  }
+
+  usePolledRead(cwd, revision, active, read);
+
+  return { status, refresh: read };
+}

--- a/apps/desktop/src/hooks/useRepo.ts
+++ b/apps/desktop/src/hooks/useRepo.ts
@@ -56,8 +56,13 @@ export function useHeadTree(
   cwd: string,
   revision: string,
   active: boolean,
-): { tree: string | null; refresh: () => void } {
+): { tree: string | null; settled: boolean; refresh: () => void } {
   const [tree, setTree] = useState<string | null>(null);
+  // Whether a read has ever come back for this directory. Without it `null`
+  // says two things at once — "not a repository" and "not asked yet" — and the
+  // view, which paints before the first read lands, would announce the first
+  // while it means the second.
+  const [settled, setSettled] = useState(false);
 
   const issued = useRef(0);
 
@@ -72,18 +77,20 @@ export function useHeadTree(
       })
       // A directory that isn't a repository answers `null`, so there is no
       // error here worth showing — the view draws its empty state either way.
-      .catch(() => issued.current === token && setTree(null));
+      .catch(() => issued.current === token && setTree(null))
+      .finally(() => issued.current === token && setSettled(true));
   }, [cwd]);
 
   const [seeded, setSeeded] = useState(cwd);
   if (seeded !== cwd) {
     setSeeded(cwd);
     setTree(null);
+    setSettled(false);
   }
 
   usePolledRead(cwd, revision, active, read);
 
-  return { tree, refresh: read };
+  return { tree, settled, refresh: read };
 }
 
 export type CommitLog = {

--- a/apps/desktop/src/lib/avatar.ts
+++ b/apps/desktop/src/lib/avatar.ts
@@ -1,0 +1,46 @@
+/// A commit carries an email and nothing else — git has no account behind it —
+/// so a face has to be resolved from that address alone.
+///
+/// Two routes, in order of certainty. GitHub's noreply address *contains* the
+/// account id, so it resolves exactly; guessing a login from a name would not,
+/// and `github.com/<login>.png` 404s for precisely the bot accounts that show
+/// up most in a history. Everything else goes to Gravatar, which is what git
+/// clients have always used and what most people's commits already resolve
+/// through.
+///
+/// Both can miss, and missing is fine: the request 404s and [Avatar] keeps the
+/// initial it was already drawing.
+const SIZE = 48;
+
+/// `12345+login@users.noreply.github.com`, the address GitHub hands out and
+/// commits made through its own UI carry. The leading number is the account id.
+const GITHUB_NOREPLY = /^(\d+)\+[^@]+@users\.noreply\.github\.com$/i;
+
+export function githubAvatar(email: string): string | null {
+  const match = GITHUB_NOREPLY.exec(email.trim());
+  return match ? `https://avatars.githubusercontent.com/u/${match[1]}?s=${SIZE}` : null;
+}
+
+/// Gravatar takes a SHA-256 of the lowercased, trimmed address — which is why
+/// this can be done here at all: the digest is `crypto.subtle`'s, so no hashing
+/// dependency comes with it.
+///
+/// `d=404` rather than a generated fallback: a missing account should fail the
+/// request so the initial stays, instead of covering it with a stranger's
+/// pattern that reads as a real person.
+export async function gravatarUrl(email: string): Promise<string | null> {
+  const address = email.trim().toLowerCase();
+  if (!address) return null;
+
+  try {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(address));
+    const hash = [...new Uint8Array(digest)]
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    return `https://gravatar.com/avatar/${hash}?s=${SIZE}&d=404`;
+  } catch {
+    // `crypto.subtle` needs a secure context. Losing the picture is not worth
+    // reporting anywhere — the letter is already on screen.
+    return null;
+  }
+}

--- a/apps/desktop/src/lib/commit.test.ts
+++ b/apps/desktop/src/lib/commit.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  checkedCount,
+  commitBase,
+  commitPaths,
+  EMPTY_TREE,
+  reconcileLog,
+  reconcileUnchecked,
+} from "./commit";
+import type { ChangedFile, Commit } from "@/types/events";
+
+function file(over: Partial<ChangedFile> = {}): ChangedFile {
+  return {
+    path: "a.txt",
+    oldPath: null,
+    status: "modified",
+    added: 1,
+    removed: 0,
+    binary: false,
+    ...over,
+  };
+}
+
+function commit(over: Partial<Commit> = {}): Commit {
+  return {
+    sha: "aaa",
+    parent: "bbb",
+    subject: "s",
+    body: "",
+    author: "Test",
+    authorEmail: "t@example.com",
+    authoredAt: "2026-08-22T10:00:00+05:45",
+    ...over,
+  };
+}
+
+describe("commitBase", () => {
+  it("diffs a root commit against the empty tree", () => {
+    expect(commitBase(commit({ parent: null }))).toBe(EMPTY_TREE);
+    expect(commitBase(commit({ parent: "bbb" }))).toBe("bbb");
+  });
+});
+
+describe("reconcileUnchecked", () => {
+  it("forgets a file that is no longer changed", () => {
+    const unchecked = new Set(["a.txt", "gone.txt"]);
+
+    const next = reconcileUnchecked(unchecked, [file({ path: "a.txt" })]);
+
+    expect([...next]).toEqual(["a.txt"]);
+  });
+
+  it("holds its identity when nothing was dropped", () => {
+    const unchecked = new Set(["a.txt"]);
+
+    expect(reconcileUnchecked(unchecked, [file({ path: "a.txt" })])).toBe(unchecked);
+  });
+
+  it("leaves a file the agent just wrote checked", () => {
+    // The set is inverted for exactly this: a file nobody has touched the
+    // checkbox of is one that goes in the commit.
+    const next = reconcileUnchecked(new Set(["a.txt"]), [
+      file({ path: "a.txt" }),
+      file({ path: "fresh.txt" }),
+    ]);
+
+    expect(next.has("fresh.txt")).toBe(false);
+  });
+});
+
+describe("commitPaths", () => {
+  it("leaves out what the reader unchecked", () => {
+    const files = [file({ path: "a.txt" }), file({ path: "b.txt" })];
+
+    expect(commitPaths(files, new Set(["b.txt"]))).toEqual(["a.txt"]);
+  });
+
+  it("carries both sides of a rename", () => {
+    // Without the old name the commit records the copy and leaves the delete
+    // behind as a dirty file.
+    const files = [file({ path: "new.txt", oldPath: "old.txt", status: "renamed" })];
+
+    expect(commitPaths(files, new Set())).toEqual(["new.txt", "old.txt"]);
+  });
+});
+
+describe("checkedCount", () => {
+  it("counts files, not the paths a rename expands to", () => {
+    const files = [
+      file({ path: "new.txt", oldPath: "old.txt", status: "renamed" }),
+      file({ path: "b.txt" }),
+    ];
+
+    expect(checkedCount(files, new Set(["b.txt"]))).toBe(1);
+  });
+});
+
+describe("reconcileLog", () => {
+  it("keeps the list when the tip has not moved", () => {
+    // The reader may have paged well past the first page; a refresh that
+    // replaced the array would throw all of that away on every event.
+    const prev = [commit({ sha: "c3" }), commit({ sha: "c2" }), commit({ sha: "c1" })];
+
+    expect(reconcileLog(prev, [commit({ sha: "c3" }), commit({ sha: "c2" })])).toBe(prev);
+  });
+
+  it("starts again when the tip moved", () => {
+    const prev = [commit({ sha: "c2" })];
+    const page = [commit({ sha: "c3" }), commit({ sha: "c2" })];
+
+    expect(reconcileLog(prev, page)).toBe(page);
+  });
+
+  it("takes the first page it is given", () => {
+    const page = [commit({ sha: "c1" })];
+
+    expect(reconcileLog([], page)).toBe(page);
+  });
+});

--- a/apps/desktop/src/lib/commit.ts
+++ b/apps/desktop/src/lib/commit.ts
@@ -1,0 +1,85 @@
+import type { ChangedFile, Commit } from "@/types/events";
+
+/// Git's empty tree, which every repository has whether anything was ever
+/// written into it or not. Stands in as the base for a root commit, so the
+/// first commit in a history opens like any other instead of being the one row
+/// that cannot be read.
+export const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+/// What a commit's own diff is taken against.
+export function commitBase(commit: Commit): string {
+  return commit.parent ?? EMPTY_TREE;
+}
+
+/// Which files the reader has turned *off*.
+///
+/// Unused today: the repo view reads and does not write, so nothing draws a
+/// checkbox. Kept with its tests, next to the `commit_files` command it was
+/// written for, because the question it answers is the awkward part of any
+/// commit surface and re-deriving it later would mean re-learning why the set
+/// is inverted.
+///
+/// Stored inverted — the unchecked set rather than the checked one — so a file
+/// the agent writes while the view is open arrives checked, like every other
+/// change. Tracking the checked set instead would make each new file default to
+/// excluded from the commit, which is the opposite of what a fresh change list
+/// means.
+export function reconcileUnchecked(
+  unchecked: ReadonlySet<string>,
+  files: readonly ChangedFile[],
+): ReadonlySet<string> {
+  const listed = new Set(files.map((f) => f.path));
+  // Identity held when nothing was dropped: this runs on every read, and a new
+  // Set each time would re-render every row for no change.
+  let stale = false;
+  for (const path of unchecked) {
+    if (!listed.has(path)) {
+      stale = true;
+      break;
+    }
+  }
+  if (!stale) return unchecked;
+
+  return new Set([...unchecked].filter((path) => listed.has(path)));
+}
+
+/// The pathspec for a commit of the checked files.
+///
+/// A rename contributes **both** names: the new one to add, and the old one so
+/// its disappearance is part of the same commit. Leaving the old side out
+/// commits the copy and leaves the delete behind as a dirty file.
+export function commitPaths(
+  files: readonly ChangedFile[],
+  unchecked: ReadonlySet<string>,
+): string[] {
+  const paths: string[] = [];
+  for (const file of files) {
+    if (unchecked.has(file.path)) continue;
+    paths.push(file.path);
+    if (file.oldPath) paths.push(file.oldPath);
+  }
+  return paths;
+}
+
+/// How many files a commit would carry, for the button's own label.
+export function checkedCount(
+  files: readonly ChangedFile[],
+  unchecked: ReadonlySet<string>,
+): number {
+  return files.reduce((n, file) => (unchecked.has(file.path) ? n : n + 1), 0);
+}
+
+/// Folds a freshly read first page into the list already on screen.
+///
+/// The tip is the whole test. While a turn runs this refetches on every event,
+/// and replacing the array each time would throw away however far the reader
+/// had paged — so an unchanged tip keeps what is there, and a moved one starts
+/// again, because everything below it may have moved with a rebase or an amend.
+export function reconcileLog(
+  prev: readonly Commit[],
+  firstPage: readonly Commit[],
+): readonly Commit[] {
+  if (prev.length === 0) return firstPage;
+  if (firstPage.length > 0 && firstPage[0].sha === prev[0].sha) return prev;
+  return firstPage;
+}

--- a/apps/desktop/src/types/events.ts
+++ b/apps/desktop/src/types/events.ts
@@ -317,6 +317,28 @@ export type CheckState = "success" | "failure" | "pending" | "skipped" | "cancel
  */
 export type CommentKind = "comment" | "approved" | "changes_requested" | "reviewed";
 
+/**
+ * One commit, as the history list draws it.
+ */
+export type Commit = { sha: string, 
+/**
+ * First parent — the side this commit's own diff is taken against. `None`
+ * on the root commit, where the caller substitutes git's empty tree. A
+ * merge keeps only its first parent, so it reads as what the merge brought
+ * onto this branch rather than as everything both sides ever did.
+ */
+parent: string | null, subject: string, body: string, author: string, 
+/**
+ * What the history list draws a face from. Git has no account behind a
+ * commit — only whatever the author configured — so this is the only
+ * identity here, and the frontend resolves it to a picture or to a letter.
+ */
+authorEmail: string, 
+/**
+ * RFC 3339, matching every other timestamp that reaches the frontend.
+ */
+authoredAt: string, };
+
 export type ContextWindow = { usedTokens: number, maxTokens: number, };
 
 /**
@@ -798,6 +820,27 @@ export type Subagent = { id: string,
  * Drives the collapsed subagent card's title.
  */
 label: string | null, };
+
+/**
+ * Where the current branch stands against its upstream — everything the push
+ * button needs to name itself.
+ */
+export type SyncStatus = { 
+/**
+ * `None` on a detached HEAD and for a directory that isn't a repo, which
+ * is how the row hides itself rather than offering a push it can't do.
+ */
+branch: string | null, 
+/**
+ * `None` for a branch that has never been pushed — the "publish" case.
+ */
+upstream: string | null, 
+/**
+ * Commits the upstream doesn't have. Zero when there is no upstream: the
+ * button reads "Publish branch" there, and a count would be answering a
+ * question nobody asked yet.
+ */
+ahead: number, };
 
 export type ToolResult = { 
 /**


### PR DESCRIPTION
The main column gets tabs: **Chat** and **Changes** (⌘1/⌘2), with a Terminal tab ready to join by being added to `VIEW_TABS`. Switching hides rather than unmounts, so the transcript keeps its scroll position and highlighted diffs.

**Changes** is a read-only view of the session's repository — an **Uncommitted** list (HEAD's tree against the working tree) and **History** for the branch, with the selected file's diff in its own full-height pane, split or unified.

## Read-only on purpose

The conversation next door is where work gets made and committed, so a second place to write commits would be a second way to do what the reader is already asking the agent for. `commit_files` and `push_branch` ship registered and tested anyway, with the checkbox path arithmetic beside them in `commit.ts`: *which* paths a commit takes is the awkward part — a rename needs both names, and the pathspec form of `commit` implies `--only` so anything staged for an excluded file stays staged — and that reasoning is expensive to rediscover. UI absent, capability parked.

## Notes

- **Commit SHAs already pass `is_tree_id`**, so `changes_since` and `file_versions` serve a commit's diff unchanged. Only a `git log` reader and a HEAD-tree lookup are new. A commit's range is two fixed ids, so it is read once and cached forever.
- **A live list sorts newest-edit first**; a frozen range keeps git's order, since what a path says on disk today has nothing to do with what it said then. Both directions are pinned by a test.
- **History opens in place** — no drill-in, no third column, and nothing selected on arrival, since a first commit touching thirty files would push the rest off screen before anything was picked.
- **Commit avatars come from the author's email**: GitHub's noreply address contains the account id so it resolves exactly, everything else goes to Gravatar over a SHA-256 the browser computes, and a miss leaves the initial standing.
- **The channel between split halves was a reserved scrollbar gutter**, not a gap — `scrollbar-gutter: stable` reserves a classic scrollbar's width at each column's right edge even though the library draws it at zero width. Fixed through the library's own `unsafeCSS` layer.
- The right panel's turn-scoped Changes tab is untouched; it answers a different question.

## Verification

`cargo test` 224 passing, `pnpm test` 126 passing, `pnpm build` clean, and run under `pnpm tauri dev`.

## Deliberately not included

No fetch or pull (so behind-ness is invisible until a push is rejected), no discard-changes, no hunk staging, and no count badge on the Changes tab — a working-tree count would force a snapshot on every event even while the reader sits on Chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/monorepo-labs/dray/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->