### PR TITLE
dray new --from: base a spawned session on existing work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,7 +487,19 @@ Hover-pause drop in `done` and have to: past that press no target left to protec
 
 **Row appear, and deliberately not selected.** User mid-conversation in session that spawned this one; yanking them out = opposite of what fanning out for. Listener sit in `[]` effect so it need `showArchivedRef`, same reason `selectedSessionIdRef` next to it exist.
 
-**Spawned session always take worktree, and no flag turn it off.** Three issue in one checkout overwrite each other, and changes panel already cannot tell two writer apart — so opt-out = footgun with no good use. `--no-worktree` existed and removed. **Name not caller's either** — `--worktree-name` and its proto field went the same way: agent have no basis for picking one, app already generate readable name, and supplied name = one more thing that collide. Cost already documented above: `-w` fork from `origin/<default>`, not from branch parent sit on, so fanning out from unpushed feature branch give children without parent's work.
+**Spawned session always take worktree, and no flag turn it off.** Three issue in one checkout overwrite each other, and changes panel already cannot tell two writer apart — so opt-out = footgun with no good use. `--no-worktree` existed and removed. **Name not caller's either** — `--worktree-name` and its proto field went the same way: agent have no basis for picking one, app already generate readable name, and supplied name = one more thing that collide.
+
+**`--from` move where tree start, not who own it.** `-w` fork from `origin/<default>` whatever checked out, so spawned session could not see work of session that spawned it — which put obvious use, *second model review what first just did*, out of reach. `--from <session-id | branch | ref>` answer it: still new worktree, based at that point. Sharing live checkout stay out of scope, and `--from` is not a way in.
+
+**Mechanism = Dray make tree itself.** `-w`'s flag surface expose no base ref (`worktree.baseRef` = settings key, not flag), so [create_worktree](apps/desktop/src-tauri/src/git.rs) run `git worktree add --no-track -B worktree-<name> <path> <base>` and child spawn **into** that directory with no `-w` at all — symmetric half of `remove_worktree` next to it. Falls out of that: tree exist before child do, so baseline = real `snapshot_tree` not `base_ref_tree`'s approximation; and tree carry no lock, since only CLI lock trees and only `-p` fail to release them.
+
+**Branch, never detached HEAD.** git refuse checking out branch another worktree hold, so `--from` cannot mean "same branch" — leaving detached-vs-new-branch as real choice. Detached suit session that only read, and cost four surfaces: PR tab look branch up, handoff row offer to push it, `remove_worktree` delete it, `sessionBranch` name it. So `--from` always mint same `worktree-<name>` branch `-w` would have, starting at given ref instead. No second flag. `-B` not `-b`, matching CLI: branch left behind by tree deleted outside Dray otherwise make that name fail forever, and `-B` cannot reach branch some worktree hold — exactly case where it somebody's live work.
+
+**Committed work only, and skill say so out loud.** Worktree at branch tip carry what was committed, not what author have open. Usually right for review; unsaid, it = reviewer reporting confidently on tree missing very change user looking at. Pinned by test, like `dray update` is.
+
+**Session id resolve through [`session_branch`](apps/desktop/src-tauri/src/store.rs), same reading `sessionBranch` in [pr.ts](apps/desktop/src/lib/pr.ts) take.** Two reader, neither can call other — PR tab need it in frontend, `--from` need it in Rust — so rule stated twice and tested twice against same four cases. What it must not become = two *different* rules: `--from` starting reviewer on one branch while header beside it name another = disagreement nothing on screen could explain. Id tried before ref, since id = address everywhere else in `dray` and v7 uuid = no branch name anybody type.
+
+**No version bump, and `Response::Created` carry resolved base for that reason.** Added optional field need none — but old app drop `from` in *silence*, start session off `origin/<default>`, and answer exactly as always, so reviewer find none of work it was spawned for. Absent `baseRef` = only evidence, and CLI turn it into sentence naming "update the app". Warned, not failed: session running either way, and non-zero exit read as "nothing happened" and earn second one.
 
 **`dray send` go both way, and that one command not two.** Child reporting summary up and parent handing child extra context = same operation, so no reply channel beside a send. Message arrive as ordinary prompt and *start a turn*, so it wake idle agent; target mid-turn queue it and CLI say so, since queued not failure. Unrestricted to parent/child pair on purpose — id = address, and naming relationship = one more rule to get wrong.
 
@@ -598,7 +610,9 @@ baseline because there no tree to snapshot. Name resolved against **project**,
 not against parent's own, so fork of fork can't collide with tree it came from.
 Item name that cost out loud: `claude -w` fork *tree* from `origin/<default>`,
 not from wherever session is, so copy carry whole conversation onto code that
-may not hold work it was about.
+may not hold work it was about. Cure now exist next door — `create_worktree` take
+base ref, and `send_msg` already spawn into tree it made — so this = wiring, not
+missing machinery. Wanted a base of parent's own branch tip; not done here.
 
 **Name resolved against index too, not disk alone.** `resolve_worktree_name` ask
 filesystem alone, and lazy fork open window that never had: fork's tree not exist

--- a/apps/cli/skill/SKILL.md
+++ b/apps/cli/skill/SKILL.md
@@ -44,6 +44,7 @@ Options:
 | `--model <alias>` | `opus`, `sonnet`, `fable`, `haiku`. Defaults to the current session's model. |
 | `--effort <level>` | `low`, `medium`, `high`, `xhigh`, `max`. Defaults to the current session's. |
 | `--harness <name>` | `claude_code`. Defaults to the current session's. |
+| `--from <session\|ref>` | Start the worktree on existing work instead of `origin/<default>`. |
 
 ### Each session gets its own worktree
 
@@ -51,9 +52,43 @@ Every session runs in its own git worktree on its own branch, and there is no wa
 to turn that off. It is what makes running them at once safe — without it, three
 agents write to one checkout and overwrite each other.
 
-One consequence worth knowing: the worktree branches from `origin/<default>`,
-**not** from the branch you are on. If your work is on a feature branch and is
-not pushed, the new session will not have it.
+By default the worktree branches from `origin/<default>`, **not** from the branch
+you are on. So a session created plainly cannot see unpushed work — yours or
+another session's.
+
+### Basing a session on existing work
+
+```bash
+dray new --from <session-id> "Review the work on this branch and report what you find"
+dray new --from feature/login "Write tests for the login flow on this branch"
+```
+
+`--from` takes a **session id** — the same id `dray ls` prints and `dray send`
+takes — or a branch, tag or commit. Naming a session is the usual case: you have
+its id already, and you do not have to know how Dray names its branches.
+
+This is what makes review possible. Spawn a session with a different model or a
+different harness, point it at yours with `--from`, and it gets its own checkout
+of the same commits — so it collides with nobody while it reads.
+
+Three things to know:
+
+- **Committed work only.** The new worktree starts at a commit. Anything the
+  other session has changed but not committed is *not* there. If you are asking
+  for a review of work in progress, commit it first — or say plainly in your
+  prompt what is missing, or the reviewer will report on a tree that lacks the
+  very change the user is looking at.
+- **A new branch, not a shared one.** The session gets its own
+  `worktree-<name>` branch starting at that commit. It never checks out the
+  branch you named, so it cannot commit onto your work or move it.
+- **Not a shared checkout.** There is no way to run two sessions in one
+  directory, and `--from` is not it. Two agents writing to one checkout overwrite
+  each other, and the changes panel cannot tell them apart.
+
+The line `dray new` prints says what it resolved: `Started "…" in worktree
+calm-owl, based on worktree-brisk-jade`. If it warns that `--from` was ignored,
+the app is older than the flag — tell the user, and treat the session as based on
+the default branch.
 
 ## Listing sessions
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -82,6 +82,12 @@ struct New {
     /// Which agent runs it. claude_code today.
     #[arg(long)]
     harness: Option<String>,
+
+    /// Base the new session's worktree on existing work: a session id, a
+    /// branch, or any git ref. Committed work only. Defaults to
+    /// origin/<default>.
+    #[arg(long, value_name = "SESSION|REF")]
+    from: Option<String>,
 }
 
 #[derive(Args)]
@@ -136,6 +142,8 @@ fn run() -> Result<(), String> {
 }
 
 fn new(args: New) -> Result<(), String> {
+    let asked_for_a_base = args.from.is_some();
+
     let request = Request::CreateSession(CreateSession {
         prompt: args.prompt,
         project_path: resolve_project(args.project),
@@ -143,21 +151,43 @@ fn new(args: New) -> Result<(), String> {
         effort: args.effort,
         harness: args.harness,
         parent_session_id: parent_session_id(),
+        from: args.from,
     });
 
     match send(request)? {
-        Response::Created { session } => {
+        Response::Created { session, base_ref } => {
             // The id alone on stdout, so `$(dray new …)` captures something
             // usable; everything a human wants goes to stderr beside it.
             println!("{}", session.session_id);
             eprintln!(
-                "Started \"{}\"{}",
+                "Started \"{}\"{}{}",
                 session.title,
                 match &session.worktree_name {
                     Some(name) => format!(" in worktree {name}"),
                     None => String::new(),
+                },
+                match &base_ref {
+                    Some(base) => format!(", based on {base}"),
+                    None => String::new(),
                 }
             );
+
+            // The one place a create can half-succeed. An app predating `--from`
+            // drops the field in silence, starts the session off
+            // `origin/<default>` and answers exactly as it always did — so a
+            // reviewer spawned to look at unpushed work would find none of it
+            // and report confidently on the wrong tree. The absent `baseRef` is
+            // the only evidence, and this turns it into a sentence.
+            //
+            // Said, not failed: the session is running either way, and exiting
+            // non-zero here reads as "nothing happened" and earns a second one.
+            if asked_for_a_base && base_ref.is_none() {
+                eprintln!(
+                    "warning: --from was ignored — this Dray app predates it, so the session \
+                     started from the default branch instead. Update the app, then delete this \
+                     session and try again."
+                );
+            }
             Ok(())
         }
         Response::Error { message } => Err(message),
@@ -509,6 +539,34 @@ mod tests {
     }
 
     #[test]
+    fn a_base_can_be_a_session_or_a_ref() {
+        // One flag for both, because the app is the only side that can tell
+        // them apart — it holds the index, and this does not.
+        for value in ["0198f0a2-1c5e-7000-8000-000000000000", "feature/login"] {
+            let cli = Cli::parse_from(["dray", "new", "review it", "--from", value]);
+            let Command::New(args) = cli.command else {
+                panic!("wrong subcommand");
+            };
+            assert_eq!(args.from.as_deref(), Some(value));
+        }
+
+        let cli = Cli::parse_from(["dray", "new", "x"]);
+        let Command::New(args) = cli.command else {
+            panic!("wrong subcommand");
+        };
+        assert_eq!(args.from, None);
+    }
+
+    /// The tree is still Dray's to make either way — `--from` moves where the
+    /// branch starts, and there is no flag for running in somebody else's
+    /// checkout.
+    #[test]
+    fn a_base_does_not_bring_back_a_way_into_someone_elses_tree() {
+        assert!(Cli::try_parse_from(["dray", "new", "x", "--in", "abc"]).is_err());
+        assert!(Cli::try_parse_from(["dray", "new", "x", "--detach"]).is_err());
+    }
+
+    #[test]
     fn an_explicit_project_beats_the_working_directory() {
         assert_eq!(
             resolve_project(Some(PathBuf::from("/x/proj"))).as_deref(),
@@ -530,6 +588,16 @@ mod tests {
         // The app tells a stale CLI to run this, so the skill has to say what
         // it is — that sentence is the whole self-heal path.
         assert!(SKILL.contains("dray update"));
+    }
+
+    /// A worktree carries what was committed, so a reviewer pointed at work in
+    /// progress reports on a tree missing the very change the user is looking
+    /// at. Nothing in the mechanism can fix that, which makes saying it part of
+    /// the feature rather than documentation around it.
+    #[test]
+    fn the_skill_says_a_base_carries_committed_work_only() {
+        assert!(SKILL.contains("--from"));
+        assert!(SKILL.contains("Committed work only"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/git.rs
+++ b/apps/desktop/src-tauri/src/git.rs
@@ -1283,16 +1283,13 @@ pub async fn worktree_disposition(worktree_path: &str, project_path: &str) -> Wo
         .map(|raw| count_changes(&raw))
         .unwrap_or(0);
 
+    let branch = current_branch(worktree_path).await;
+
     // `--exclude` applies to the *next* ref-enumerating option only, so this
     // drops the worktree's own branch from `--branches` while `--remotes` and
     // `--tags` stay whole — which is what lets a pushed branch read as safe.
     // The glob is relative to `refs/heads`, and spelling it in full silently
     // matches nothing, leaving every count at zero.
-    let branch = git(worktree_path, &["symbolic-ref", "--short", "-q", "HEAD"])
-        .await
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-
     let unpushed_commits = match &branch {
         Some(branch) => git(
             worktree_path,
@@ -1326,6 +1323,104 @@ pub async fn worktree_disposition(worktree_path: &str, project_path: &str) -> Wo
         unpushed_commits,
         locked_by,
     }
+}
+
+/// The branch `cwd` has checked out, or `None` for a detached HEAD, a
+/// directory that isn't a repo, and a repo whose branch is unborn.
+///
+/// `symbolic-ref` rather than `rev-parse --abbrev-ref`, which answers the
+/// literal string `HEAD` on a detached one — a branch name nothing can look up
+/// and everything downstream would treat as real.
+pub async fn current_branch(cwd: &str) -> Option<String> {
+    git(cwd, &["symbolic-ref", "--short", "-q", "HEAD"])
+        .await
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// The commit `base` names, or `None` when it names nothing in this repo.
+///
+/// `^{commit}` rather than a bare verify, so a tag or a tree-ish is either
+/// peeled to a commit or refused — `worktree add` wants a commit, and the
+/// failure it gives for anything else arrives after the tree is half made.
+pub async fn resolve_commit(cwd: &str, base: &str) -> Option<String> {
+    git(
+        cwd,
+        &[
+            "rev-parse",
+            "--verify",
+            "-q",
+            "--end-of-options",
+            &format!("{base}^{{commit}}"),
+        ],
+    )
+    .await
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+}
+
+/// Creates a worktree at `<project>/.claude/worktrees/<name>` on a new branch
+/// `worktree-<name>`, starting from `base`. Returns the path.
+///
+/// The symmetric half of [`remove_worktree`], and it exists because the harness
+/// cannot do this: `claude -w` resolves the repo's default branch, fetches
+/// `origin/<it>` and passes *that* to `git worktree add`, and its flag surface
+/// exposes no base ref at all. So a session that has to start from existing
+/// work is one Dray makes the tree for and then spawns the child *into*, with
+/// no `-w` at all.
+///
+/// **A branch, never a detached HEAD.** Detaching would suit a session that
+/// only reads, but every surface downstream reads a worktree session's branch
+/// off its name — the PR tab looks one up, the handoff row offers to push it,
+/// and the removal above deletes it — so a tree with no branch breaks four
+/// things to prevent a commit nobody was going to object to. Same name the CLI
+/// would have minted, so `--from` changes where the branch starts and nothing
+/// else about it.
+///
+/// `-B` rather than `-b`, matching the CLI: a branch left behind by a tree
+/// deleted outside Dray would otherwise make that name fail forever, since the
+/// name is what the branch is derived from. It cannot clobber live work — git
+/// refuses to reset a branch another worktree holds, which is exactly the case
+/// where somebody is using it.
+///
+/// Deliberately **not** locked. The CLI locks the trees it makes and a `-p` run
+/// never releases the lock, which is the whole reason removal has to unlock
+/// first; a tree made here has no such lock to leave behind.
+pub async fn create_worktree(project_path: &str, name: &str, base: &str) -> Result<String> {
+    let path = PathBuf::from(project_path)
+        .join(".claude")
+        .join("worktrees")
+        .join(name);
+
+    // Checked before the tree, not after: `worktree add` on an unresolvable
+    // start point leaves the branch and directory behind on some git versions,
+    // and this way the reader gets the ref they typed named back at them.
+    if resolve_commit(project_path, base).await.is_none() {
+        bail!("{base} is not a branch, tag or commit in this repository");
+    }
+
+    let path = path.to_string_lossy().into_owned();
+    let branch = format!("worktree-{name}");
+
+    // `--no-track` so the branch takes no upstream from the base. Without it a
+    // base that is a remote-tracking ref makes every later `git push` on this
+    // session's branch aim at the *base's* branch.
+    run(
+        project_path,
+        &[
+            "worktree",
+            "add",
+            "--no-track",
+            "-B",
+            &branch,
+            "--end-of-options",
+            &path,
+            base,
+        ],
+    )
+    .await?;
+
+    Ok(path)
 }
 
 /// Deletes a worktree directory and the branch it was checked out on.
@@ -1615,6 +1710,121 @@ mod tests {
         }
 
         path
+    }
+
+    /// The whole point of the function: the tree holds the commits of the ref
+    /// it was based on, not whatever the default branch is at. That is what
+    /// `claude -w` cannot be asked for.
+    #[tokio::test]
+    async fn creates_a_worktree_at_the_ref_it_was_given() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        // Work sitting on a branch nobody pushed — the case a reviewer spawned
+        // off `origin/<default>` would find nothing of.
+        run(at, &["checkout", "-q", "-b", "authors-work"]).await.unwrap();
+        fs::write(dir.join("feature.txt"), "the work\n").await.unwrap();
+        run(at, &["add", "-A"]).await.unwrap();
+        run(at, &["commit", "-qm", "the work"]).await.unwrap();
+        run(at, &["checkout", "-q", "-"]).await.unwrap();
+
+        let path = create_worktree(at, "reviewer", "authors-work")
+            .await
+            .expect("a branch that exists is a base");
+
+        assert!(
+            Path::new(&path).join("feature.txt").exists(),
+            "the base's own commits are missing from the tree"
+        );
+        // Its own branch, not the author's: git would refuse to check that one
+        // out twice, and a session that shares a branch can move it.
+        assert_eq!(
+            current_branch(&path).await.as_deref(),
+            Some("worktree-reviewer")
+        );
+        // `--no-track`, or every push from this session would aim at the base.
+        assert_eq!(
+            git(at, &["config", "--get", "branch.worktree-reviewer.merge"]).await,
+            None
+        );
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    /// Refused before anything is on disk, so a typo costs an error rather than
+    /// a half-made tree the reader has to clean up.
+    #[tokio::test]
+    async fn refuses_a_base_the_repo_cannot_resolve() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        let err = create_worktree(at, "nope", "no-such-branch")
+            .await
+            .expect_err("an unresolvable base is not a base");
+        assert!(err.to_string().contains("no-such-branch"), "unhelpful: {err}");
+
+        assert!(!dir.join(".claude").join("worktrees").join("nope").exists());
+        let branches = git(at, &["branch", "--list", "worktree-nope"]).await.unwrap();
+        assert!(branches.trim().is_empty(), "branch left behind: {branches}");
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    /// A commit is as good a base as a branch, and `resolve_commit` peels a
+    /// tag rather than handing `worktree add` something it will refuse late.
+    #[tokio::test]
+    async fn a_commit_and_a_tag_are_both_bases() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        let head = git(at, &["rev-parse", "HEAD"]).await.unwrap();
+        let head = head.trim();
+        run(at, &["tag", "v1"]).await.unwrap();
+
+        assert_eq!(resolve_commit(at, "v1").await.as_deref(), Some(head));
+        create_worktree(at, "at-a-commit", head)
+            .await
+            .expect("a commit is a base");
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    /// The name is what the branch is derived from, so a branch left behind by
+    /// a tree deleted outside Dray would make that name fail forever. `-B`
+    /// resets it — and cannot reach a branch some worktree still holds, which
+    /// is every case where the branch is somebody's live work.
+    #[tokio::test]
+    async fn a_leftover_branch_does_not_block_the_name() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        run(at, &["branch", "worktree-recycled"]).await.unwrap();
+        create_worktree(at, "recycled", "HEAD")
+            .await
+            .expect("a branch with no worktree behind it is ours to reset");
+
+        // And the live half: the same name a second time is git's refusal, not
+        // a silent second checkout.
+        let err = create_worktree(at, "recycled", "HEAD")
+            .await
+            .expect_err("a branch another worktree holds must not be reset");
+        assert!(err.to_string().contains("already used"), "unexpected: {err}");
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn a_detached_head_is_no_branch() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        assert!(current_branch(at).await.is_some());
+        run(at, &["checkout", "-q", "--detach", "HEAD"]).await.unwrap();
+        // `rev-parse --abbrev-ref` answers the literal string "HEAD" here,
+        // which is the wrong answer this reads around.
+        assert_eq!(current_branch(at).await, None);
+
+        fs::remove_dir_all(&dir).await.ok();
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/git.rs
+++ b/apps/desktop/src-tauri/src/git.rs
@@ -1813,6 +1813,38 @@ mod tests {
         fs::remove_dir_all(&dir).await.ok();
     }
 
+    /// `send_msg` undoes the tree when the index write that follows it fails,
+    /// because removal is offered from a session's own row and an orphan with
+    /// no row is one nothing in the app can reach. That rollback is this pair,
+    /// so the pair has to close: no directory, no branch, no registration.
+    #[tokio::test]
+    async fn a_created_worktree_is_removable_again() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        let path = create_worktree(at, "rolled-back", "HEAD").await.unwrap();
+
+        let deleted_branch = remove_worktree(at, &path, Some("worktree-rolled-back"))
+            .await
+            .expect("a tree we made a moment ago is ours to remove");
+
+        // Unlocked, so this needs none of the unlock dance a `-w` tree does —
+        // only the CLI locks trees, and only a `-p` run fails to release one.
+        assert!(deleted_branch, "the branch outlived its worktree");
+        assert!(!Path::new(&path).exists());
+
+        let list = git(at, &["worktree", "list", "--porcelain"]).await.unwrap();
+        assert!(!list.contains("rolled-back"), "registration left behind");
+
+        // And the name is free again, which is what makes the rollback complete
+        // rather than merely tidy.
+        create_worktree(at, "rolled-back", "HEAD")
+            .await
+            .expect("a rolled-back name must not be burned");
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
     #[tokio::test]
     async fn a_detached_head_is_no_branch() {
         let dir = scratch_repo().await;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -68,6 +68,10 @@ async fn send_msg(
             branch,
             use_worktree,
             worktree_name,
+            // The composer offers no base ref: a worktree session created there
+            // is one the reader is starting fresh, and the picker already hides
+            // the branch list in worktree mode because `-w` would not honour it.
+            None,
             is_new_session,
             // The composer never has a parent, and its prompts are the user's
             // own; only the orchestration socket sets either.

--- a/apps/desktop/src-tauri/src/orchestration.rs
+++ b/apps/desktop/src-tauri/src/orchestration.rs
@@ -245,6 +245,14 @@ async fn create_session(create: CreateSession, app: &AppHandle) -> Result<Respon
         .map(|p| p.permission_mode)
         .unwrap_or_else(ApprovalPolicy::default);
 
+    // Resolved before anything is written, so a `--from` naming a session or a
+    // ref that cannot be found costs an error rather than a session sitting in
+    // the sidebar on the wrong base.
+    let base_ref = match create.from.as_deref() {
+        Some(from) => Some(resolve_base(from, &project_path).await?),
+        None => None,
+    };
+
     let session_id = uuid::Uuid::now_v7().to_string();
     let manager = app.state::<SessionManager>();
 
@@ -267,6 +275,7 @@ async fn create_session(create: CreateSession, app: &AppHandle) -> Result<Respon
             // one, and a name that collides is a create that fails for a field
             // nobody wanted. `None` lets the app generate a readable one.
             None,
+            base_ref.as_deref(),
             true,
             create.parent_session_id.as_deref(),
             // The creating session is this one's *parent*, which the sidebar
@@ -287,7 +296,60 @@ async fn create_session(create: CreateSession, app: &AppHandle) -> Result<Respon
 
     Ok(Response::Created {
         session: summarize(item),
+        base_ref,
     })
+}
+
+/// What `--from` starts the new worktree at: a session id, a branch, or any
+/// other ref.
+///
+/// A session id is tried first, because it is the address everywhere else in
+/// `dray` — `ls` prints it, `send` takes it — and an agent holding one should
+/// not have to learn how Dray names branches to point at that session's work.
+/// A ref that happens to look like a session id is the only ambiguity, and a
+/// v7 UUID is not a branch name anybody types.
+///
+/// The session's branch comes from [`store::session_branch`], the one reading
+/// of that question, so this cannot start a reviewer on one branch while the
+/// author's header names another.
+///
+/// **Committed work only**, and nothing here can change that: a worktree at a
+/// branch tip carries what was committed and not what the author has open in
+/// their editor. Usually right for a review, and said plainly in the skill,
+/// because the failure is an agent reporting confidently on a tree that is
+/// missing the very change the user is looking at.
+async fn resolve_base(from: &str, project_path: &str) -> Result<String> {
+    if let Some(item) = store::get_session_index_item(from).await? {
+        // Read where the session actually runs, which is its worktree for a
+        // worktree session — `session_branch` outranks it for a relocated one,
+        // whose `cwd` is the shared project root.
+        let observed = crate::git::current_branch(&item.cwd).await;
+        let branch = store::session_branch(&item, observed.as_deref()).with_context(|| {
+            format!(
+                "session {from} is on no branch — a detached HEAD, or a directory that is not \
+                 a repository. Pass a branch or a commit instead."
+            )
+        })?;
+
+        // A session in another repo — or one whose branch has since been
+        // deleted — names a branch this one has never heard of. Said here
+        // rather than left to git, whose error names the branch without saying
+        // that a session was what asked for it.
+        if crate::git::resolve_commit(project_path, &branch).await.is_none() {
+            bail!(
+                "session {from} is on branch {branch}, which {project_path} does not have — \
+                 check the two are the same repository, and that the branch still exists"
+            );
+        }
+
+        return Ok(branch);
+    }
+
+    if crate::git::resolve_commit(project_path, from).await.is_some() {
+        return Ok(from.to_string());
+    }
+
+    bail!("{from} is neither a session id nor a branch, tag or commit in {project_path}")
 }
 
 async fn list_sessions(list: ListSessions) -> Result<Response> {
@@ -392,6 +454,7 @@ async fn send_message(send: SendMessage, app: &AppHandle) -> Result<Response> {
             &target.cwd,
             None,
             false,
+            None,
             None,
             false,
             None,

--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -352,6 +352,20 @@ impl SessionManager {
                 None => cwd.to_string(),
             };
 
+            // Read back rather than taken from the caller: the picker sends
+            // `None` when the user didn't touch it, and the repo is still on
+            // some branch worth recording. Non-repos report `None` and stay that
+            // way.
+            //
+            // Ahead of the worktree below, though it reads the project root and
+            // `worktree add` never moves that HEAD: it is one more fallible step
+            // that would otherwise sit inside the window the rollback has to
+            // cover, and the shortest window is the one least able to go wrong.
+            let branch = match branch {
+                Some(b) => Some(b.to_string()),
+                None => git::list_branches(cwd).await?.current,
+            };
+
             // A base ref is the one case Dray makes the tree itself. The harness
             // cannot be told where to fork from — `-w` resolves the default
             // branch and fetches `origin/<it>`, and its flag surface exposes no
@@ -360,10 +374,9 @@ impl SessionManager {
             // which would mean checking a ref out over whatever the reader has
             // in the project root.
             //
-            // Ahead of the index write, unlike the spawn below: a session whose
-            // process fails to start is still worth a row, since its transcript
-            // and its worktree exist, while a base git cannot resolve has left
-            // nothing behind at all and the caller is getting the error.
+            // Ahead of the index write, unlike the spawn below: a base git
+            // cannot resolve has left nothing behind at all and the caller is
+            // getting the error.
             let owned_worktree = match (base_ref, &worktree_name) {
                 (Some(base), Some(name)) => {
                     git::create_worktree(cwd, name, base).await?;
@@ -371,15 +384,6 @@ impl SessionManager {
                 }
                 (Some(_), None) => bail!("a base ref needs a worktree to check it out into"),
                 (None, _) => false,
-            };
-
-            // Read back rather than taken from the caller: the picker sends
-            // `None` when the user didn't touch it, and the repo is still on
-            // some branch worth recording. Non-repos report `None` and stay that
-            // way.
-            let branch = match branch {
-                Some(b) => Some(b.to_string()),
-                None => git::list_branches(cwd).await?.current,
             };
 
             // Indexed before the process spawns, so a session that fails to
@@ -397,7 +401,28 @@ impl SessionManager {
                 permission_mode,
                 parent_session_id,
             );
-            append_session_index_item(item.clone()).await?;
+
+            // The one failure that has to undo the tree, and the row that just
+            // failed to be written is exactly why: removal is offered from a
+            // session's own row, so an orphan here is one nothing in the app can
+            // ever reach and `git worktree remove` by hand is the only recovery.
+            // The spawn below is deliberately *not* covered — by then the row
+            // exists, and deleting the session already takes the tree with it.
+            //
+            // Only a tree Dray made. A `-w` one does not exist yet, and the
+            // failed create above left nothing to undo.
+            if let Err(e) = append_session_index_item(item.clone()).await {
+                if owned_worktree {
+                    // Logged, not propagated: the caller has to see what
+                    // actually failed, not how the tidy-up went.
+                    if let Err(undo) =
+                        git::remove_worktree(cwd, &session_cwd, item.branch.as_deref()).await
+                    {
+                        eprintln!("could not roll back {session_cwd}: {undo}");
+                    }
+                }
+                return Err(e);
+            }
 
             // Detached: generation takes ~16s and the snapshot below is what the
             // composer waits on. The title written above stands until this lands.

--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -320,6 +320,11 @@ impl SessionManager {
         branch: Option<&str>,
         use_worktree: bool,
         worktree_name: Option<&str>,
+        // Where the worktree starts from, already resolved to a git ref by the
+        // caller — the orchestration socket turns a session id into one, and
+        // nothing below here knows sessions. `None` is the ordinary case and
+        // hands the tree to `claude -w`, which forks it from `origin/<default>`.
+        base_ref: Option<&str>,
         is_new_session: bool,
         // Set only for a session created over the orchestration socket. The
         // composer never has one, and it is recorded rather than acted on —
@@ -345,6 +350,27 @@ impl SessionManager {
             let session_cwd = match &worktree_name {
                 Some(name) => worktree_path(cwd, name),
                 None => cwd.to_string(),
+            };
+
+            // A base ref is the one case Dray makes the tree itself. The harness
+            // cannot be told where to fork from — `-w` resolves the default
+            // branch and fetches `origin/<it>`, and its flag surface exposes no
+            // base at all — so the tree is created here and the child is spawned
+            // *into* it with no `-w`. Refused for a session with no worktree,
+            // which would mean checking a ref out over whatever the reader has
+            // in the project root.
+            //
+            // Ahead of the index write, unlike the spawn below: a session whose
+            // process fails to start is still worth a row, since its transcript
+            // and its worktree exist, while a base git cannot resolve has left
+            // nothing behind at all and the caller is getting the error.
+            let owned_worktree = match (base_ref, &worktree_name) {
+                (Some(base), Some(name)) => {
+                    git::create_worktree(cwd, name, base).await?;
+                    true
+                }
+                (Some(_), None) => bail!("a base ref needs a worktree to check it out into"),
+                (None, _) => false,
             };
 
             // Read back rather than taken from the caller: the picker sends
@@ -384,15 +410,26 @@ impl SessionManager {
             crate::title::spawn_title_generation(session_id, prompt, cwd, app);
 
             // Taken before the child exists, so nothing it does can end up
-            // inside its own baseline. A worktree has no directory to snapshot
-            // yet — the CLI creates the tree after launch — so that case
-            // resolves the fork point the tree will start from instead. Slightly
-            // approximate: the CLI fetches `origin/<default>` first, so an
-            // upstream commit landing in between would read as this turn's work.
-            let baseline = if worktree_name.is_some() {
-                git::base_ref_tree(cwd).await
+            // inside its own baseline. A worktree the CLI has yet to create has
+            // no directory to snapshot, so that case resolves the fork point the
+            // tree will start from instead — slightly approximate, since the CLI
+            // fetches `origin/<default>` first and an upstream commit landing in
+            // between would read as this turn's work. A tree created above has
+            // none of that: it is on disk and clean, so its snapshot is exact.
+            let baseline = match (owned_worktree, worktree_name.is_some()) {
+                (false, true) => git::base_ref_tree(cwd).await,
+                _ => git::snapshot_tree(&session_cwd).await,
+            };
+
+            // A tree we made is a directory that already exists and a checkout
+            // already on the right commit, so the child starts in it and is told
+            // nothing about worktrees at all. Every other creation spawns at the
+            // project root, because the directory `-w` is about to make cannot
+            // be `chdir`ed into before it exists.
+            let (spawn_cwd, spawn_worktree) = if owned_worktree {
+                (session_cwd.as_str(), None)
             } else {
-                git::snapshot_tree(&session_cwd).await
+                (cwd, worktree_name.as_deref())
             };
 
             let mut session = Session::init(
@@ -401,9 +438,9 @@ impl SessionManager {
                 &model_spec,
                 effort,
                 permission_mode,
-                cwd,
+                spawn_cwd,
                 &session_cwd,
-                worktree_name.as_deref(),
+                spawn_worktree,
                 is_new_session,
                 None,
                 app,

--- a/apps/desktop/src-tauri/src/store.rs
+++ b/apps/desktop/src-tauri/src/store.rs
@@ -391,6 +391,39 @@ pub async fn resolve_unclaimed_worktree_name(
     bail!("could not find an unused worktree name after 16 attempts")
 }
 
+/// The branch a session's work lands on — the reading `--from <session-id>`
+/// resolves through, and the same one `sessionBranch` in `pr.ts` takes.
+///
+/// One rule, stated twice because it has two readers and neither can call the
+/// other: the PR tab needs it in the frontend, and basing a worktree on another
+/// session's work needs it here. What it must not become is two *different*
+/// rules — a `--from` that starts a reviewer on one branch while the header
+/// beside it names another is a disagreement nothing on screen could explain.
+///
+/// `observed` is git's own reading of HEAD, and it wins wherever the session
+/// still has a checkout of its own: the recorded branch is a guess made at
+/// creation, and a checkout inside the tree moves HEAD without touching it.
+///
+/// `worktree_removed` is the one case it loses. A relocated session runs in the
+/// project root, a checkout shared with every other session and with the
+/// reader's own editor, so HEAD there answers "what is this checkout on" and
+/// never "where did this session's work land".
+///
+/// The guess itself is just `branch`, with no `worktree-<name>` rebuild beside
+/// it: [`SessionIndexItem::new`] and [`SessionIndexItem::fork`] both write that
+/// name into the field at creation, so the record already holds it. `pr.ts`
+/// rebuilds it because a frontend session object can predate that write.
+pub fn session_branch(item: &SessionIndexItem, observed: Option<&str>) -> Option<String> {
+    if item.worktree_removed {
+        return item.branch.clone();
+    }
+
+    observed
+        .filter(|b| !b.is_empty())
+        .map(str::to_string)
+        .or_else(|| item.branch.clone())
+}
+
 /// `claude -w <name>` places the tree here and names its branch
 /// `worktree-<name>` — both confirmed against the worktree fixtures.
 pub fn worktree_path(project_path: &str, name: &str) -> String {
@@ -1125,6 +1158,62 @@ mod tests {
         // A tree of its own, so HEAD in it is the honest answer again.
         let elsewhere = parent.fork("child", Some("bold-otter"));
         assert!(!elsewhere.worktree_removed);
+    }
+
+    /// The four cases `sessionBranch` in `pr.ts` is tested on, so `--from` and
+    /// the PR tab cannot come to disagree about which branch a session is on.
+    #[test]
+    fn a_sessions_branch_reads_the_same_way_the_pr_tab_reads_it() {
+        let worktree = SessionIndexItem::new(
+            "a",
+            Harness::ClaudeCode,
+            "/p/.claude/worktrees/calm-owl",
+            "/p",
+            Some("calm-owl"),
+            Some("main"),
+            "hi",
+            ModelId::Opus,
+            None,
+            ApprovalPolicy::Auto,
+            None,
+        );
+        // The name the CLI mints, which `new` already wrote into the field.
+        assert_eq!(
+            session_branch(&worktree, None).as_deref(),
+            Some("worktree-calm-owl")
+        );
+        // Git's own reading outranks the guess: anything checking out another
+        // branch inside the tree leaves the record describing one it left.
+        assert_eq!(
+            session_branch(&worktree, Some("fix/thing")).as_deref(),
+            Some("fix/thing")
+        );
+
+        let plain = SessionIndexItem::new(
+            "b",
+            Harness::ClaudeCode,
+            "/p",
+            "/p",
+            None,
+            Some("feature"),
+            "hi",
+            ModelId::Opus,
+            None,
+            ApprovalPolicy::Auto,
+            None,
+        );
+        assert_eq!(session_branch(&plain, None).as_deref(), Some("feature"));
+
+        // Relocated: `cwd` is the shared project root, so HEAD there answers
+        // what that checkout is on and never where this session's work landed.
+        let mut settled = worktree.clone();
+        settled.worktree_name = None;
+        settled.cwd = settled.project_path.clone();
+        settled.worktree_removed = true;
+        assert_eq!(
+            session_branch(&settled, Some("main")).as_deref(),
+            Some("worktree-calm-owl")
+        );
     }
 
     /// A fork is a copy, so it sits exactly where the original sits: beside its

--- a/crates/dray-proto/src/lib.rs
+++ b/crates/dray-proto/src/lib.rs
@@ -81,6 +81,15 @@ pub struct CreateSession {
     /// Absent for a call from the user's own terminal, which is ordinary.
     #[serde(default)]
     pub parent_session_id: Option<String>,
+    /// Where the new session's worktree starts from: a session id, a branch, or
+    /// any git ref. `None` is the ordinary case and means `origin/<default>`,
+    /// which is what the harness would have picked on its own.
+    ///
+    /// A session id is resolved to the branch that session's work lands on, and
+    /// that resolution is the app's — the CLI has no index to read and no
+    /// business learning how a session's branch is named.
+    #[serde(default)]
+    pub from: Option<String>,
 }
 
 /// A prompt sent into a session that already exists.
@@ -118,7 +127,17 @@ pub struct ListSessions {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum Response {
-    Created { session: SessionSummary },
+    Created {
+        session: SessionSummary,
+        /// What `from` resolved to, echoed back so the caller sees the commit
+        /// its session actually started at rather than the string it asked
+        /// with. `None` both for an ordinary create and — the case that
+        /// matters — for an app too old to know the field at all, which is how
+        /// the CLI catches a `--from` that was silently dropped instead of
+        /// honoured.
+        #[serde(default)]
+        base_ref: Option<String>,
+    },
     Listed { sessions: Vec<SessionSummary> },
     /// `queued` when the target had a turn in flight, so the prompt is held
     /// until it reaches a boundary rather than being dropped or interrupting.
@@ -224,6 +243,42 @@ mod tests {
         assert_eq!(create.model, None);
         assert_eq!(create.effort, None);
         assert_eq!(create.harness, None);
+        assert_eq!(create.from, None);
+    }
+
+    #[test]
+    fn a_base_travels_on_the_create() {
+        let line = serde_json::to_string(&Envelope::new(Request::CreateSession(CreateSession {
+            prompt: "review it".into(),
+            from: Some("worktree-calm-owl".into()),
+            ..Default::default()
+        })))
+        .unwrap();
+        assert!(line.contains(r#""from":"worktree-calm-owl""#));
+
+        let back: Envelope = serde_json::from_str(&line).unwrap();
+        let Request::CreateSession(create) = back.request else {
+            panic!("wrong variant");
+        };
+        assert_eq!(create.from.as_deref(), Some("worktree-calm-owl"));
+    }
+
+    /// An app predating `--from` answers a create with no `baseRef` at all, and
+    /// that absence is the only signal the CLI gets that the flag was dropped
+    /// rather than honoured — so it has to survive parsing rather than fail it.
+    #[test]
+    fn a_create_answered_without_a_base_still_parses() {
+        let response: Response = serde_json::from_str(
+            r#"{"status":"created","session":{"sessionId":"a","title":"t","cwd":"/p",
+                "projectPath":"/p","branch":null,"worktreeName":null,"status":"idle",
+                "modified":"now"}}"#,
+        )
+        .unwrap();
+
+        let Response::Created { base_ref, .. } = response else {
+            panic!("wrong variant");
+        };
+        assert_eq!(base_ref, None);
     }
 
     #[test]


### PR DESCRIPTION
## TLDR for human

- `dray new --from <session-id | branch | ref>` — a spawned session's worktree can now start on existing work instead of `origin/<default>`, which is what makes "have a second model review what the first just did" reachable.
- Dray creates the worktree itself (`git worktree add`) and spawns the child **into** it with no `-w`, since `claude -w`'s flag surface exposes no base ref. `git.rs` now owns both halves.
- Three calls DRA-43 asked me to make: a new `worktree-<name>` branch rather than a detached HEAD; committed work only, said out loud in the skill; and a session id resolved through the same reading `sessionBranch` takes.
- No protocol bump — instead `Response::Created` echoes the resolved base, so a new CLI meeting an old app can say `--from` was dropped rather than silently reviewing the wrong tree.

---

Fixes DRA-43.

## The problem

Every worktree Dray creates went through one line — `args.extend(["-w", name])`. `claude -w` resolves the repo default branch, fetches `origin/<it>`, and hands that to `git worktree add --no-track -B`. Its flag surface exposes no base ref at all (`worktree.baseRef` is a settings key, not a flag). So a session spawned by `dray new` could not see the work of the session that spawned it, and the obvious use was unreachable: a reviewer given a fresh tree off `origin/main` has nothing to review.

CLAUDE.md already recorded this as a known cost of `-w`. This says the cost is not acceptable.

## The mechanism

`git.rs` gained `create_worktree` — the symmetric half of the `remove_worktree` sitting next to it. It runs `git worktree add --no-track -B worktree-<name> <path> <base>`, and `send_msg` then spawns the child into that directory with **no `-w` at all**.

Two things fall out of Dray owning the creation:

- The tree exists before the child does, so the changes-panel baseline is a real `snapshot_tree` rather than `base_ref_tree`'s approximation. (`base_ref_tree` is still what the ordinary `-w` path uses, and still approximate for the documented reason.)
- The tree carries no lock. Only the CLI locks the trees it makes, and only a `-p` run fails to release the lock — which is the whole reason `remove_worktree` has to unlock first. A tree made here leaves nothing behind.

Deliberately **not** "run inside the existing worktree". Two agents in one checkout is the exact thing the mandatory-worktree rule exists to prevent, and the changes panel provably cannot attribute two writers. `--from` is not a way in; a test pins that no `--in` or `--detach` flag exists.

## The three points DRA-43 raised

**Detached HEAD vs. a new branch.** git refuses to check out a branch another worktree holds, and the author's session is holding it — so `--from` cannot mean "the same branch", which is what makes this a real choice. Decided: **always a new `worktree-<name>` branch**, the same name `-w` would have minted, starting at the given ref. No second flag.

Detaching suits a session that only reads, but it costs four surfaces that read a worktree session's branch off its name: the PR tab looks one up, the handoff row offers to push it, `remove_worktree` deletes it, `sessionBranch` names it. That is four things broken to prevent a commit nobody was going to object to.

`-B` rather than `-b`, matching the CLI: a branch left behind by a tree deleted outside Dray would otherwise make that name fail *forever*, since the branch name is derived from the worktree name. It cannot clobber live work — git refuses to reset a branch another worktree holds, which is exactly the case where somebody is using it. Both halves are pinned by a test.

**Committed work only.** A worktree at a branch tip carries what was committed, not what the author has open in their editor. Nothing in the mechanism can change that, which makes saying it part of the feature rather than documentation around it — an agent that does not know will report confidently on a tree missing the very change the user is looking at. It is in SKILL.md and pinned by a test, the same way `dray update` is.

**Resolving a session id.** Goes through `store::session_branch`, which is the reading `sessionBranch` in `pr.ts` takes, tested against the same four cases (worktree, plain, observed-HEAD-outranks-the-guess, relocated). The rule is stated twice because it has two readers and neither can call the other — the PR tab needs it in the frontend, `--from` needs it in Rust. What it must not become is two *different* rules: a `--from` that starts a reviewer on one branch while the header beside it names another is a disagreement nothing on screen could explain.

The id is tried before the ref, because the id is the address everywhere else in `dray` — `ls` prints it, `send` takes it — and a v7 UUID is not a branch name anybody types.

## One judgment call worth review

I did **not** bump `PROTOCOL_VERSION`. The rule in the proto crate says an added optional field needs no bump, and bumping would refuse every existing CLI for every command to protect one flag.

But the failure it would have caught is real: an old app drops `from` in silence, starts the session off `origin/<default>`, and answers exactly as it always did — so a reviewer spawned to look at unpushed work finds none of it. So `Response::Created` now echoes the resolved base back, and its absence is the evidence the CLI turns into a sentence naming "update the app".

Warned rather than failed: the session is running either way, and a non-zero exit reads as "nothing happened" and earns a second session.

## Scope

DRA-44 is blocked on this and is **not** implemented here. Its half is reachable — `create_worktree` takes a base ref and `send_msg` already spawns into a tree it made — so "Fork in new worktree" basing a fork on its parent's branch tip is wiring, not missing machinery. CLAUDE.md records that.

## Tests

- 286 Rust (`cargo test`, bare — filtered runs rewrite the generated TS), 17 CLI, 9 proto, 196 frontend. All pass.
- New: `create_worktree` puts the base's own commits in the tree and the session on its own branch with no upstream; an unresolvable base is refused before anything reaches disk; a commit and a tag both work as bases; a leftover branch is recycled but a live one is refused; a detached HEAD reads as no branch; `session_branch` matches `sessionBranch`'s four cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
