### PR TITLE
PR detection on turn end, sidebar marks, composer handoff row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,8 @@ Baseline ride on `user_message.baseline` and closing head on `turn_completed.hea
 
 **Right pane = one frame with tabs, not one panel per view.** [RightPanel](apps/desktop/src/components/RightPanel.tsx) own `<aside>`, border, tab row; `ChangesPanel` and `SubagentPanel` = bodies rendering inside it, carry no chrome. `AppShell` have single `panel` slot, so two self-framing panels could only ever be mutually exclusive with two booleans deciding it — third view now tab and component instead. Tab row `h-(--titlebar-h)` and carry drag region itself, in place of empty spacer each panel used to open with. No close button: `PanelToggle` and ⌘E both close it, matching ⌘B for sidebar. That toggle exported from `RightPanel` but rendered by `App`, because pane not exist before session do and button have to outlive it — same split `SidebarToggle` have on far side.
 
+**Changes glyph = plain foreground, not command yellow.** Yellow = app's "this is for you", colour of session standing still behind question. Turn having touched file neither warning nor thing to answer, and yellow read as one every turn — lot of alarm for a fact. PR glyph keep its emerald: that one say state of work, and green = what merge button already is.
+
 **Toggle double as changes indicator**, which whole of quick-access rail that was going to sit beside it. With pane closed and last turn having changed tree, it draw git glyph instead of panel one and its click open _changes_ tab not whichever tab last used — glyph opening something else = lie. ⌘E stay plain toggle: show nothing, so promise nothing. Signal = `turnChangedTree`, cost no git call — both sides of range content-addressed tree ids, so ids that differ _are_ changed tree. Reading panel's own file list instead not work: `useChanges` pause while hidden, exactly when indicator have to be right.
 
 **No row in changes list open by default.** List = answer to "what did this turn touch", and auto-opening one file by position put arbitrary diff above that list and push rest off screen.
@@ -245,7 +247,15 @@ Three exits clear it, all needed: `block_start` that not thinking (text or tool 
 
 **Session's PR = tab in right pane**, beside Changes and Subagents. [PrPanel](apps/desktop/src/components/PrPanel.tsx) render readiness, checks, comments and merge action; frame, tab row and mount-forever bargain all `RightPanel`'s, exactly as that section promise.
 
-**Tab called `PR`, and it lead when PR is open.** Short form what anyone working on one call it, and long one widest label in row of three. `tabOrder` put it first when session have **open** PR — at that point session's work no longer about this turn, it about landing, and first tab where eye go. Merged or closed PR don't promote: it record, not something to act on.
+**Tab called `PR`, and it lead when PR is open.** Short form what anyone working on one call it, and long one widest label in row of three. `tabOrder` put it first when session have **open** PR — at that point session's work no longer about this turn, it about landing, and first tab where eye go. Draft count, being `OPEN` with `isDraft` set. Merged or closed PR don't promote: it record, not something to act on.
+
+**Which tab open = one line, and `null` what make it work.** `ade.panelTab` hold `PanelTab | null` and default **null** = "reader never picked". `activeTab` then = pick where pick still name tab this session draw, else derived default — PR when open one exist, Changes otherwise. Storing `"changes"` as initial value = whole of old bug: fresh install indistinguishable from reader who chose Changes, so open PR could never lead. Not written back either, so switching to PR-less session keep pick for when they switch to one that have it.
+
+Last turn changing tree **don't** enter into it. Changes describe one turn and superseded by next; PR = state of work. Toggle's own click still set tab to match glyph it drew — git icon opening subagents = lie — and that now only thing `handleTogglePanel` do. ⌘E stay plain toggle: draw nothing, promise nothing.
+
+**⌘⇧[ / ⌘⇧] step tab, and legend drawn not hidden.** Browser and editor chord, so it arrive already known. Step over `tabs` (what `tabOrder` return) not `PANEL_TABS`, so session with no PR tab cycle two and never land on undrawn one. Keycaps sit **right after tabs**, no label: next to thing they act on they read as belonging to row without word saying so, and refresh button take `ml-auto` instead. Three cap not four — `[ ]` = one key with two end, and splitting it read as chord wanting both. Deliberate exception to app's tooltip rule: chord for row of two or three tab = one nobody go looking for.
+
+Binding on **`{` / `}`**, not on brackets: shift layout reach `key`, so ⌘⇧[ report as `{`. `useHotkey` grew `code` option (`BracketLeft`/`BracketRight`) for engines that report unshifted one instead — both route, since character alone one engine away from silently never firing and position alone put chord under different glyph on every non-US layout.
 
 **Hook live in `App`, not in panel.** Tab row need to know whether open PR exist *before* that tab ever shown, so ordering can't wait on panel fetching for itself. Follow that first read **not** gated on `active` — only poll is, which half `useChanges` was really guarding. One read per session selection, deduped by freshness window.
 
@@ -271,6 +281,8 @@ Only **tip commit's** rollup asked for (`commits(last:1)`) — check reported ag
 **Badge count leave merged PR out** (`prBadgeCount`). Every other state on panel have something reader can still do — open one merge, draft go ready, **closed one reopen** — and merged one have nothing at all, so counting it inflate badge that exist to say how much still live. It stay in list either way: list = record, badge = workload.
 
 **Single PR not collapsible, and draw no chevron.** Disclosure arrow that can only ever point down = affordance for nothing, and collapsing the only row leave tab showing one line. Header become plain label rather than button, and lose hover fill with it.
+
+**Refresh go entirely on Subagents**, which have nothing to re-read. It reserved its width back when keycaps sat to its right and would slide on that one tab; with them anchored to tabs there nothing left to hold still, and empty box on far edge = slot for button reader not waiting for.
 
 **One refresh button, in tab row, owned by frame.** It mean same thing on every tab, so it sit in same place rather than once per panel; active tab decide what it re-read. Subagents get none — nothing to fetch, and button that do nothing worse than no button. Both panel bodies therefore presentational and **their hooks live in `App`**: `useChanges` moved up beside `usePullRequest` for exactly this, since tab row need what they know before either tab opened.
 
@@ -298,6 +310,12 @@ Thread carry two facts ordinary comment don't. `path:line` say where it hang —
 
 **Poll only while something can still move.** `isSettling` = open PR with pending check or unresolved mergeability; nothing else ever polled, since settled PR not going to change under reader's eyes. 15s while settling, and gated on `active` — hidden tab must not keep spawning `gh`. Pending check spin for this reason: it one row on pane about to change on own, and poll driving it invisible otherwise. Answers cached per `cwd + branch` across mounts and counted fresh for 30s, because switching session change props and `gh` cost better part of second, which read as panel reloading every time it looked at.
 
+`active` read off **pick**, not off `activeTab` — that derive from this hook's own answer, so it not exist yet at call site. Unset pick count, since derived default = PR tab whenever open one exist. Two disagree in exactly one case: session whose only PR merged, where pick unset, default resolve to Changes, and this read true. Harmless — merged PR never settle, and poll gate on that too.
+
+**PR appearing = turn ending, and nothing else could see it.** Poll gate on PR tab being visible **and** active, and `prTabVisible` hide tab exactly while answer "no PR" — so one state needing recheck = only one that could never self-heal, and PR created mid-session stayed invisible until reader switched away and back. Fix = refetch on **falling edge of `busy`** in `App`. Session id ride along in that ref, because `busy` = *selected* session's: switching from running session to idle one drop it with no turn having ended.
+
+**And appearance open pane, once.** `usePullRequest` take `onOpened`, fired from inside `load` — only fetch know what *previous* answer was, and previous answer = whole guard. `before` read off cache ahead of write; callback fire only where it existed, held no open PR, and new one do. First read have no `before`, so opening app onto session that already have PR raise nothing. Key-guarded like every other write there: read landing after session switch must not pull pane open onto branch reader left.
+
 **Every write refetch, and that not deferred optimism.** Merge close PR and move it down list, ready-for-review move it out of draft — each change more than field it name, so panel read new state back rather than guess. Merge itself two-step: button arm confirm that replace it, same shape sidebar's delete use. Method live in button's own menu not in confirm, so confirm read as one sentence naming exactly what about to happen — and menu spell out what each method do to base's history, since this only irreversible choice on pane. Menu `align="end"` and `w-80`: button sit at pane's right edge so start-aligned menu open off window, and at default width each description ran five lines and menu grew taller than panel.
 
 **Merge button green, and it GitHub's green not app's emerald.** `--accent-merge` = only place app use it. Primary fill on this palette near-white, which made **least reversible control on pane also brightest thing on it**; green what same button is on GitHub, so it recognisable before it read. No icon on it either — label already say "merge", and glyph was widest thing in button that only ever name one of three near-identical actions.
@@ -318,7 +336,19 @@ Thread carry two facts ordinary comment don't. `path:line` say where it hang —
 
 **Every comment collapsed, avatar in place of icon.** List where some row open and some closed read as accident not rule, so all start closed and first line of body (heading marks stripped) stand in for rest — row saying only who wrote it make reader open every one to find one that matter. Verdict carried by **coloured word** in closed row — `approved`, `requested changes` — so one thing worth knowing without opening anything already there. Author's picture replace icon that used to sit there: it say *who* in same space, where column of identical speech bubbles said nothing. Comment rows sit in `gap-2` column where check rows don't: checks = dense column of one-line facts, comments = separate things people said. Check row keep state glyph **and** take avatar second — state why anyone look at list, so it keep left edge; avatar read as who saying so. Avatar fall back to initial and cover it on load, so slow or missing image never leave hole at row's left edge.
 
-**Panel toggle draw PR over changes.** Two indicators = same promise ("something here, and this is way to it"), so only one can be drawn and PR win: it tab that open first, it state of *work* rather than of last turn, and it survive next prompt landing where changes mark don't. Glyph = **`text-emerald-500`, not `--accent-merge`**: that token is button *fill*, dark enough to carry white text, and at 1.5px stroke on dark background it all but disappeared beside bright changes yellow. Emerald = same green open-PR glyph use inside panel, so mark and thing it point at match. Toggle's click set tab to match glyph — git icon opening subagents would be lie, same rule changes indicator already follow.
+**Sidebar row carry PR mark, and it one `gh` per repo not per row.** [useOpenPrs](apps/desktop/src/hooks/useOpenPrs.ts) ask `open_prs` once per **distinct repo** among visible sessions — `gh` cost better part of second, so spawn per row make sidebar most expensive thing in app. Backend's `QUERY_OPEN` = states:OPEN, first:100, ordered by update, carrying `number headRefName isDraft` and nothing else: row draw open-or-draft, so shipping checks and review threads for every session = payload nobody read. `Response<T>` gone generic so both query share three envelopes around `pullRequests`.
+
+**Matching live in frontend, deliberately.** Backend answer *list* not map, because which branch session land on = frontend's own rule (`sessionBranch` rebuild worktree session's from its worktree name) and map built in Rust = second copy of it free to disagree.
+
+Glyph sit **beside rail, ahead of title**, and take **no room when absent** — unlike rail next to it, which hold its slot. Two differ because rail come and go on *same* row as agent work, where branch either have PR or don't: row that never get one would otherwise pay for mark forever, and most never do. Rail keep outer edge, since it "over to you" and clear when reader deal with it, where this standing fact about branch. Emerald for open (same green panel glyph and merge button use), muted `GitPullRequestDraft` for draft, since draft = work not asking to land yet. `title` attribute rather than tooltip: decoration on row that itself a control, and tooltip open every time cursor cross list.
+
+**Asked for active list's repos only.** `showArchived` true → empty set, no call. Settled session = work reader already dealt with, so repo appearing nowhere but archived list = one nobody waiting to land. Marks already fetched still draw over there, since cache outlive the ask — what dropped is spending, not answer. `projectFilter` narrow it further for free, since row not on screen need no mark.
+
+Cache module-level per repo, fresh **120s** — longer than panel's 30s, because this feed mark rather than view being read, and glyph arriving minute late cost nothing where stale merge button would. Refreshed on same turn-end edge panel use, so mark and pane land together. Failure silent and total (no `gh`, not GitHub repo, logged out): empty map cached *and stamped* like success, so repo `gh` can't answer for stop being asked until window expire rather than on every render. Undefined therefore mean both "no PR" and "couldn't ask" — mark decoration on list that work without it, so two read same.
+
+**Toggle's PR glyph count draft, and draw draft's own shape.** `hasOpenPr` = any `state === "OPEN"`, which draft satisfy. `draft` prop true only where **every** open PR is one — session carrying draft beside real PR have something asking to land. Glyph keep emerald either way: shape carry distinction, colour carry "there is something here", and muting it would read as dimmed chrome.
+
+**Panel toggle draw PR over changes.** Two indicators = same promise ("something here, and this is way to it"), so only one can be drawn and PR win: it tab that open first, it state of *work* rather than of last turn, and it survive next prompt landing where changes mark don't. Glyph = **`text-emerald-500`, not `--accent-merge`**: that token is button *fill*, dark enough to carry white text, and at 1.5px stroke on dark background it all but disappeared. Emerald = same green open-PR glyph use inside panel, so mark and thing it point at match. Toggle's click set tab to match glyph — git icon opening subagents would be lie, same rule changes indicator already follow.
 
 **Collapsed preview = plain text, so markup come off first.** `firstLine` strip heading marks, emphasis, and link syntax keeping only its text — `(https://…)` half usually longer than words around it and not clickable in truncating span anyway. Vercel comment's opener otherwise read as raw markdown.
 
@@ -373,6 +403,52 @@ If it come back: commit = `add -A -- <paths>` then `commit -m … -- <paths>`, b
 **History drill in, not third column.** Window can't hold commit list, file list *and* split diff without diff becoming narrowest of three. Selecting commit replace list with its files under back-header; selection kept on step back, so long history don't lose reader's place.
 
 **Selected file derived, never stored.** `find(path) ?? files[0]` — file that stop being changed can't leave pane pointing at nothing, and first-by-position right here where turn panel refuse it: diff have own pane, so opening one hide nothing.
+
+## Handing work back
+
+**Composer hide row of end-of-turn action behind itself.** [HandoffRow](apps/desktop/src/components/composer/HandoffRow.tsx) sit above composer card, clipped to sliver, open on hover. Buttons = Commit, Commit & push, Push/Publish branch, Create PR, Draft PR.
+
+**Almost every button send prompt.** Click = reader typing "commit" without typing it, straight through `handleSendMsg`. So no confirm dialog and no error surface — agent write message with context it already have, and whatever go wrong report in transcript like any other tool failure. Same rule repo view already keep: conversation next door = where work get made, so second place to commit = second way to do thing reader already asking agent for. This a shortcut *into* conversation, not around it.
+
+**Prompt = one to three word**, literally `"commit"`, `"commit and push"`, `"create a PR"`, `"create a draft PR"`. Model know how to commit and whether branch have upstream better than sentence written here do — and longer prompt = spec competing with repo's own instruction, which firm about commit message. Pinned by test (≤4 words).
+
+**Push the exception, and run git direct.** Line = whether there a judgement to make. Push have exactly one correct implementation and nothing to decide, so it call `push_branch` — which already both case, `git push` with upstream and `git push -u origin <branch>` without. Spending model turn on that buy nothing and cost reader a wait. Hence no separate **Publish branch** action: one button, count dropped from label when no upstream since "Push 0" answer question nobody asked.
+
+Push own both end of its own feedback, since it report into no transcript: spinner on button while in flight, and error banner above composer — same one every other backend failure reach reader through. It refresh `work_status` on success rather than wait for next turn's edge, because count on button now wrong and it the thing reader looking at.
+
+Cost of that trade worth naming: agent not deterministic. Commit might come back with different message style, or agent might run tests first. Prompt one = **suggestion, not command**. Push is a command.
+
+**Hidden, not contextual-visible, and that the whole shape.** Turn touching file = most turns, so row drawn on "there are changes" = row drawn always — exactly what make every other tool's commit button noise. Reverse hold too: finishing turn ≠ wanting to commit. Peek cost discoverability once and buy quiet every turn after.
+
+**Which button exist = [handoff.ts](apps/desktop/src/lib/handoff.ts), pure and tested.** Dirty tree → Commit + Commit & push. Clean tree with commits ahead → Push (count in label); no upstream at all → Push without count, offered even at zero ahead since branch nobody pushed = one nobody else can see. Push **never** beside Commit: with dirty tree reader want commit first and Commit & push already carry it. Create PR + Draft PR both spelled out, not one behind other's menu — draft = different decision, not variant. Both hidden on default branch (PR against itself), where no remote resolve default branch, and where branch **already have PR** — panel where that acted on, and second button open duplicate. Empty = resting state, and row hide entirely on it.
+
+**`hasPr` come from sidebar's own per-repo read, not fourth git call.** `useOpenPrs.prFor` already answer it for every visible row.
+
+**One backend command, not three stitched.** `work_status` = `dirty` count, `branch`, `upstream`, `ahead`, `default_branch`. Superset of `sync_status` because every field answer same question — "what left to do with this work" — and reading them separately let row draw Commit from one snapshot beside Push count from another. `default_branch` arrive **stripped of remote** (`main`, not `origin/main`), so "am I on default branch" = one comparison and not parsing rule free to drift. Infallible like `sync_status`: non-repo answer default, row read that as nothing to offer.
+
+**Read on falling edge of turn, and on arriving at session. Nothing else.** Those two moment it can change from inside app. Between turns only reader in another window move tree, and polling for that = several `git` spawn a second to catch something rare. Row going one turn stale = the trade.
+
+**Composer = occluder, not a clip.** Buttons sit full height in reserve fraction as tall (`h-1` against their `h-7`), so most of each run past it and **behind card** — card opaque and paint later, coming later in form. Sliver deliberately tiny: enough to say something under there, not enough to read as row of buttons composer happen to be covering. Hover slide whole row clear (`-translate-y-7`). Clip instead leave same picture and different lie: button end where card start rather than continue behind it, so nothing suggest there more of them.
+
+**Hover zone and thing it move = separate element, and have to be.** With one element, box travel with buttons — so cursor that opened row sit on its edge moment it open, row shut under it and reopen, forever. Zone stay put (`-top-7 pt-7`, turning 4px target into 32px one); only inner row translate, and it translate *within* zone, so cursor never outside it. `w-fit` keep that invisible box off rest of transcript's bottom edge, where full-width strip would swallow click and text selection.
+
+**Row order interleave two ladder**: Commit, Create PR, Commit & push, Draft PR. Each ladder run plain-first then variant; reading across give two thing anyone do here, reading down give each one's longer form. Concatenated instead put both PR button at far end, where compound commit action sit between reader and thing they most often want next. `px-3` on reserve match card's own inner padding, so first button's edge land on same line as toolbar button inside it.
+
+**Three fact, each a bug obvious version have:**
+
+- Reserve = **fixed height**, row positioned out of flow inside it. In flow, row push composer down and transcript up every time cursor cross it on way to input — the one path cursor take most.
+- Buttons carry **opaque fill** — `secondary`, never `outline`. Outline = `bg-input/30` in dark palette, so transcript read straight through part meant to be hidden. No `default` variant either: primary fill near-white on this palette, and near-white button poking out of composer = loudest thing on screen. Order carry priority instead.
+- They take **no pointer events until row open**. Visible quarter sit directly above composer, so without this a click aimed at input and landing few px high send a commit.
+
+**Composer card take own token, `--composer`, and that vibrancy fix not colour change.** Start as copy of `--card`, and whole of its job = be the one raised surface staying a **fill** on glass, since handoff row park behind it and veil there show buttons it exist to hide. Own token not borrowed `--popover`: composer not a popover, and next change to floating surface should not have to wonder whether composer wanted it too. Exception live in vibrancy block beside rule it break — that where `--card` get its 5.5% and `--composer` deliberately don't.
+
+Inline variant — same button along toolbar row, ghost and dimmed — built as mockup and **rejected**. Permanent-but-quiet still permanent: it spend width every turn on thing wanted at end of one, which the failure mode being avoided, only softer. Peek keep it.
+
+Icons for `pr`/`draftPr` = same pair sidebar row and panel toggle draw, so mark and thing it lead to match everywhere.
+
+Hover delay symmetric (150ms): keep cursor merely passing through from popping row open, and let one overshooting on way out come back without it having closed.
+
+**Row live in `ChatInput` as `handoff` node**, like `toolbar` — so component keep owning layout and spacing, including that row's cut edge land on card's own top edge. Absent on new task: no session to send into.
 
 ## Deleting a worktree
 
@@ -687,13 +763,15 @@ Several things deliberately unfinished — don't mistake for bugs:
 
 - **Worktree cleanup hang off session lifecycle, not off merge.** `--delete-branch` still deliberately not passed (see above) — merge button say nothing about tree. Cleanup live on settle and on delete instead, see _Deleting a worktree_ below. Merged session whose reader never settle it therefore still leave tree behind; that reader's call, not merge's.
 
+- **Handoff row have no Revert, no Amend, no Stash.** Each destroy or rewrite work, and button that send prompt for one = button whose blast radius decided by model. Reader can still type it.
+
 - **Repo view read, commit and push — no fetch, no pull, no discard.** Ahead count against *last known* upstream, so branch someone else pushed to read as level until push itself fail. Discard-changes and stage-hunk deliberately absent: both destroy work, and neither belong in first pass of surface agent also writing to.
 
 - **No count on Changes view tab.** Working-tree file count would force snapshot on every event even while reader sit on Chat — exactly what `active` gate exist to prevent. Sub-tab carry count, since by then reads already running.
 
 - **Blocked commit name no session either.** Same shape as blocked install: button dim while turn run and say nothing about when it free. Turn end unblock it, but nothing tell reader that.
 
-- **No PR indicator in sidebar.** Row show nothing about whether session's branch have open PR — deliberately parked, since answering it for every visible row need per-repo cache and refresh rule panel's own 30s freshness window don't cover.
+- **Sidebar's PR mark say open or draft, and nothing else.** No number, no check state, no merge readiness — row already carry title, unread rail and timestamp, and mark exist to say "this branch have somewhere to land". Number ride `title` attribute alone.
 
 - **Beta channel have no picker.** `ade.updateChannel` in local storage = whole switch, and nothing write it. Backend take channel per check, so picker = control and `setChannel`, not protocol change.
 

--- a/apps/desktop/src-tauri/src/git.rs
+++ b/apps/desktop/src-tauri/src/git.rs
@@ -998,11 +998,14 @@ pub async fn work_status(cwd: &str) -> WorkStatus {
         .await
         .map_or(0, |s| count_changes(&s));
 
-    // `default_base` answers `origin/main`; the row compares against a branch
-    // name, so the remote is dropped once, here.
+    // `default_base` answers `origin/<branch>` — the remote is hardcoded there —
+    // so the prefix comes off rather than everything up to the last slash. A
+    // branch name may hold slashes of its own, and `release/current` cut down to
+    // `current` matches nothing, which reads to the handoff row as "you are on a
+    // feature branch" and offers a pull request against the branch itself.
     let default_branch = default_base(cwd)
         .await
-        .map(|base| base.rsplit_once('/').map_or(base.clone(), |(_, b)| b.to_string()));
+        .map(|base| base.strip_prefix("origin/").unwrap_or(&base).to_string());
 
     WorkStatus {
         dirty,
@@ -2483,8 +2486,47 @@ mod tests {
 
         let status = work_status(at).await;
         let default = status.default_branch.expect("a pushed branch resolves one");
-        assert!(!default.contains('/'), "still carries its remote: {default}");
+        assert!(!default.starts_with("origin/"), "still carries its remote: {default}");
         assert_eq!(Some(default), status.branch);
+
+        fs::remove_dir_all(&dir).await.ok();
+        fs::remove_dir_all(&remote).await.ok();
+    }
+
+    /// Only the remote comes off. A default branch holding slashes of its own —
+    /// `release/current` — cut down to its last segment matches no branch, which
+    /// reads as "you are on a feature branch" and offers a pull request against
+    /// the branch the work is already on.
+    #[tokio::test]
+    async fn work_status_keeps_slashes_inside_the_default_branch_name() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+        let remote = std::env::temp_dir().join(format!("dray-remote-{}", Uuid::now_v7()));
+
+        fs::create_dir_all(&remote).await.unwrap();
+        run(remote.to_str().unwrap(), &["init", "-q", "--bare", "."])
+            .await
+            .unwrap();
+        run(at, &["remote", "add", "origin", remote.to_str().unwrap()])
+            .await
+            .unwrap();
+
+        run(at, &["checkout", "-q", "-b", "release/current"]).await.unwrap();
+        push_branch(at).await.unwrap();
+        // `-b` on the ref git would have written for us, so `origin/HEAD`
+        // resolves the way a cloned repo's does.
+        run(
+            at,
+            &["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/release/current"],
+        )
+        .await
+        .unwrap();
+
+        let status = work_status(at).await;
+        assert_eq!(status.default_branch.as_deref(), Some("release/current"));
+        // And so the handoff row sees it as the branch it is on, not a feature
+        // branch to open a pull request from.
+        assert_eq!(status.default_branch, status.branch);
 
         fs::remove_dir_all(&dir).await.ok();
         fs::remove_dir_all(&remote).await.ok();

--- a/apps/desktop/src-tauri/src/git.rs
+++ b/apps/desktop/src-tauri/src/git.rs
@@ -961,6 +961,58 @@ pub struct SyncStatus {
     pub ahead: u32,
 }
 
+/// What the composer's action row needs to decide which buttons it has, in one
+/// read.
+///
+/// A superset of [`SyncStatus`] rather than three calls stitched together in
+/// the frontend: every field here answers the same question — "what is there
+/// left to do with this work" — and reading them separately would let the row
+/// draw a Commit button from one snapshot beside a Push count from another.
+#[derive(Debug, Clone, Default, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct WorkStatus {
+    /// Uncommitted paths. A count and not a list — the row only asks whether
+    /// there is anything, and the changes view is where the files are read.
+    pub dirty: u32,
+    /// `None` on a detached HEAD and outside a repo, which is how the row hides
+    /// itself entirely.
+    pub branch: Option<String>,
+    /// `None` for a branch never pushed — the "publish" case.
+    pub upstream: Option<String>,
+    pub ahead: u32,
+    /// The branch this work would land on, short of its remote (`main`, not
+    /// `origin/main`). Stripped here rather than in the row, so "am I on the
+    /// default branch" is one comparison and not a parsing rule that can drift.
+    /// `None` where there is no remote to ask.
+    pub default_branch: Option<String>,
+}
+
+/// Infallible like [`sync_status`], and for the same reason: a directory that
+/// isn't a repo answers with the default, and the row reads that as nothing to
+/// offer rather than as an error.
+pub async fn work_status(cwd: &str) -> WorkStatus {
+    let sync = sync_status(cwd).await;
+
+    let dirty = git(cwd, &["status", "--porcelain"])
+        .await
+        .map_or(0, |s| count_changes(&s));
+
+    // `default_base` answers `origin/main`; the row compares against a branch
+    // name, so the remote is dropped once, here.
+    let default_branch = default_base(cwd)
+        .await
+        .map(|base| base.rsplit_once('/').map_or(base.clone(), |(_, b)| b.to_string()));
+
+    WorkStatus {
+        dirty,
+        branch: sync.branch,
+        upstream: sync.upstream,
+        ahead: sync.ahead,
+        default_branch,
+    }
+}
+
 /// Infallible by design, like [`list_branches`]: a directory that isn't a repo
 /// answers with the default rather than an error the reader can't act on.
 ///
@@ -2390,5 +2442,65 @@ mod tests {
 
         fs::remove_dir_all(&dir).await.ok();
         fs::remove_dir_all(&remote).await.ok();
+    }
+
+    /// The composer's action row draws itself off these four facts, and a dirty
+    /// count that ignores untracked files would hide the Commit button for the
+    /// commonest case of all — an agent that just wrote a new file.
+    #[tokio::test]
+    async fn work_status_answers_what_is_left_to_do() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        let clean = work_status(at).await;
+        assert_eq!(clean.dirty, 0);
+        assert!(clean.branch.is_some());
+        assert_eq!(clean.upstream, None);
+
+        fs::write(dir.join("new.txt"), "fresh\n").await.unwrap();
+        assert_eq!(work_status(at).await.dirty, 1);
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    /// The default branch is compared against `branch`, so it has to arrive
+    /// without its remote — `origin/main` would never equal `main` and the row
+    /// would offer to open a pull request against the branch it is already on.
+    #[tokio::test]
+    async fn work_status_names_the_default_branch_without_its_remote() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+        let remote = std::env::temp_dir().join(format!("dray-remote-{}", Uuid::now_v7()));
+
+        fs::create_dir_all(&remote).await.unwrap();
+        run(remote.to_str().unwrap(), &["init", "-q", "--bare", "."])
+            .await
+            .unwrap();
+        run(at, &["remote", "add", "origin", remote.to_str().unwrap()])
+            .await
+            .unwrap();
+        push_branch(at).await.unwrap();
+
+        let status = work_status(at).await;
+        let default = status.default_branch.expect("a pushed branch resolves one");
+        assert!(!default.contains('/'), "still carries its remote: {default}");
+        assert_eq!(Some(default), status.branch);
+
+        fs::remove_dir_all(&dir).await.ok();
+        fs::remove_dir_all(&remote).await.ok();
+    }
+
+    /// Outside a repo every field has to answer "nothing to do" rather than
+    /// error — the row hides on `branch` being `None`.
+    #[tokio::test]
+    async fn work_status_outside_a_repo_offers_nothing() {
+        let dir = std::env::temp_dir().join(format!("dray-plain-{}", Uuid::now_v7()));
+        fs::create_dir_all(&dir).await.unwrap();
+
+        let status = work_status(dir.to_str().unwrap()).await;
+        assert_eq!(status.branch, None);
+        assert_eq!(status.dirty, 0);
+
+        fs::remove_dir_all(&dir).await.ok();
     }
 }

--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -171,6 +171,25 @@ query($owner:String!,$repo:String!,$branch:String!){
  }}
 "#;
 
+/// Every open pull request in the repo, by head branch.
+///
+/// One query for the whole sidebar rather than one per row: `gh` costs the
+/// better part of a second, so asking per session would be a spawn per visible
+/// row on every refresh. Open only — the mark says "this branch has somewhere
+/// to land", and a merged PR is a record the row has nothing to do with.
+///
+/// `first:100` is the cap, and it is a real one: a repo with more than a
+/// hundred open pull requests marks the hundred most recently touched, which is
+/// the set any session in this app is plausibly working on.
+const QUERY_OPEN: &str = r#"
+query($owner:String!,$repo:String!){
+ repository(owner:$owner,name:$repo){
+  pullRequests(states:OPEN,first:100,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{
+   number headRefName isDraft
+  }}
+ }}
+"#;
+
 /// A GraphQL connection. `nodes` is nullable on every one of them, so the
 /// `Option` is load-bearing rather than defensive.
 #[derive(Deserialize)]
@@ -185,13 +204,30 @@ impl<T> Nodes<T> {
     }
 }
 
+/// Generic over the node shape, because both queries here answer with the same
+/// three envelopes around a `pullRequests` connection and only the fields
+/// inside it differ.
 #[derive(Deserialize)]
-struct Response {
-    data: Option<ResponseData>,
+struct Response<T> {
+    data: Option<ResponseData<T>>,
     /// GraphQL reports a failed query with a 200 and an `errors` array, so a
     /// zero exit code proves nothing on its own.
     #[serde(default)]
     errors: Vec<GraphQlError>,
+}
+
+impl<T> Response<T> {
+    /// The connection's nodes, or the first error GitHub reported.
+    fn prs(self) -> Result<Vec<T>, String> {
+        if let Some(first) = self.errors.first() {
+            return Err(first.message.clone());
+        }
+        Ok(self
+            .data
+            .and_then(|d| d.repository)
+            .map(|r| Nodes::take(r.pull_requests))
+            .unwrap_or_default())
+    }
 }
 
 #[derive(Deserialize)]
@@ -201,14 +237,14 @@ struct GraphQlError {
 }
 
 #[derive(Deserialize)]
-struct ResponseData {
-    repository: Option<Repository>,
+struct ResponseData<T> {
+    repository: Option<Repository<T>>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct Repository {
-    pull_requests: Option<Nodes<RawPr>>,
+struct Repository<T> {
+    pull_requests: Option<Nodes<T>>,
 }
 
 #[derive(Deserialize)]
@@ -795,23 +831,10 @@ async fn prs_for_branch_inner(cwd: &str, branch: &str) -> Result<Vec<PullRequest
 
 /// Splits parsing off the spawn so the fixture can exercise it.
 fn read_prs(out: &str) -> Result<Vec<PullRequest>, String> {
-    let response: Response =
+    let response: Response<RawPr> =
         serde_json::from_str(out).map_err(|e| format!("could not read GitHub's answer: {e}"))?;
 
-    // A failed GraphQL query still exits zero and answers 200, so the error
-    // array is the only place the failure is reported.
-    if let Some(first) = response.errors.first() {
-        return Err(first.message.clone());
-    }
-
-    let mut prs: Vec<PullRequest> = response
-        .data
-        .and_then(|d| d.repository)
-        .map(|r| Nodes::take(r.pull_requests))
-        .unwrap_or_default()
-        .into_iter()
-        .map(RawPr::map)
-        .collect();
+    let mut prs: Vec<PullRequest> = response.prs()?.into_iter().map(RawPr::map).collect();
 
     // An open PR is the one being worked on whatever its age, so it outranks a
     // newer merged one — otherwise reopening an old branch shows the reader the
@@ -822,6 +845,81 @@ fn read_prs(out: &str) -> Result<Vec<PullRequest>, String> {
     });
 
     Ok(prs)
+}
+
+/// One open pull request, cut down to what a sidebar row can draw.
+///
+/// Deliberately not a `PullRequest`: the row says "this branch has an open PR,
+/// and whether it is a draft" and nothing else, so carrying checks, comments
+/// and review threads for every session in the list would be payload nobody
+/// reads.
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct OpenPr {
+    pub number: u64,
+    /// The branch it was opened from — what the caller matches a session by.
+    pub head_ref_name: String,
+    pub is_draft: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawOpenPr {
+    number: u64,
+    #[serde(default)]
+    head_ref_name: String,
+    #[serde(default)]
+    is_draft: bool,
+}
+
+/// Every open pull request in the repo `cwd` sits in.
+///
+/// One call for a whole sidebar's worth of rows — see [`QUERY_OPEN`]. The
+/// caller matches a session to its entry by branch, so this answers a list
+/// rather than a map: which branch a session lands on is the frontend's own
+/// rule (a worktree session's is rebuilt from its worktree name), and building
+/// the map here would be a second copy of it.
+#[tauri::command]
+pub async fn open_prs(cwd: String) -> Result<Vec<OpenPr>, PrUnavailable> {
+    open_prs_inner(&cwd).await.map_err(unavailable)
+}
+
+async fn open_prs_inner(cwd: &str) -> Result<Vec<OpenPr>, String> {
+    let (owner, repo) = repo_slug(cwd).await?;
+
+    let out = gh(
+        cwd,
+        &[
+            "api",
+            "graphql",
+            "-f",
+            &format!("owner={owner}"),
+            "-f",
+            &format!("repo={repo}"),
+            "-f",
+            &format!("query={QUERY_OPEN}"),
+        ],
+    )
+    .await?;
+
+    read_open_prs(&out)
+}
+
+/// Splits parsing off the spawn, like [`read_prs`].
+fn read_open_prs(out: &str) -> Result<Vec<OpenPr>, String> {
+    let response: Response<RawOpenPr> =
+        serde_json::from_str(out).map_err(|e| format!("could not read GitHub's answer: {e}"))?;
+
+    Ok(response
+        .prs()?
+        .into_iter()
+        .map(|pr| OpenPr {
+            number: pr.number,
+            head_ref_name: pr.head_ref_name,
+            is_draft: pr.is_draft,
+        })
+        .collect())
 }
 
 /// Merges the PR. Returns once `gh` has, so the caller can refetch and show
@@ -1143,6 +1241,36 @@ mod tests {
     fn diff_counts_come_through() {
         let pr = parse();
         assert_eq!((pr.additions, pr.deletions, pr.changed_files), (2155, 66, 22));
+    }
+
+    /// The sidebar's query carries the branch and the draft flag, and a draft
+    /// is an open PR — reading it as anything else leaves the row unmarked for
+    /// exactly the PR that has just been opened.
+    #[test]
+    fn open_prs_carry_their_branch_and_draft_flag() {
+        let out = r#"{"data":{"repository":{"pullRequests":{"nodes":[
+            {"number":9,"headRefName":"worktree-calm-navy-beacon","isDraft":true},
+            {"number":8,"headRefName":"fix/thing","isDraft":false}]}}}}"#;
+        let prs = read_open_prs(out).expect("open prs parse");
+        assert_eq!(prs.len(), 2);
+        assert_eq!(prs[0].head_ref_name, "worktree-calm-navy-beacon");
+        assert!(prs[0].is_draft);
+        assert!(!prs[1].is_draft);
+    }
+
+    /// Same 200-with-errors trap the branch query has: a zero exit code proves
+    /// nothing, and reading it as success marks every row as PR-less.
+    #[test]
+    fn an_open_pr_query_error_is_an_error() {
+        let out = r#"{"data":null,"errors":[{"message":"Could not resolve to a Repository"}]}"#;
+        assert!(read_open_prs(out).is_err());
+    }
+
+    /// A repo with no open PRs answers a null connection, not an empty one.
+    #[test]
+    fn no_open_prs_reads_as_empty() {
+        let out = r#"{"data":{"repository":{"pullRequests":{"nodes":null}}}}"#;
+        assert!(read_open_prs(out).expect("null connection parses").is_empty());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -246,6 +246,11 @@ async fn sync_status(cwd: String) -> git::SyncStatus {
     git::sync_status(&cwd).await
 }
 
+#[tauri::command]
+async fn work_status(cwd: String) -> git::WorkStatus {
+    git::work_status(&cwd).await
+}
+
 /// Commits the checked files alone. `paths` are this session's own change list,
 /// so a path the reader unchecked is one this never sees.
 #[tauri::command]
@@ -478,6 +483,7 @@ pub fn run() {
             head_tree,
             log_commits,
             sync_status,
+            work_status,
             commit_files,
             push_branch,
             set_session_flags,
@@ -494,6 +500,7 @@ pub fn run() {
             updater::check_update,
             updater::install_update,
             github::prs_for_branch,
+            github::open_prs,
             github::merge_pr,
             github::reopen_pr,
             github::mark_pr_ready,

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -24,6 +24,13 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
+  /* The composer card's own fill. Starts life as a copy of `--card` and exists
+     to be the one raised surface that stays a *fill* on glass: the handoff row
+     is parked behind it, so a veil there shows the buttons it is meant to hide.
+     Its own token rather than borrowing `--popover`, because the composer is
+     not a popover and the next change to floating surfaces should not have to
+     wonder whether the composer wanted it too. See the vibrancy block below. */
+  --composer: oklch(0.205 0 0);
   --primary: oklch(0.922 0 0);
   --primary-foreground: oklch(0.205 0 0);
   --secondary: oklch(0.269 0 0);
@@ -172,6 +179,7 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-composer: var(--composer);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
   --radius-sm: calc(var(--radius) * 0.6);
@@ -270,6 +278,11 @@
        these nested now stack, so a tile inside the composer card reads a step
        lighter than the card instead of vanishing into it. */
     --card: oklch(1 0 0 / 5.5%);
+    /* `--composer` is deliberately *not* given the same treatment, and this is
+       the one place that rule lives. It is the only raised surface with
+       something parked behind it — the handoff row — so a veil there would show
+       the buttons it exists to hide. It costs the composer its glass and buys
+       the one thing on that edge that has to be opaque. */
     /* Same treatment for the one highlight that lands on the glass rather than
        inside a menu: the sidebar has no fill here, so a selected session row —
        and the panel's active tab, which shares the token — is drawn straight

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { invoke } from "@tauri-apps/api/core";
 
@@ -13,8 +13,17 @@ import QuitDialog from "@/components/QuitDialog";
 import WorktreeDialog, { type WorktreePrompt } from "@/components/WorktreeDialog";
 import PrPanel from "@/components/PrPanel";
 import { useChanges } from "@/hooks/useChanges";
+import { useOpenPrs } from "@/hooks/useOpenPrs";
+import { useWorkStatus } from "@/hooks/useWorkStatus";
+import HandoffRow from "@/components/composer/HandoffRow";
+import { handoffActions } from "@/lib/handoff";
 import { prTabVisible, usePullRequest } from "@/hooks/usePullRequest";
-import RightPanel, { PanelToggle, TabBody, type PanelTab } from "@/components/RightPanel";
+import RightPanel, {
+  PanelToggle,
+  TabBody,
+  tabOrder,
+  type PanelTab,
+} from "@/components/RightPanel";
 import Sidebar, { DevBadge, SidebarToggle, sortSessions } from "@/components/Sidebar";
 import SubagentPanel from "@/components/SubagentPanel";
 import ComposerToolbar from "@/components/composer/ComposerToolbar";
@@ -113,7 +122,11 @@ function App() {
   const anyRunning = Object.values(statusBySession).some((s) => s === "in_progress");
 
   const [panelOpen, setPanelOpen] = useState(false);
-  const [panelTab, setPanelTab] = useLocalStorage<PanelTab>("ade.panelTab", "changes");
+  // `null` is "never picked", and it is the whole of the default-tab rule.
+  // Storing `"changes"` as the initial value made a fresh install
+  // indistinguishable from a reader who had chosen Changes, so an open PR could
+  // never lead — see `activeTab`.
+  const [panelTab, setPanelTab] = useLocalStorage<PanelTab | null>("ade.panelTab", null);
   const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
 
   // Per session, and deliberately not persisted the way `panelTab` is: which
@@ -198,24 +211,57 @@ function App() {
   // there is an open PR before that tab has ever been shown, so ordering it
   // first can't wait on the panel fetching for itself.
   const prBranch = selectedSession ? sessionBranch(selectedSession) : null;
-  // `panelTab` and not `activeTab`, which cannot exist yet — it is derived from
-  // this hook's own answer. Harmless: the only case the two disagree is a tab
-  // that isn't drawn, which means no PRs, which means nothing to poll for.
+  // "The PR tab is on screen", read off the *pick* rather than off `activeTab`,
+  // which cannot exist yet — it is derived from this hook's own answer. An
+  // unset pick counts, since the derived default is the PR tab whenever there
+  // is an open one. The one case the two disagree is a session whose only PRs
+  // are merged: the pick is unset, the default resolves to Changes, and this
+  // reads true — harmless, because a merged PR never settles and the poll is
+  // gated on that too.
   const pullRequests = usePullRequest(
     selectedSession?.cwd ?? "",
     prBranch,
-    panelOpen && panelTab === "pr",
+    panelOpen && (panelTab === "pr" || panelTab === null),
+    // A pull request appearing is the moment the session stops being about the
+    // turn and starts being about landing, so the pane opens onto it rather
+    // than waiting to be asked. Fires at most once per PR — see `onOpened` —
+    // and a reader who has picked a tab keeps it, same rule `activeTab` reads
+    // by, so this can never take a pane back off whatever they chose.
+    // A fresh closure each render is fine: the hook holds it in a ref.
+    () => setPanelOpen(true),
   );
-  const hasOpenPr = pullRequests.prs.some((pr) => pr.state === "OPEN");
+  // A draft counts: GitHub reports one as `OPEN` with `isDraft` set, and a
+  // draft is still the point at which the work stops being about this turn.
+  const openPrsHere = pullRequests.prs.filter((pr) => pr.state === "OPEN");
+  const hasOpenPr = openPrsHere.length > 0;
+  // Only where *every* open one is a draft. A session carrying a draft beside a
+  // real PR has something asking to land, and the mark should say so.
+  const allDrafts = hasOpenPr && openPrsHere.every((pr) => pr.isDraft);
   const hasPrTab = prTabVisible(pullRequests.prs, pullRequests.error);
 
-  // The stored tab outlives the session it was chosen in, so it can name one
-  // this session doesn't have. Resolved on read rather than written back:
-  // switching to a session without a PR must not forget that the PR tab is
-  // where the reader was, for when they switch to one that has it.
-  const activeTab: PanelTab = panelTab === "pr" && !hasPrTab ? "changes" : panelTab;
+  // Where the pane lands with nothing picked. An open pull request wins over
+  // anything the last turn did: changes describe one turn and are superseded by
+  // the next, where a PR is the state of the work.
+  const defaultTab: PanelTab = hasOpenPr && hasPrTab ? "pr" : "changes";
+
+  const tabs = tabOrder({ pr: hasPrTab, prFirst: hasOpenPr });
+
+  // One rule, read rather than written back: an explicit pick wins wherever it
+  // still names a tab this session draws, and otherwise the derived default
+  // stands in. Not written back, so switching to a session without a PR keeps
+  // the reader's pick for when they switch to one that has it.
+  const activeTab: PanelTab = panelTab && tabs.includes(panelTab) ? panelTab : defaultTab;
 
   const togglePanel = () => setPanelOpen((prev) => !prev);
+
+  // Moves along the visible row, wrapping. Off `tabs` rather than `PANEL_TABS`,
+  // so a session with no PR tab cycles through two and never lands on one that
+  // isn't drawn.
+  const stepTab = (delta: number) => {
+    if (!panelOpen) return;
+    const from = tabs.indexOf(activeTab);
+    setPanelTab(tabs[(from + delta + tabs.length) % tabs.length]);
+  };
 
   // Opens the tab without touching the selection, so a run the reader already
   // had expanded is still expanded when they come back to it.
@@ -242,24 +288,94 @@ function App() {
     [selectedSession?.events],
   );
 
+  // Filtered here rather than inside the sidebar, so the list and the ⌘⇧↑/↓ walk
+  // read one array. `projectPath` on the item is the repo root, so a worktree
+  // session stays under the project it forked from.
+  const visibleSessions = useMemo(
+    () =>
+      projectFilter
+        ? sessionIndexItems.filter((i) => i.projectPath === projectFilter)
+        : sessionIndexItems,
+    [sessionIndexItems, projectFilter],
+  );
+
+  // The sidebar's marks: one `gh` per repo on screen rather than one per row —
+  // see `useOpenPrs`. Distinct paths, and the *active* list's only: a settled
+  // session is work the reader has already dealt with, so a repo that appears
+  // nowhere but the archived list is one nobody is waiting to land. Marks
+  // already fetched still draw over there, since the cache outlives this — what
+  // is dropped is the spending, not the answer.
+  const repoPaths = useMemo(
+    () => (showArchived ? [] : [...new Set(visibleSessions.map((i) => i.projectPath))]),
+    [showArchived, visibleSessions],
+  );
+  const openPrs = useOpenPrs(repoPaths);
+
+  // A pull request appears because something happened, and the thing that
+  // happens is a turn — the agent running `gh pr create`, or the reader opening
+  // one in a browser while a turn was in flight. Nothing else re-reads: the
+  // panel's poll is gated on the PR tab being visible *and* active, and that tab
+  // is hidden exactly while the answer is "no PR", so the one state that needed
+  // rechecking was the only one that could never self-heal.
+  //
+  // The falling edge, not `!busy`, or an idle session re-asks on every unrelated
+  // render — and the session id rides along because `busy` is the *selected*
+  // session's: switching from a running session to an idle one drops it without
+  // any turn having ended.
+  const lastTurn = useRef({ sessionId: selectedSessionId, busy });
+  useEffect(() => {
+    const prev = lastTurn.current;
+    lastTurn.current = { sessionId: selectedSessionId, busy };
+    if (prev.sessionId !== selectedSessionId || !prev.busy || busy) return;
+    pullRequests.refresh();
+    openPrs.refresh();
+  }, [selectedSessionId, busy, pullRequests.refresh, openPrs.refresh]);
+
+  // What the composer's handoff row draws itself from. Read on the same falling
+  // edge as the pull requests above, since a turn is what moves all of it.
+  const { status: workStatus, refresh: refreshWorkStatus } = useWorkStatus(
+    selectedSession?.cwd ?? "",
+    busy,
+  );
+  // From the sidebar's own per-repo read, not a fourth git call: once a pull
+  // request exists the panel is where it is acted on, and a Create PR button
+  // beside it would open a duplicate.
+  const sessionHasPr =
+    !!selectedSession && !!openPrs.prFor(selectedSession.projectPath, prBranch);
+
+  // The one handoff action that runs rather than asks. It reports into no
+  // transcript, so both ends are its own: the flag the button spins on, and the
+  // error banner above the composer — the same one every other backend failure
+  // reaches the reader through.
+  const [pushing, setPushing] = useState(false);
+  const push = async () => {
+    if (pushing || !selectedSession) return;
+    setPushing(true);
+    try {
+      await invoke("push_branch", { cwd: selectedSession.cwd });
+      // Straight away rather than on the next turn's edge: the count on the
+      // button is now wrong, and it is the thing the reader is looking at.
+      refreshWorkStatus();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setPushing(false);
+    }
+  };
+
   // Read off the two tree ids rather than off the panel's file list: the panel
   // pauses its reads while hidden, which is exactly when the indicator has to
   // be right.
   const lastTurnChanged = turnChangedTree({ baseline, head });
 
-  // The toggle's own click lands on what its glyph promised — a git icon that
-  // opened the subagents tab would be a lie. ⌘E stays a plain toggle: it shows
-  // nothing, so it promises nothing.
+  // The click lands on whatever the glyph was drawing — a git icon that opened
+  // the subagents tab would be a lie. That is all this does now: which tab the
+  // pane *defaults* to is `activeTab`'s rule and needs no help here, and ⌘E
+  // stays a plain toggle because it draws nothing and so promises nothing.
   const handleTogglePanel = () => {
     if (!panelOpen) {
-      // Same precedence the glyph draws with, so the tab that opens is the one
-      // the button was showing.
       if (hasOpenPr && hasPrTab) setPanelTab("pr");
-      // Remembered tabs are restored, with one exception: a PR tab holding
-      // nothing but merged or closed work is a record, and opening the pane
-      // onto a record is not what the reader reached for. Only on open — the
-      // tab stays clickable, so it can still be read on purpose.
-      else if (lastTurnChanged || panelTab === "pr") setPanelTab("changes");
+      else if (lastTurnChanged) setPanelTab("changes");
     }
     togglePanel();
   };
@@ -289,17 +405,6 @@ function App() {
       : activeTab === "pr"
         ? { onRefresh: pullRequests.refresh, loading: pullRequests.loading }
         : null;
-
-  // Filtered here rather than inside the sidebar, so the list and the ⌘⇧↑/↓ walk
-  // read one array. `projectPath` on the item is the repo root, so a worktree
-  // session stays under the project it forked from.
-  const visibleSessions = useMemo(
-    () =>
-      projectFilter
-        ? sessionIndexItems.filter((i) => i.projectPath === projectFilter)
-        : sessionIndexItems,
-    [sessionIndexItems, projectFilter],
-  );
 
   // Same order the sidebar draws, so the walk matches the list even when the
   // sidebar is collapsed and there is nothing on screen to follow.
@@ -334,6 +439,12 @@ function App() {
   useHotkey("ArrowDown", () => stepSession(1), { shift: true });
   // ⌘E for the right pane against ⌘B for the left.
   useHotkey("e", togglePanel);
+  // ⌘⇧[ / ⌘⇧] — the browser and editor chord for stepping through tabs, so it
+  // arrives already known. The shift layout reaches `key`, so the character is
+  // `{` rather than `[`; the physical key rides along for the engines that
+  // report the unshifted one — see `code`.
+  useHotkey("{", () => stepTab(-1), { shift: true, code: "BracketLeft" });
+  useHotkey("}", () => stepTab(1), { shift: true, code: "BracketRight" });
   // By position in the tab row, so a third view needs only a third line here.
   // No-ops without a session, where there is no row to switch.
   useHotkey("1", () => setViewTab("chat"));
@@ -373,6 +484,7 @@ function App() {
           onProjectFilterChange={setProjectFilter}
           statusBySession={statusBySession}
           askingSessions={askingSessions}
+          prFor={openPrs.prFor}
           selectedSessionId={selectedSessionId}
           collapsed={collapsed}
           onToggleCollapsed={toggleSidebar}
@@ -449,6 +561,7 @@ function App() {
               open={panelOpen}
               changes={lastTurnChanged}
               pr={hasOpenPr && hasPrTab}
+              draft={allDrafts}
             />
           )}
         </header>
@@ -520,6 +633,17 @@ function App() {
                     "dialog",
                   )
               : undefined
+          }
+          handoff={
+            <HandoffRow
+              actions={handoffActions(workStatus, sessionHasPr)}
+              // Straight out as a prompt, exactly as if it had been typed. A
+              // turn already running queues it, like any other send.
+              onSend={(prompt) => void handleSendMsg(prompt)}
+              onPush={() => void push()}
+              pushing={pushing}
+              disabled={!selectedSessionId}
+            />
           }
           toolbar={
             <ComposerToolbar

--- a/apps/desktop/src/components/ChatInput.tsx
+++ b/apps/desktop/src/components/ChatInput.tsx
@@ -56,6 +56,12 @@ type ChatInputProps = {
   /// node rather than the controls' own props, so this component keeps owning
   /// layout and measurement and nothing else.
   toolbar?: ReactNode;
+  /// The "hand it back" actions, parked behind the card with a quarter of each
+  /// button standing above it. A node for the toolbar's reason, and placed here
+  /// rather than by the shell so it sits inside the same `max-w-3xl` column and
+  /// against the card's own top edge — the card is what hides it, so nothing can
+  /// come between them. Absent on a new task: there is no session to send into.
+  handoff?: ReactNode;
   busy?: boolean;
   /// Which session's draft is in the box, and what the composer refocuses on
   /// when the user switches. `null` is the new task's own draft, not the
@@ -135,6 +141,7 @@ export default function ChatInput({
   onCancelQueued,
   queuedCount = 0,
   toolbar,
+  handoff,
   busy = false,
   sessionId = null,
   isNewTask = false,
@@ -533,17 +540,31 @@ export default function ChatInput({
             same edge as the text below it. */}
         {isNewTask && <div className="-ml-2.5 pb-1.5">{toolbar}</div>}
 
+        {/* Directly above the card and with no gap: the row runs on past its own
+            reserve and behind the card, which is the opaque thing that hides it.
+            Anything between the two would show the buttons through the gap and
+            leave them floating rather than tucked. */}
+        {!isNewTask && handoff}
+
         {/* The ring lives on the card so the whole composer reads as one control.
             --input bakes in its own alpha, which makes Tailwind's /40-style opacity
             modifiers silently no-op, so both states set an explicit color.
             `relative` anchors the command picker, which opens upward out of the
-            card rather than displacing anything as it filters. */}
+            card rather than displacing anything as it filters.
+
+            `bg-composer`, not `bg-card`, and that is a vibrancy fix rather than
+            a colour change: the two tokens carry the same value, and only
+            `--card` becomes a 5.5% veil on glass. A veil is right for a surface
+            sitting *in* the page and wrong for one that has to hide something —
+            and this card has the handoff row parked behind it, which showed
+            straight through. Its own token rather than a borrowed one, so the
+            reason lives in the palette beside the rule it is an exception to. */}
         <div
           ref={cardRef}
           className={cn(
             "relative rounded-2xl transition-colors",
             !isNewTask &&
-              "border border-[oklch(1_0_0/6%)] bg-card focus-within:border-[oklch(1_0_0/8%)]",
+              "border border-[oklch(1_0_0/6%)] bg-composer focus-within:border-[oklch(1_0_0/8%)]",
           )}
         >
           {/* Two separate consequences of the empty state, passed separately

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -1,4 +1,4 @@
-import { GitCompare, GitPullRequest, RefreshCw } from "lucide-react";
+import { GitCompare, GitPullRequest, GitPullRequestDraft, RefreshCw } from "lucide-react";
 
 import PanelRightIcon from "@/components/icons/PanelRightIcon";
 import { Button } from "@/components/ui/button";
@@ -16,6 +16,7 @@ export function PanelToggle({
   open,
   changes = false,
   pr = false,
+  draft = false,
 }: {
   onToggle: () => void;
   open: boolean;
@@ -25,14 +26,20 @@ export function PanelToggle({
   /// otherwise going to sit beside it. Nothing to say once the pane is open:
   /// the changes are on screen, and the toggle goes back to being a toggle.
   changes?: boolean;
-  /// This session has an open pull request, which outranks `changes`.
+  /// Every one of this session's open pull requests is a draft. Draws the draft
+  /// glyph rather than the plain one — the mark still appears, because a draft
+  /// is still somewhere for the work to land, and it keeps the emerald so it
+  /// still reads as content rather than as dimmed chrome. Shape carries the
+  /// distinction, colour carries the "there is something here".
+  draft?: boolean;
+  /// This session has an open pull request, which outranks `changes`. A draft
+  /// counts — GitHub reports one as `OPEN` with `isDraft` set.
   ///
   /// The two indicators are the same promise — "there is something here, and
   /// this is the way to it" — so only one can be drawn, and the PR is the one
   /// worth drawing: it is the tab that opens first, it is the state of the
   /// work rather than of the last turn, and it is the one that survives the
-  /// next prompt landing. Green, matching the merge button it leads to; the
-  /// changes yellow stays what it means when there is no PR.
+  /// next prompt landing. Green, matching the merge button it leads to.
   pr?: boolean;
 }) {
   const indicating = (pr || changes) && !open;
@@ -68,9 +75,21 @@ export function PanelToggle({
               // text — and at 1.5px stroke on a dark background it all but
               // disappeared. This is the emerald the open-PR glyph uses in the
               // panel itself, so the mark and the thing it points at match.
-              <GitPullRequest className="size-4 text-emerald-500" strokeWidth={1.5} />
+              draft ? (
+                <GitPullRequestDraft
+                  className="size-4 text-emerald-500"
+                  strokeWidth={1.5}
+                />
+              ) : (
+                <GitPullRequest className="size-4 text-emerald-500" strokeWidth={1.5} />
+              )
             ) : (
-              <GitCompare className="size-4 text-accent-command" strokeWidth={1.5} />
+              // Plain foreground, not the command yellow it started as. Yellow
+              // is the app's "this is for you" — the colour of a session
+              // standing still behind a question — and a turn having touched
+              // files is neither a warning nor a thing to answer. It read as
+              // one, every turn, which is a lot of alarm for a fact.
+              <GitCompare className="size-4 text-foreground" strokeWidth={1.5} />
             )
           ) : (
             <PanelRightIcon className="size-4.5" dim={!open} />
@@ -78,7 +97,13 @@ export function PanelToggle({
         </Button>
       </TooltipTrigger>
       <TooltipContent side="left">
-        {indicating ? (pr ? "Open pull request" : "Last turn's changes") : "Toggle Panel"}
+        {indicating
+          ? pr
+            ? draft
+              ? "Draft pull request"
+              : "Open pull request"
+            : "Last turn's changes"
+          : "Toggle Panel"}
         <KbdGroup>
           <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
           <Kbd>E</Kbd>
@@ -104,11 +129,16 @@ const LABELS: Record<PanelTab, string> = {
 
 /// Which tabs exist, and in what order.
 ///
-/// Changes leads by default — it answers "what just happened" and is the tab
-/// that opens by default. An *open* PR takes the lead instead, because at that
-/// point the session's work is no longer about this turn: it is about landing,
-/// and the first tab is where the eye goes. A merged or closed PR does not,
-/// since it is a record rather than something to act on.
+/// Changes leads by default — it answers "what just happened". An *open* PR
+/// takes the lead instead, because at that point the session's work is no
+/// longer about this turn: it is about landing, and the first tab is where the
+/// eye goes. A draft counts, being `OPEN` with `isDraft` set. A merged or
+/// closed PR does not lead, since it is a record rather than something to act
+/// on.
+///
+/// This is also the order ⌘⇧[ / ⌘⇧] steps through, and `App` derives the
+/// default tab from the same two flags — so the tab that leads the row and the
+/// tab the pane opens onto cannot disagree.
 ///
 /// The PR tab is absent entirely for a session that has no PR to show — see
 /// `prTabVisible`. A tab whose only content is "there is nothing here" is one
@@ -206,6 +236,25 @@ export default function RightPanel({
           </button>
         ))}
 
+        {/* Beside the tabs rather than at the far end, and with no label: next
+            to the thing it acts on, the caps read as belonging to the row
+            without a word saying so. Drawn at all — rather than hidden in a
+            tooltip the way the rest of the app's shortcuts are — because a
+            chord for a row of two or three tabs is one nobody goes looking for.
+
+            Three caps, not four: `[ ]` is one key with two ends rather than two
+            alternatives, so splitting it reads as a chord wanting both. */}
+        <KbdGroup className="ml-1.5 shrink-0 opacity-50">
+          <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+          <Kbd>⇧</Kbd>
+          <Kbd>[ ]</Kbd>
+        </KbdGroup>
+
+        {/* Gone entirely on Subagents, which has nothing to re-read. It reserved
+            its width back when the keycaps sat to its right and would have slid
+            on that one tab; with them anchored to the tabs there is nothing left
+            to hold still, and an empty box on the far edge is a slot for a
+            button the reader is not waiting for. */}
         {refresh && (
           <Button
             variant="ghost"

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -4,6 +4,8 @@ import {
   CheckCheck,
   ChevronDown,
   GitBranchPlus,
+  GitPullRequest,
+  GitPullRequestDraft,
   Inbox,
   // Pin,
   Plus,
@@ -39,9 +41,11 @@ import { useFullscreen } from "@/hooks/useFullscreen";
 import { burstConfetti } from "@/lib/confetti";
 import type { ManualCheck } from "@/hooks/useUpdater";
 import { isToday, relativeTime } from "@/lib/format";
+import { sessionBranch } from "@/lib/pr";
 import { IS_MAC } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import type {
+  OpenPr,
   Project,
   SessionIndexItem,
   SessionStatus,
@@ -60,6 +64,10 @@ type SidebarProps = {
   // status machine still reads these as `in_progress`, and it is right to —
   // the turn is open, it is only the agent that has stopped.
   askingSessions: Set<string>;
+  /// This session's branch has an open pull request, or nothing. A lookup
+  /// rather than a field on the item, because pull requests are read per repo
+  /// and the index knows nothing about them.
+  prFor: (repoPath: string, branch: string | null) => OpenPr | undefined;
   selectedSessionId: string | null;
   collapsed: boolean;
   onToggleCollapsed: () => void;
@@ -148,6 +156,7 @@ export default function Sidebar({
   items,
   statusBySession,
   askingSessions,
+  prFor,
   selectedSessionId,
   collapsed,
   onToggleCollapsed,
@@ -275,6 +284,7 @@ export default function Sidebar({
               item={item}
               status={statusBySession[item.sessionId] ?? item.status}
               asking={askingSessions.has(item.sessionId)}
+              pr={prFor(item.projectPath, sessionBranch(item))}
               active={item.sessionId === selectedSessionId}
               // The settled list is a history, and the question asked of it is
               // "what did I finish today" — so everything older is held back
@@ -689,6 +699,7 @@ function SessionRow({
   item,
   status,
   asking,
+  pr,
   active,
   faded = false,
   onSelect,
@@ -698,6 +709,10 @@ function SessionRow({
   item: SessionIndexItem;
   status: SessionStatus;
   asking: boolean;
+  /// This session's branch has an open pull request. Undefined covers both "no
+  /// PR" and "we couldn't ask" — the mark is decoration, so the two read the
+  /// same.
+  pr?: OpenPr;
   active: boolean;
   faded?: boolean;
   onSelect: (sessionId: string) => Promise<void>;
@@ -790,6 +805,38 @@ function SessionRow({
             />
           )}
         </span>
+
+        {/* Ahead of the title, and it takes no room when there is none — unlike
+            the rail beside it, which holds its slot. The two differ because the
+            rail comes and goes on the *same* row as its agent works, where a
+            branch either has a pull request or does not: a row that never gets
+            one would otherwise pay for the mark forever, and most never do.
+
+            The rail keeps the outer edge because it is the "over to you" mark
+            and clears when the reader deals with it, where this is a standing
+            fact about the branch.
+
+            Emerald for open — the same green the panel's glyph and the merge
+            button use, so the mark and what it points at match — and a draft
+            takes the muted outline it already has in lucide, since a draft is
+            work that isn't asking to land yet. `title` rather than a tooltip:
+            this is a decoration on a row that is itself a control, and a
+            tooltip on it would open every time the cursor crossed the list. */}
+        {pr && (
+          <span
+            className={cn(
+              "mr-1 flex shrink-0 items-center",
+              pr.isDraft ? "text-muted-foreground" : "text-emerald-500",
+            )}
+            title={pr.isDraft ? `Draft pull request #${pr.number}` : `Pull request #${pr.number}`}
+          >
+            {pr.isDraft ? (
+              <GitPullRequestDraft className="size-3.5" strokeWidth={1.5} />
+            ) : (
+              <GitPullRequest className="size-3.5" strokeWidth={1.5} />
+            )}
+          </span>
+        )}
 
         <span className="min-w-0 flex-1 truncate text-ui">{item.title}</span>
 

--- a/apps/desktop/src/components/composer/HandoffRow.tsx
+++ b/apps/desktop/src/components/composer/HandoffRow.tsx
@@ -1,0 +1,130 @@
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { HANDOFF_ICONS } from "@/components/composer/handoffIcons";
+import type { HandoffAction } from "@/lib/handoff";
+
+/// The row of "I'm done, take it from here" actions, parked behind the composer.
+///
+/// Almost every button here **sends a prompt** — it is the reader typing
+/// "commit" without typing it. No confirm dialog and no error surface: the
+/// agent writes the message with the context it already has, and whatever goes
+/// wrong is reported in the transcript like any other tool failure. Push is the
+/// exception and runs git directly, because it has one correct implementation
+/// and nothing to decide. Which buttons exist when is [handoffActions]' rule,
+/// and it is contextual — no commit offer on a clean tree, no pull request from
+/// the branch the work lands on.
+///
+/// It hides rather than sits, and that shape is the point. A turn that touched
+/// a file is most turns, so a row drawn on "there are changes" is a row drawn
+/// always — which is what makes every other tool's commit button noise. And the
+/// reverse of that: finishing a turn is not the same as wanting to commit.
+///
+/// **The composer is the occluder, not a clip.** The buttons sit at full height
+/// in a reserve a fraction as tall, so most of each one runs on past it and
+/// behind the card — which is opaque, and which paints later than this because
+/// it comes later in the form. Hovering slides the whole row clear. Clipping
+/// instead would leave the same picture and a different lie: the buttons would
+/// end where the card starts rather than continue behind it, so nothing would
+/// suggest there was more of them.
+///
+/// **The hover zone and the thing it moves are separate elements**, and they
+/// have to be. With one element, the box travels with the buttons — so the
+/// cursor that opened the row sits on its edge the moment it opens, and the row
+/// shuts under it and reopens, forever. The zone stays put; only the inner row
+/// translates, and it translates *within* the zone, so the cursor is never
+/// outside it.
+///
+/// Three more details, each a bug the obvious version has:
+///
+/// - The reserve is a **fixed height** and everything else is positioned out of
+///   flow inside it. In flow, the row would push the composer down and the
+///   transcript up every time the cursor crossed it on its way to the input —
+///   which is the one path the cursor takes most.
+/// - The buttons carry **opaque fills** (`secondary`, never `outline`). Outline
+///   is `bg-input/30` in the dark palette, so the transcript reads straight
+///   through the part that is meant to be hidden.
+/// - They take **no pointer events until the row is open**. The sliver sits
+///   directly above the composer, so without this a click aimed at the input
+///   and landing a few pixels high would send a commit.
+export default function HandoffRow({
+  actions,
+  onSend,
+  onPush,
+  pushing = false,
+  disabled = false,
+}: {
+  actions: HandoffAction[];
+  onSend: (prompt: string) => void;
+  /// Runs the push and resolves when git has. The only action here that isn't a
+  /// prompt — see [HandoffAction].
+  onPush: () => void;
+  /// A push is in flight. The one action with no transcript to report into, so
+  /// it has to say so on the button itself: a prompt lands as a visible message
+  /// a frame later, where this would look like a click that did nothing.
+  pushing?: boolean;
+  /// No session to send into. Nothing fires, but the reserve still stands — its
+  /// absence would move the composer.
+  disabled?: boolean;
+}) {
+  // Nothing to offer is a real state and the commonest one: a clean default
+  // branch with everything pushed. The reserve goes with it, since there is no
+  // sliver to keep room for.
+  if (actions.length === 0) return null;
+
+  return (
+    // `h-1` against the buttons' own `h-7` is all that shows: enough to say
+    // there is something under there, not enough to read as a row of buttons
+    // the composer happens to be covering. This is the component's one dial —
+    // raise it and more of each button stands proud.
+    //
+    // `px-3` matches the card's own inner padding, so the first button's edge
+    // lands on the same line as the toolbar buttons inside it.
+    <div className="relative h-1 px-3">
+      {/* The zone, not the row. `-top-7 pt-7` grows its box 28px upward without
+          moving what's inside it, turning a 4px target into a 32px one — and
+          `w-fit` keeps that box off the rest of the transcript's bottom edge,
+          where an invisible full-width strip would swallow clicks and text
+          selection. */}
+      <div className="group absolute -top-7 left-3 w-fit pt-7">
+        <div
+          className={
+            "flex gap-1 " +
+            // The delay is symmetric on purpose: it keeps a cursor merely
+            // passing through from popping the row open, and lets one that
+            // overshoots on the way out come back without it having closed.
+            "transition-transform delay-150 duration-200 ease-out " +
+            // -28px clears the card's top edge, so the open row reads as sitting
+            // above the composer rather than resting on it.
+            "group-hover:-translate-y-7 group-focus-within:-translate-y-7"
+          }
+        >
+          {actions.map((action) => {
+            const Icon = HANDOFF_ICONS[action.id];
+            const busy = action.kind === "push" && pushing;
+            return (
+              <Button
+                key={action.id}
+                type="button"
+                size="sm"
+                variant="secondary"
+                disabled={disabled || busy}
+                onClick={() =>
+                  action.kind === "push" ? onPush() : onSend(action.prompt)
+                }
+                className="pointer-events-none group-focus-within:pointer-events-auto group-hover:pointer-events-auto"
+              >
+                {busy ? (
+                  <Loader2 className="size-3.5 animate-spin" strokeWidth={1.5} />
+                ) : (
+                  <Icon className="size-3.5" strokeWidth={1.5} />
+                )}
+                {action.label}
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/composer/handoffIcons.ts
+++ b/apps/desktop/src/components/composer/handoffIcons.ts
@@ -1,0 +1,22 @@
+import {
+  ArrowUp,
+  GitCommitHorizontal,
+  GitPullRequest,
+  GitPullRequestDraft,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import type { HandoffAction } from "@/lib/handoff";
+
+/// One glyph per handoff action.
+///
+/// The two pull request glyphs are the pair the sidebar row and the panel
+/// toggle already draw — the mark and the thing it leads to have to match
+/// wherever they appear.
+export const HANDOFF_ICONS: Record<HandoffAction["id"], LucideIcon> = {
+  commit: GitCommitHorizontal,
+  commitPush: ArrowUp,
+  push: ArrowUp,
+  pr: GitPullRequest,
+  draftPr: GitPullRequestDraft,
+};

--- a/apps/desktop/src/hooks/useHotkey.ts
+++ b/apps/desktop/src/hooks/useHotkey.ts
@@ -6,6 +6,12 @@ type HotkeyOptions = {
   shift?: boolean;
   /// Option on macOS, Alt elsewhere.
   alt?: boolean;
+  /// A physical key accepted alongside `key`, for a chord whose character moves
+  /// under Shift — ⌘⇧[ arrives as `{`, and which of the two `key` carries is
+  /// the browser's call. Matching the character alone is one engine away from
+  /// silently never firing, and matching position alone would put the chord
+  /// under a different glyph on every non-US layout, so this takes both.
+  code?: string;
 };
 
 /// Binds a document-level shortcut. The handler is held in a ref so passing a
@@ -13,7 +19,7 @@ type HotkeyOptions = {
 export function useHotkey(
   key: string,
   handler: () => void,
-  { meta = true, shift = false, alt = false }: HotkeyOptions = {},
+  { meta = true, shift = false, alt = false, code }: HotkeyOptions = {},
 ) {
   const handlerRef = useRef(handler);
   handlerRef.current = handler;
@@ -28,7 +34,8 @@ export function useHotkey(
       // broken the character.
       const matches =
         e.key.toLowerCase() === key.toLowerCase() ||
-        (alt && key.length === 1 && e.code === `Key${key.toUpperCase()}`);
+        (alt && key.length === 1 && e.code === `Key${key.toUpperCase()}`) ||
+        (code !== undefined && e.code === code);
       if (!matches) return;
       // Accept either modifier rather than branching on platform: a Mac reports
       // metaKey, everything else ctrlKey, and neither fires the other's chord.
@@ -46,5 +53,5 @@ export function useHotkey(
 
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [key, meta, shift, alt]);
+  }, [key, meta, shift, alt, code]);
 }

--- a/apps/desktop/src/hooks/useOpenPrs.ts
+++ b/apps/desktop/src/hooks/useOpenPrs.ts
@@ -16,9 +16,11 @@ const FRESH_MS = 120_000;
 const cache = new Map<string, Map<string, OpenPr>>();
 const fetchedAt = new Map<string, number>();
 
-/// Repos we are mid-flight on, so two effects landing in the same frame — a
-/// turn ending in a project that is also newly visible — cost one `gh`.
-const inFlight = new Set<string>();
+/// The read currently running for a repo, so two effects landing in the same
+/// frame — a turn ending in a project that is also newly visible — cost one
+/// `gh`. The promise rather than a bare flag, because a *forced* read that
+/// collides has to queue behind it rather than be dropped; see `load`.
+const inFlight = new Map<string, Promise<void>>();
 
 const EMPTY: Map<string, OpenPr> = new Map();
 
@@ -46,15 +48,32 @@ export function useOpenPrs(repoPaths: string[]) {
   const [byRepo, setByRepo] = useState<Map<string, Map<string, OpenPr>>>(() => new Map(cache));
 
   const load = useCallback(async (force: boolean) => {
+    // Deferred rather than dropped, and that distinction is the whole of this
+    // branch. A forced read is one the caller knows something new about — a
+    // turn has just ended and may have opened a pull request — while the read
+    // already running was issued before that. Skipping it on the collision
+    // leaves the pre-creation answer standing until something else happens to
+    // refresh, so the sidebar stays unmarked and the composer keeps offering
+    // Create PR for a branch that has one.
+    const deferred: string[] = [];
+
     const stale = pathsRef.current.filter((path) => {
-      if (inFlight.has(path)) return false;
+      if (inFlight.has(path)) {
+        if (force) deferred.push(path);
+        return false;
+      }
       return force || Date.now() - (fetchedAt.get(path) ?? 0) >= FRESH_MS;
     });
-    if (stale.length === 0) return;
+    if (stale.length === 0 && deferred.length === 0) return;
 
-    await Promise.all(
-      stale.map(async (path) => {
-        inFlight.add(path);
+    const read = async (path: string) => {
+      const running = inFlight.get(path);
+      // Waits for the slot rather than taking it: two reads of one repo answer
+      // the same thing, and letting them overlap makes which one lands last a
+      // race.
+      if (running) await running;
+
+      const attempt = (async () => {
         try {
           const prs = await invoke<OpenPr[]>("open_prs", { cwd: path });
           cache.set(path, new Map(prs.map((pr) => [pr.headRefName, pr])));
@@ -65,10 +84,17 @@ export function useOpenPrs(repoPaths: string[]) {
           cache.set(path, new Map());
         } finally {
           fetchedAt.set(path, Date.now());
-          inFlight.delete(path);
         }
-      }),
-    );
+      })();
+
+      inFlight.set(path, attempt);
+      await attempt;
+      // Only if it is still ours: a later read may already have claimed the
+      // slot while this one was settling.
+      if (inFlight.get(path) === attempt) inFlight.delete(path);
+    };
+
+    await Promise.all([...stale, ...deferred].map(read));
 
     setByRepo(new Map(cache));
   }, []);

--- a/apps/desktop/src/hooks/useOpenPrs.ts
+++ b/apps/desktop/src/hooks/useOpenPrs.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { invoke } from "@tauri-apps/api/core";
+
+import type { OpenPr } from "@/types/events";
+
+/// How long a repo's answer counts as fresh. Longer than the panel's own 30s,
+/// because this feeds a mark rather than a view being read: the sidebar is on
+/// screen the whole time, and a row's glyph appearing a minute late costs
+/// nothing where a stale merge button would.
+const FRESH_MS = 120_000;
+
+/// Last answer per repo, kept across mounts for [usePullRequest]'s reason —
+/// switching projects changes the argument, and a project flipped away from and
+/// back to should draw its marks immediately rather than blank and refill.
+const cache = new Map<string, Map<string, OpenPr>>();
+const fetchedAt = new Map<string, number>();
+
+/// Repos we are mid-flight on, so two effects landing in the same frame — a
+/// turn ending in a project that is also newly visible — cost one `gh`.
+const inFlight = new Set<string>();
+
+const EMPTY: Map<string, OpenPr> = new Map();
+
+/// Open pull requests for every repo the sidebar is showing sessions from,
+/// keyed by head branch.
+///
+/// One query per repo rather than one per session: `gh` costs the better part
+/// of a second, so a spawn per visible row would make the sidebar the most
+/// expensive thing in the app. The frontend does the matching, because which
+/// branch a session lands on is its own rule — `sessionBranch` rebuilds a
+/// worktree session's from its worktree name — and the backend answering a map
+/// would be a second copy of it.
+///
+/// Failure is silent and total: no `gh`, not a GitHub repo, logged out. The
+/// mark is decoration on a list that works without it, so there is nothing here
+/// to report and nothing for the reader to do.
+export function useOpenPrs(repoPaths: string[]) {
+  // The effect depends on the *set*, not on the array identity a caller mints
+  // fresh every render. The paths themselves are read off a ref rather than out
+  // of this string, since a repo path can hold whatever separator we picked.
+  const key = [...repoPaths].sort().join("\n");
+  const pathsRef = useRef(repoPaths);
+  pathsRef.current = repoPaths;
+
+  const [byRepo, setByRepo] = useState<Map<string, Map<string, OpenPr>>>(() => new Map(cache));
+
+  const load = useCallback(async (force: boolean) => {
+    const stale = pathsRef.current.filter((path) => {
+      if (inFlight.has(path)) return false;
+      return force || Date.now() - (fetchedAt.get(path) ?? 0) >= FRESH_MS;
+    });
+    if (stale.length === 0) return;
+
+    await Promise.all(
+      stale.map(async (path) => {
+        inFlight.add(path);
+        try {
+          const prs = await invoke<OpenPr[]>("open_prs", { cwd: path });
+          cache.set(path, new Map(prs.map((pr) => [pr.headRefName, pr])));
+        } catch {
+          // An empty map, not an absent one, and stamped like a success: a repo
+          // `gh` can't answer for should stop being asked until the window
+          // expires rather than on every render.
+          cache.set(path, new Map());
+        } finally {
+          fetchedAt.set(path, Date.now());
+          inFlight.delete(path);
+        }
+      }),
+    );
+
+    setByRepo(new Map(cache));
+  }, []);
+
+  useEffect(() => {
+    void load(false);
+  }, [key, load]);
+
+  return {
+    /// A session's pull request, or nothing. Takes the repo *and* the branch,
+    /// since a branch name says nothing about which checkout it belongs to.
+    prFor: useCallback(
+      (repoPath: string, branch: string | null): OpenPr | undefined =>
+        branch ? (byRepo.get(repoPath) ?? EMPTY).get(branch) : undefined,
+      [byRepo],
+    ),
+    /// Re-reads every repo currently on screen. Called when a turn ends — that
+    /// is when a pull request appears.
+    refresh: useCallback(() => void load(true), [load]),
+  };
+}

--- a/apps/desktop/src/hooks/usePullRequest.ts
+++ b/apps/desktop/src/hooks/usePullRequest.ts
@@ -24,6 +24,8 @@ const fetchedAt = new Map<string, number>();
 
 const keyOf = (cwd: string, branch: string) => `${cwd} ${branch}`;
 
+const isOpen = (pr: PullRequest) => pr.state === "OPEN";
+
 /// What `invoke` rejected with, as the backend meant it.
 ///
 /// Tauri hands the serialized `Err` back, so this is already the right shape —
@@ -79,7 +81,18 @@ type State = {
 ///
 /// Nothing here holds a "current" PR. Something did, and it was the bug: see
 /// `act`.
-export function usePullRequest(cwd: string, branch: string | null, active: boolean) {
+export function usePullRequest(
+  cwd: string,
+  branch: string | null,
+  active: boolean,
+  /// Called the moment a branch that had no open pull request turns out to have
+  /// one. Fired from inside `load` rather than derived by the caller from
+  /// `prs`, because only the fetch knows what the *previous* answer was — and
+  /// the previous answer is the whole guard. A first read has none, so opening
+  /// the app onto a session that already has a PR is not an appearance and
+  /// raises nothing.
+  onOpened?: () => void,
+) {
   const key = branch ? keyOf(cwd, branch) : null;
 
   const [state, setState] = useState<State>(() => ({
@@ -93,6 +106,9 @@ export function usePullRequest(cwd: string, branch: string | null, active: boole
   // landing after a session switch can tell it is answering the wrong branch.
   const keyRef = useRef(key);
   keyRef.current = key;
+
+  const onOpenedRef = useRef(onOpened);
+  onOpenedRef.current = onOpened;
 
   /// Every write to `state` goes through this.
   ///
@@ -118,6 +134,10 @@ export function usePullRequest(cwd: string, branch: string | null, active: boole
 
       commit(key, (prev) => ({ ...prev, loading: true }));
 
+      // Read before the write below, since that is what makes this an
+      // appearance rather than a first sighting.
+      const before = cache.get(key);
+
       try {
         const prs = await invoke<PullRequest[]>("prs_for_branch", { cwd, branch });
         // The cache is keyed, so it is written whatever the reader switched to
@@ -125,6 +145,13 @@ export function usePullRequest(cwd: string, branch: string | null, active: boole
         cache.set(key, prs);
         fetchedAt.set(key, Date.now());
         commit(key, () => ({ prs, error: null, loading: false }));
+
+        // Guarded on the key for the same reason every other write here is: a
+        // read that lands after a session switch must not pull the panel open
+        // onto a branch the reader has left.
+        if (keyRef.current === key && before && !before.some(isOpen) && prs.some(isOpen)) {
+          onOpenedRef.current?.();
+        }
       } catch (e) {
         // The previous answer stays up: a failed refresh is a refresh that
         // failed, not the PR going away.

--- a/apps/desktop/src/hooks/useWorkStatus.ts
+++ b/apps/desktop/src/hooks/useWorkStatus.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { invoke } from "@tauri-apps/api/core";
+
+import type { WorkStatus } from "@/types/events";
+
+/// Last answer per directory, kept across mounts so switching sessions and
+/// coming back draws the row immediately rather than blank and refilling. Not
+/// invalidated by anything: every write below is a whole fresh answer, and the
+/// key is the directory the answer is about.
+const cache = new Map<string, WorkStatus>();
+
+/// What is left to do with this session's work — see [handoffActions].
+///
+/// Read on the **falling edge of a turn** and on arriving at a session, and
+/// nowhere else. Those are the two moments it can change from inside the app:
+/// the agent writes, commits and pushes during a turn, and nothing between
+/// turns moves the tree except the reader in another window. Polling for that
+/// would be several `git` spawns a second to catch something rare — the row
+/// going one turn stale is the trade, and the same one every other read in
+/// this app makes.
+export function useWorkStatus(cwd: string, busy: boolean) {
+  const [status, setStatus] = useState<WorkStatus | null>(() => cache.get(cwd) ?? null);
+
+  // Guards a read that outlives the session it started in, so a slow answer
+  // can't write one checkout's state under another's name.
+  const issued = useRef(0);
+
+  const read = useRef((at: string) => {
+    if (!at) return;
+    const token = ++issued.current;
+    void invoke<WorkStatus>("work_status", { cwd: at })
+      .then((next) => {
+        cache.set(at, next);
+        if (issued.current === token) setStatus(next);
+      })
+      // Infallible on the Rust side, so anything landing here is the bridge
+      // itself. The row draws nothing and that is the honest answer.
+      .catch(() => issued.current === token && setStatus(null));
+  }).current;
+
+  // Adopt the cache on the way in, then read. Both, because the cached answer
+  // is what the reader saw last time and the fresh one is what is true now.
+  useEffect(() => {
+    setStatus(cache.get(cwd) ?? null);
+    read(cwd);
+  }, [cwd, read]);
+
+  // The falling edge alone: a turn *starting* changes nothing yet, and reading
+  // on every render of a running turn would spawn `git` through the whole of it.
+  const wasBusy = useRef(busy);
+  useEffect(() => {
+    const fell = wasBusy.current && !busy;
+    wasBusy.current = busy;
+    if (fell) read(cwd);
+  }, [busy, cwd, read]);
+
+  // For the push button, which changes all of this without a turn happening —
+  // and whose count is the thing on screen the reader is looking at when it
+  // lands.
+  const refresh = useCallback(() => read(cwd), [cwd, read]);
+
+  return { status, refresh };
+}

--- a/apps/desktop/src/lib/handoff.test.ts
+++ b/apps/desktop/src/lib/handoff.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { handoffActions } from "./handoff";
+import type { WorkStatus } from "@/types/events";
+
+const status = (over: Partial<WorkStatus> = {}): WorkStatus => ({
+  dirty: 0,
+  branch: "feature",
+  upstream: "origin/feature",
+  ahead: 0,
+  defaultBranch: "main",
+  ...over,
+});
+
+const ids = (...args: Parameters<typeof handoffActions>) =>
+  handoffActions(...args).map((a) => a.id);
+
+describe("handoffActions", () => {
+  it("offers nothing outside a repository", () => {
+    expect(ids(status({ branch: null }), false)).toEqual([]);
+    expect(ids(null, false)).toEqual([]);
+  });
+
+  it("offers nothing on a settled default branch", () => {
+    expect(ids(status({ branch: "main" }), false)).toEqual([]);
+  });
+
+  // Reading across gives the two things anyone does here; reading down gives
+  // each one's longer form.
+  it("interleaves the local and remote ladders", () => {
+    expect(ids(status({ dirty: 1 }), false)).toEqual([
+      "commit",
+      "pr",
+      "commitPush",
+      "draftPr",
+    ]);
+  });
+
+  // One ladder shorter than the other must not leave a hole or reorder the rest.
+  it("keeps order when only one ladder has entries", () => {
+    expect(ids(status({ ahead: 2 }), false)).toEqual(["push", "pr", "draftPr"]);
+  });
+
+  it("offers no pull request from the branch it would land on", () => {
+    expect(ids(status({ branch: "main", dirty: 2 }), false)).toEqual([
+      "commit",
+      "commitPush",
+    ]);
+  });
+
+  it("offers no pull request where there is no remote to resolve one", () => {
+    expect(ids(status({ defaultBranch: null, dirty: 1 }), false)).toEqual([
+      "commit",
+      "commitPush",
+    ]);
+  });
+
+  // The panel is where an existing PR is acted on; a second button here would
+  // open a duplicate against the same base.
+  it("drops the pull request buttons once one exists", () => {
+    expect(ids(status({ dirty: 1 }), true)).toEqual(["commit", "commitPush"]);
+  });
+
+  // With a dirty tree the commit comes first, and "Commit & push" already
+  // carries the push — a third button would be the same action twice.
+  it("does not offer push beside commit", () => {
+    expect(ids(status({ dirty: 1, ahead: 3 }), true)).toEqual([
+      "commit",
+      "commitPush",
+    ]);
+  });
+
+  it("offers push only once the tree is clean", () => {
+    expect(ids(status({ ahead: 3 }), true)).toEqual(["push"]);
+  });
+
+  // A branch nobody has pushed is one nobody else can see, so the offer stands
+  // even at zero ahead. `push_branch` sets the upstream itself, so this is the
+  // same action rather than a second one.
+  it("offers push for a branch with no upstream", () => {
+    const [action] = handoffActions(status({ upstream: null }), true);
+    expect(action.id).toBe("push");
+    // No count: an unpublished branch is ahead of nothing, and "Push 0" would
+    // answer a question nobody asked yet.
+    expect(action.label).toBe("Push");
+  });
+
+  it("counts the commits in the push label", () => {
+    expect(handoffActions(status({ ahead: 3 }), true)[0].label).toBe("Push 3");
+  });
+
+  // Push runs git directly; everything else asks the agent. Getting this wrong
+  // either spends a model turn on a one-liner or silently drops a click.
+  it("marks push as the only action that is not a prompt", () => {
+    const all = [
+      ...handoffActions(status({ dirty: 1 }), false),
+      ...handoffActions(status({ ahead: 1 }), false),
+    ];
+    for (const action of all) {
+      expect(action.kind).toBe(action.id === "push" ? "push" : "prompt");
+    }
+  });
+
+  // Short enough to be what the reader would have typed. A longer prompt is a
+  // spec competing with the repo's own instructions about commit messages.
+  it("keeps the prompts to a few words", () => {
+    for (const action of handoffActions(status({ dirty: 1 }), false)) {
+      if (action.kind !== "prompt") continue;
+      expect(action.prompt.split(" ").length).toBeLessThanOrEqual(4);
+    }
+  });
+
+  // Every id needs a glyph in `HandoffRow`'s map, and a duplicate id in one row
+  // would also collide as a React key.
+  it("never repeats an id in one row", () => {
+    for (const over of [{ dirty: 1 }, { ahead: 2 }, { upstream: null }, {}]) {
+      const drawn = ids(status(over), false);
+      expect(new Set(drawn).size).toBe(drawn.length);
+    }
+  });
+});

--- a/apps/desktop/src/lib/handoff.ts
+++ b/apps/desktop/src/lib/handoff.ts
@@ -1,0 +1,117 @@
+import type { WorkStatus } from "@/types/events";
+
+/// One thing the reader can do with the work when a turn is over.
+///
+/// Almost all of these are **prompts**, sent verbatim as if typed, and that is
+/// the design: the agent writes the commit message with the context it just
+/// worked in, so there is no second write path, no confirm dialog and no error
+/// surface — whatever goes wrong is reported in the transcript like any other
+/// tool failure. The prompts are one or three words for the same reason. The
+/// model knows how to commit and whether the branch has an upstream; a sentence
+/// spelling it out here is a spec competing with the repo's own instructions,
+/// and this repo has firm ones about commit messages.
+///
+/// `push` is the exception, and the line is whether there is a judgement to
+/// make. Pushing has exactly one correct implementation and nothing to decide,
+/// so it runs directly.
+export type HandoffAction = {
+  id: "commit" | "commitPush" | "push" | "pr" | "draftPr";
+  label: string;
+} & (
+  | {
+      /// Sent verbatim as if it were typed. Deliberately as short as the button
+      /// — the model knows how to commit, and whether the branch has an
+      /// upstream, better than a sentence written here does. Anything longer is
+      /// a spec competing with the repo's own instructions.
+      kind: "prompt";
+      prompt: string;
+    }
+  | {
+      /// Runs `push_branch` directly. The one action here with a single correct
+      /// implementation and nothing to decide: `git push`, or `git push -u
+      /// origin <branch>` where there is no upstream yet. Spending a model turn
+      /// on that buys nothing and costs the reader a wait.
+      kind: "push";
+    }
+);
+
+/// Whether this checkout could carry a pull request at all.
+///
+/// The default branch is where work lands, so opening a pull request from it is
+/// a request against itself. A repo with no remote resolves no default branch
+/// and gets no button either — there is nowhere to push it.
+function canOpenPr(status: WorkStatus): boolean {
+  return (
+    status.branch !== null &&
+    status.defaultBranch !== null &&
+    status.branch !== status.defaultBranch
+  );
+}
+
+/// Which buttons the composer's action row draws, in the order they are drawn.
+///
+/// Empty is the resting state and the row hides on it — outside a repo, on a
+/// clean default branch with nothing to push, or anywhere the answer to "what
+/// is left to do" is nothing.
+///
+/// `hasPr` comes from the sidebar's own per-repo read rather than from git:
+/// once a pull request exists, the panel is where it is acted on, and a second
+/// "Create PR" button would open a duplicate.
+export function handoffActions(
+  status: WorkStatus | null,
+  hasPr: boolean,
+): HandoffAction[] {
+  if (!status || status.branch === null) return [];
+
+  // Two ladders, each running plain-first then variant, and the row draws them
+  // interleaved: Commit, Create PR, Commit & push, Draft PR. Reading across
+  // gives the two things anyone does here; reading down gives each one's
+  // longer form. Both ladders concatenated instead would put the two pull
+  // request buttons at the far end, where the compound commit action sits
+  // between the reader and the thing they most often want next.
+  const local: HandoffAction[] = [];
+  const remote: HandoffAction[] = [];
+
+  if (status.dirty > 0) {
+    local.push({ id: "commit", label: "Commit", kind: "prompt", prompt: "commit" });
+    local.push({
+      id: "commitPush",
+      label: "Commit & push",
+      kind: "prompt",
+      prompt: "commit and push",
+    });
+  } else if (status.ahead > 0 || status.upstream === null) {
+    // Only where there is nothing to commit: with a dirty tree the reader wants
+    // the commit first, and "Commit & push" above already carries the push.
+    //
+    // One action for both cases, because `push_branch` is already both — it
+    // sets the upstream where there isn't one. A branch nobody has pushed is
+    // one nobody else can see, so the offer stands at zero commits ahead, and
+    // the count comes off the label there since it would read as zero.
+    local.push({
+      id: "push",
+      label: status.upstream === null ? "Push" : `Push ${status.ahead}`,
+      kind: "push",
+    });
+  }
+
+  if (canOpenPr(status) && !hasPr) {
+    // Both spelled out rather than one behind the other's menu: a draft is a
+    // different decision, not a variant of the same one, and burying it makes
+    // the reader open a menu to find out it is there.
+    remote.push({ id: "pr", label: "Create PR", kind: "prompt", prompt: "create a PR" });
+    remote.push({
+      id: "draftPr",
+      label: "Draft PR",
+      kind: "prompt",
+      prompt: "create a draft PR",
+    });
+  }
+
+  const actions: HandoffAction[] = [];
+  for (let i = 0; i < Math.max(local.length, remote.length); i++) {
+    if (local[i]) actions.push(local[i]);
+    if (remote[i]) actions.push(remote[i]);
+  }
+  return actions;
+}

--- a/apps/desktop/src/types/events.ts
+++ b/apps/desktop/src/types/events.ts
@@ -465,6 +465,20 @@ model: string, inputTokens: number | null, outputTokens: number | null, cachedIn
  */
 contextWindow: number | null, maxOutputTokens: number | null, };
 
+/**
+ * One open pull request, cut down to what a sidebar row can draw.
+ *
+ * Deliberately not a `PullRequest`: the row says "this branch has an open PR,
+ * and whether it is a draft" and nothing else, so carrying checks, comments
+ * and review threads for every session in the list would be payload nobody
+ * reads.
+ */
+export type OpenPr = { number: number, 
+/**
+ * The branch it was opened from — what the caller matches a session by.
+ */
+headRefName: string, isDraft: boolean, };
+
 export type PermissionBehavior = "allow" | "deny";
 
 /**
@@ -916,6 +930,38 @@ reasoningTokens: number | null, totalTokens: number | null, costUsd: number | nu
  * and every event that doesn't report one. See [`ModelUsage`].
  */
 perModel: Array<ModelUsage>, };
+
+/**
+ * What the composer's action row needs to decide which buttons it has, in one
+ * read.
+ *
+ * A superset of [`SyncStatus`] rather than three calls stitched together in
+ * the frontend: every field here answers the same question — "what is there
+ * left to do with this work" — and reading them separately would let the row
+ * draw a Commit button from one snapshot beside a Push count from another.
+ */
+export type WorkStatus = { 
+/**
+ * Uncommitted paths. A count and not a list — the row only asks whether
+ * there is anything, and the changes view is where the files are read.
+ */
+dirty: number, 
+/**
+ * `None` on a detached HEAD and outside a repo, which is how the row hides
+ * itself entirely.
+ */
+branch: string | null, 
+/**
+ * `None` for a branch never pushed — the "publish" case.
+ */
+upstream: string | null, ahead: number, 
+/**
+ * The branch this work would land on, short of its remote (`main`, not
+ * `origin/main`). Stripped here rather than in the row, so "am I on the
+ * default branch" is one comparison and not a parsing rule that can drift.
+ * `None` where there is no remote to ask.
+ */
+defaultBranch: string | null, };
 
 /**
  * What removing this worktree would cost, read once so the dialog and the


### PR DESCRIPTION
## What

Three connected pieces around "the work is done, what now".

### PR detection was structurally broken

A PR created mid-session stayed invisible until you switched sessions and came back. The poll was gated on the PR tab being visible **and** active — but that tab hides exactly while the answer is "no PR", so the one state that needed rechecking was the only one that could never self-heal.

Now a refetch runs on the falling edge of a turn (session-id guarded, since `busy` is the selected session's). When a PR appears, the pane opens onto it — fired from inside `load` by comparing against the cached previous answer, so it happens at most once per PR and never on app restart.

### Sidebar PR marks

Session rows show an open or draft PR glyph, left of the title, absent when there is none. One `gh api graphql` per distinct repo rather than per row, active-list repos only, 120s cache, refreshed on the same turn-end edge. New `open_prs` backend command returns just `number headRefName isDraft`.

### Composer handoff row

A row of end-of-turn actions parked *behind* the composer, a 4px sliver showing, sliding up on hover. Contextual: `Commit · Create PR · Commit & push · Draft PR`, or `Push` when the tree is clean, and nothing at all on a settled default branch.

Four of the five send a short prompt (`commit`, `create a PR`) as if typed — so the agent writes the message with the context it worked in, there is no second write path, and failures land in the transcript like any other tool failure. `Push` runs `git push` directly: one correct implementation, nothing to decide.

New `work_status` command answers dirty / branch / upstream / ahead / default-branch in one read.

### Panel tab default

`ade.panelTab` now stores `PanelTab | null`, where `null` means "never picked". Storing `"changes"` as the initial value made a fresh install indistinguishable from a reader who had chosen Changes, so an open PR could never lead. The rule collapses to one line and the old precedence block is gone. ⌘⇧[ / ⌘⇧] cycle the visible tabs, with keycaps drawn beside them.

## Notable decisions

- **Peek, not a permanent row.** A turn that touched a file is most turns, so a row drawn on "there are changes" is drawn always — the thing other tools get wrong. The composer occludes it rather than a clip, so the buttons continue behind the card instead of ending at it.
- **`--composer` token.** New palette entry, a copy of `--card`, deliberately *not* given a veil under vibrancy — it is the one raised surface with something parked behind it.
- **Changes indicator went from yellow to white.** Yellow is `--accent-command`, the app's "this is for you"; a turn having touched files is neither a warning nor something to answer.

## Testing

- 147 frontend tests (11 new, covering `handoffActions` ordering and contextual rules)
- 249 Rust tests (7 new, covering `work_status` and the open-PR query)
- `tsc --noEmit` and production build clean

Not run in the app. The peek's sliver height, hover delay, and the keycap row's fit at 32rem are the parts that need eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
