### PR TITLE
fix(chat): stop red marking errors nobody acts on

### DIFF
--- a/apps/desktop/src/components/chat/ToolCall.tsx
+++ b/apps/desktop/src/components/chat/ToolCall.tsx
@@ -6,7 +6,7 @@ import DiffView from "@/components/chat/DiffView";
 import ImageRow from "@/components/chat/ImageRow";
 import { cn } from "@/lib/utils";
 import { countChanges, editSides, readRange } from "@/lib/diff";
-import { formatToolInput, toolLabel, toolSummary } from "@/lib/tools";
+import { formatToolInput, isRoutineError, toolLabel, toolSummary } from "@/lib/tools";
 import type { ToolResult, ToolType } from "@/types/events";
 import type { JsonValue } from "@/types/serde_json/JsonValue";
 
@@ -83,6 +83,12 @@ export default function ToolCall({
   const summary = title ?? toolSummary(name, toolType, input);
   const pending = result === undefined;
   const failed = result?.isError ?? false;
+
+  // Failed and worth interrupting the reader over are different questions. Most
+  // errors here are the agent probing a path or a binary and moving on, so red
+  // on every one of them is red on a resting transcript. The row still reads as
+  // failed either way — the "Error:" body says so — this only decides the colour.
+  const alarming = failed && !isRoutineError(result?.text);
 
   // Inside a group the label is redundant — except with no summary to stand in
   // its place, where dropping it would leave a blank, unclickable row.
@@ -169,7 +175,7 @@ export default function ToolCall({
           <span
             className={cn(
               "shrink-0",
-              failed ? "text-destructive" : "text-foreground/80",
+              alarming ? "text-destructive" : "text-foreground/80",
               pending && "shimmer-text",
             )}
           >
@@ -185,7 +191,7 @@ export default function ToolCall({
           <span
             className={cn(
               "min-w-0 max-w-fit truncate font-mono",
-              !showLabel && failed ? "text-destructive" : "text-muted-foreground",
+              !showLabel && alarming ? "text-destructive" : "text-muted-foreground",
               !showLabel && pending && "shimmer-text",
             )}
           >
@@ -218,7 +224,14 @@ export default function ToolCall({
             indicators for one fact just competed with each other. A non-zero
             exit stays: that is an outcome, which the label never encodes. */}
         {result?.exitCode != null && result.exitCode !== 0 && (
-          <span className="ml-auto shrink-0 text-destructive">exit {result.exitCode}</span>
+          <span
+            className={cn(
+              "ml-auto shrink-0",
+              alarming ? "text-destructive" : "text-muted-foreground",
+            )}
+          >
+            exit {result.exitCode}
+          </span>
         )}
       </button>
 
@@ -238,8 +251,8 @@ export default function ToolCall({
           because an error is the reason to look at the row and should not be the
           smallest text on it; an answered question, because the harness writes
           it as a sentence and a code box would frame prose as output. Neither is
-          tinted — the red label above already marks a failure, and the "Error:"
-          lead-in names the text without a second color repeating it. */}
+          tinted — the "Error:" lead-in names the text on its own, which is also
+          what carries a routine failure that the label above left uncoloured. */}
       {open && shown && (
         <pre
           className={cn(

--- a/apps/desktop/src/components/chat/ToolGroupRow.tsx
+++ b/apps/desktop/src/components/chat/ToolGroupRow.tsx
@@ -27,12 +27,6 @@ export default function ToolGroupRow({
       !resultByCallId.has(event.payload.callId),
   );
 
-  const failed = group.calls.some(
-    (event) =>
-      event.payload.type === "tool_call_started" &&
-      resultByCallId.get(event.payload.callId)?.isError,
-  );
-
   // The run's total `+N -M`, summed from the same per-call counts the rows
   // underneath show, so the header can never disagree with what expanding it
   // reveals. Without this a run of edits collapses to "Edited 1 file · 4 calls"
@@ -81,15 +75,10 @@ export default function ToolGroupRow({
         {/* Styled as the turn summary is, not as a tool row: with the
             double-nesting rule this heads the turn's work where that summary
             otherwise would, so the two must read as the same kind of toggle.
-            A group can hold both a failure and a still-running call, and
-            pending wins — the shimmer's transparent fill would cancel the
-            destructive color and leave the text invisible. */}
-        <span
-          className={cn(
-            "shrink-0",
-            pending ? "shimmer-text" : failed && "text-destructive",
-          )}
-        >
+            A failing call inside does not color it: one error among a dozen
+            calls would paint the whole run as failed, and the row that failed
+            says so itself once the group is expanded. */}
+        <span className={cn("shrink-0", pending && "shimmer-text")}>
           {group.target
             ? groupVerb(group.name, pending)
             : groupLabel(group.name, group.targets, pending)}

--- a/apps/desktop/src/lib/tools.test.ts
+++ b/apps/desktop/src/lib/tools.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { isRoutineError } from "./tools";
+
+// Every string here is a real `Bash` error taken out of `~/.dray/sessions`,
+// including the "Exit code N" prefix a shell failure actually arrives with —
+// the patterns have to match inside that, not against a bare message.
+describe("isRoutineError", () => {
+  it("passes over a worktree isolation refusal", () => {
+    expect(
+      isRoutineError(
+        "This session is isolated in the worktree /Users/y/p/.claude/worktrees/ivory-gold-fjord, " +
+          "but this command is too complex to verify that it stays inside the worktree. " +
+          "Refusing to run it — a worktree-isolated session's git operations must target its own worktree.",
+      ),
+    ).toBe(true);
+  });
+
+  it("passes over a missing path, whatever spelled it", () => {
+    expect(isRoutineError("Exit code 1\n(eval):cd:1: no such file or directory: apps/desktop")).toBe(
+      true,
+    );
+    expect(
+      isRoutineError("Exit code 1\nsed: src/components/ChatInput.tsx: No such file or directory"),
+    ).toBe(true);
+    expect(isRoutineError("Exit code 2\nugrep: warning: src/App.tsx: No such file or directory")).toBe(
+      true,
+    );
+  });
+
+  it("passes over a glob that matched nothing", () => {
+    expect(isRoutineError("Exit code 1\n(eval):1: no matches found: *.tgz")).toBe(true);
+  });
+
+  it("passes over a binary that isn't there", () => {
+    expect(isRoutineError("Exit code 127\n(eval):1: command not found: claude")).toBe(true);
+  });
+
+  it("passes over a command the harness blocked", () => {
+    expect(isRoutineError("Blocked: sleep 60 followed by: gh pr view 7")).toBe(true);
+  });
+
+  it("still marks a real failure", () => {
+    expect(isRoutineError("Exit code 1\ntar: Option --one-top-level=dlg is not supported")).toBe(
+      false,
+    );
+    expect(
+      isRoutineError("Exit code 1\nTraceback (most recent call last):\n  File \"<string>\", line 1"),
+    ).toBe(false);
+    expect(isRoutineError("Exit code 1\n(eval):1: === not found")).toBe(false);
+  });
+
+  it("treats a call with no text as worth marking", () => {
+    expect(isRoutineError(undefined)).toBe(false);
+    expect(isRoutineError("")).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/tools.ts
+++ b/apps/desktop/src/lib/tools.ts
@@ -175,3 +175,33 @@ export function toolArgument(input: JsonValue): string | null {
     null
   );
 }
+
+// An errored call the reader never has to act on. Every one of these is the
+// agent probing — a path it guessed at, a binary it checked for, a command the
+// harness declined — and it recovers on the next call without anyone looking.
+// Measured over ten sessions of real logs: 38 of 45 failed `Bash` calls were
+// one of these five, so colouring on `isError` alone made red the transcript's
+// resting state and left nothing to mark the seven that mattered.
+//
+// Matched anywhere in the text, not anchored: a shell failure arrives as
+// "Exit code 1" with the message on the line under it. `Blocked:` is the
+// exception and is anchored per-line, because it opens the harness's own
+// refusal rather than appearing inside output.
+const ROUTINE_ERRORS = [
+  // A worktree-isolated session refusing a command it can't prove stays inside
+  // its own tree. Not a failure at all — the command never ran.
+  /is isolated in the worktree|too complex to verify that it stays inside the worktree/i,
+  /no such file or directory/i,
+  // zsh's own wording when a glob matches nothing, which is the same miss.
+  /no matches found:/i,
+  /command not found:/i,
+  /^Blocked:/m,
+];
+
+/// Whether a failed call's error is one the reader can safely ignore, so the
+/// row reports it without the alarm. The row still reads as failed — only the
+/// red goes.
+export function isRoutineError(text: string | undefined): boolean {
+  if (!text) return false;
+  return ROUTINE_ERRORS.some((pattern) => pattern.test(text));
+}


### PR DESCRIPTION
Red was the transcript's resting state. Two changes.

**Group header no longer reds.** `ToolGroupRow` marked "Ran 3 commands" destructive when any one call inside it errored — one failure among a dozen calls painted the whole run as failed. The failing row still colors itself once the group is expanded.

**Tool rows keep red for failures worth looking at.** New `isRoutineError` in `lib/tools.ts` passes over five classes:

1. Worktree isolation refusal — the command never ran
2. `no such file or directory`
3. `no matches found:` — zsh glob miss
4. `command not found:`
5. `Blocked: …` — harness declined the command

Rows still read as failed and still show `Error: <text>` when expanded; only the color and the `exit N` badge go quiet.

**Why these five.** Surveyed the last 10 sessions in `~/.dray/sessions`: 45 errored Bash calls, of which 38 were one of these — the agent probing a path or a binary and recovering on the next call. The other 7 (bad `tar` flag, python traceback, exit 8 from a `gh` pipeline) still mark red.

Tests use the real error strings from those logs, `Exit code N` prefix included, since the patterns have to match inside that rather than against a bare message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
