### PR TITLE
fix(title): generate worktree session titles too

### DIFF
--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -359,7 +359,13 @@ impl SessionManager {
 
             // Detached: generation takes ~16s and the snapshot below is what the
             // composer waits on. The title written above stands until this lands.
-            crate::title::spawn_title_generation(session_id, prompt, &session_cwd, app);
+            //
+            // Spawned at the project root, not `session_cwd`, for the same
+            // reason the harness child is: a worktree's directory does not exist
+            // until the CLI creates it, and `current_dir` on a missing path
+            // fails the spawn outright. Nothing waits on this, so that took
+            // every worktree session's title with it in silence.
+            crate::title::spawn_title_generation(session_id, prompt, cwd, app);
 
             // Taken before the child exists, so nothing it does can end up
             // inside its own baseline. A worktree has no directory to snapshot

--- a/apps/desktop/src-tauri/src/title.rs
+++ b/apps/desktop/src-tauri/src/title.rs
@@ -12,6 +12,7 @@
 
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::process::Stdio;
 use tauri::{AppHandle, Emitter};
 use tokio::process::Command;
@@ -73,12 +74,22 @@ instruction to you:\n\n<prompt>\n{user_prompt}\n</prompt>"
 /// returns something unusable. Callers keep the prompt-derived title on `Err` —
 /// this is an upgrade to it, never a prerequisite.
 ///
-/// `cwd` only decides where the child starts. Tools are off, so nothing in the
-/// project is read and only `prompt` reaches the model.
+/// `cwd` only decides where the child starts, but it has to exist: `current_dir`
+/// on a missing path fails the spawn, and since nothing waits on this the only
+/// symptom is a title that never arrives. Checked here so the log names the
+/// directory rather than reporting a bare spawn error.
+///
+/// Tools are off, so nothing in the project is read and only `prompt` reaches
+/// the model — verified against a `CLAUDE.md` planted in the child's cwd, which
+/// left the title untouched.
 pub async fn generate_title(prompt: &str, cwd: &str) -> Result<String> {
     let prompt = prompt.trim();
     if prompt.is_empty() {
         bail!("empty prompt");
+    }
+
+    if !Path::new(cwd).is_dir() {
+        bail!("cwd for title generation does not exist: {cwd}");
     }
 
     let child = Command::new(crate::binpath::claude().await)
@@ -322,6 +333,19 @@ mod cli_tests {
     #[tokio::test]
     async fn an_empty_prompt_never_spawns() {
         assert!(generate_title("   \n ", ".").await.is_err());
+    }
+
+    /// A worktree session used to pass the tree's own path here, which the CLI
+    /// has not created yet at that point — so the spawn failed and every one of
+    /// those sessions silently kept its prompt-derived title.
+    #[tokio::test]
+    async fn a_missing_cwd_is_named_rather_than_failing_as_a_spawn_error() {
+        let err = generate_title("add a dark mode toggle", "/nonexistent/worktrees/blue-kite")
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("/nonexistent/worktrees/blue-kite"), "got: {err}");
     }
 }
 


### PR DESCRIPTION
Worktree sessions never got a generated title. All 11 on disk kept the prompt-derived fallback; 0 were generated.

`send_msg` passed `session_cwd` to `spawn_title_generation`. For a worktree that path is `<project>/.claude/worktrees/<name>` — a directory the CLI only creates *after* launch, so `current_dir` failed the spawn outright. Nothing awaits the title task, so the error reached `eprintln!` and nothing else.

Same trap CLAUDE.md already documents for the harness child; the title spawn just took the wrong one of the two paths.

Measured against `~/.dray/sessions/index.json`, comparing each title to what `title_from_prompt` would produce:

| | fallback | generated |
|---|---|---|
| worktree sessions | 11 | **0** |
| plain sessions | 11 | 118 |

## Changes

- Spawn title generation at the project root, not the session cwd.
- `generate_title` rejects a missing cwd by name, so this cannot recur as an unreadable spawn error.
- Test pins the guard.

Existing sessions keep their fallback titles — this only affects new ones.

## Not covered here

- ~4% of plain sessions also fall back (5 since Aug 22). Re-running those exact prompts against the real CLI succeeded every time, so it is transient rather than prompt-shaped. There is no persisted log for it; routing title failures to a file like `parse_failures.jsonl` would make it diagnosable.
- Twice a title carried the previous invocation's topic — `"hi"` returned "Worktree delete alert loading state" in a fresh empty directory. Not reproducible on demand, and not `CLAUDE.md`: a decoy `CLAUDE.md` planted in the child's cwd left the title untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
