### PR TITLE
Deleting state for the worktree dialog

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -721,10 +721,7 @@ function App() {
     <QuitDialog />
     <WorktreeDialog
       prompt={worktreePrompt}
-      onConfirm={(sessionId) => {
-        setWorktreePrompt(null);
-        void removeWorktree(sessionId);
-      }}
+      onConfirm={(sessionId) => removeWorktree(sessionId)}
       onClose={() => setWorktreePrompt(null)}
     />
     </DiffWorkerPool>

--- a/apps/desktop/src/components/WorktreeDialog.tsx
+++ b/apps/desktop/src/components/WorktreeDialog.tsx
@@ -1,3 +1,6 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -42,7 +45,7 @@ export default function WorktreeDialog({
   onClose,
 }: {
   prompt: WorktreePrompt | null;
-  onConfirm: (sessionId: string) => void;
+  onConfirm: (sessionId: string) => Promise<boolean>;
   onClose: () => void;
 }) {
   // Held for the fade: Radix keeps `Content` mounted while it closes, and the
@@ -50,8 +53,30 @@ export default function WorktreeDialog({
   // state for the frame the eye is still on.
   const cost = prompt && worktreeCost(prompt.disposition);
 
+  // The dialog stays up while git works. Unlocking the tree, removing it and
+  // deleting its branch is three commands over a directory that can be large,
+  // and a dialog sitting unchanged through them reads as one the click missed.
+  //
+  // Reset on *open* rather than on close, for the reason `cost` is held:
+  // clearing it as the dialog leaves flips the button back to "Delete anyway"
+  // for the length of the fade.
+  const [deleting, setDeleting] = useState(false);
+  useEffect(() => {
+    if (prompt) setDeleting(false);
+  }, [prompt]);
+
+  // No "Deleted" state to match the notice card's. That card has to keep
+  // saying so because the reader is looking elsewhere by then; this dialog is
+  // the thing they are looking at, and it closing says it. A failure closes it
+  // too — the error banner already carries the reason.
+  const confirm = async (sessionId: string) => {
+    setDeleting(true);
+    await onConfirm(sessionId);
+    onClose();
+  };
+
   return (
-    <AlertDialog open={prompt !== null} onOpenChange={(next) => !next && onClose()}>
+    <AlertDialog open={prompt !== null} onOpenChange={(next) => !next && !deleting && onClose()}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Delete this worktree?</AlertDialogTitle>
@@ -72,16 +97,28 @@ export default function WorktreeDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Keep it</AlertDialogCancel>
+          <AlertDialogCancel disabled={deleting}>Keep it</AlertDialogCancel>
           {/* Red whether or not anything is lost: this deletes a directory
               either way, and a button that only turns red sometimes teaches
               the reader to read the colour instead of the sentence. What the
               cost changes is the label. */}
           <AlertDialogAction
             destructive
-            onClick={() => prompt && onConfirm(prompt.sessionId)}
+            // Full strength while disabled: the spinner and the verb are the
+            // state, and dimming them as well makes the one live thing on the
+            // dialog the hardest part of it to read.
+            className="disabled:opacity-100"
+            disabled={deleting}
+            // Radix's `Action` closes the dialog itself, through
+            // `composeEventHandlers` — so `preventDefault` is what holds it up
+            // for the work. Without it the deleting state lasts one frame.
+            onClick={(e) => {
+              e.preventDefault();
+              if (prompt) void confirm(prompt.sessionId);
+            }}
           >
-            {cost ? "Delete anyway" : "Delete worktree"}
+            {deleting && <Loader2 className="animate-spin" />}
+            {deleting ? "Deleting…" : cost ? "Delete anyway" : "Delete worktree"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>


### PR DESCRIPTION
Removing a worktree unlocks it, runs `git worktree remove`, then deletes the branch — seconds of work on a large tree. The dialog closed the moment the button was pressed, so the app went quiet with nothing saying the delete was still running.

Now the dialog stays up for the work:

- Confirm button becomes a spinner + "Deleting…", at full strength (`disabled:opacity-100`) so the one live thing on the dialog isn't the dimmest.
- "Keep it" and Escape blocked while it runs.
- Closes when git finishes, or on failure — the error banner already carries the reason.
- No "Deleted" confirmation like the notice card's: that card has to keep saying so because the reader looked away, and this dialog is the thing they're looking at.

Radix's `AlertDialogAction` closes on click through `composeEventHandlers`, so `preventDefault` is what holds it open. `deleting` resets on *open* rather than close, for the reason `cost` is held — clearing it on the way out flips the label back for the length of the fade.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)