### PR TITLE
fix(chat): break long tokens in the transcript

### DIFF
--- a/apps/desktop/src/components/chat/EventRow.tsx
+++ b/apps/desktop/src/components/chat/EventRow.tsx
@@ -36,7 +36,7 @@ function Notice({
           the line's top edge while its glyph sits inset within that box, so it
           reads high against the first line of text. */}
       <Icon className={cn("size-3.5 shrink-0", wrap && "mt-1")} />
-      <span className={wrap ? "min-w-0" : "truncate"}>{children}</span>
+      <span className={wrap ? "min-w-0 wrap-anywhere" : "truncate"}>{children}</span>
     </p>
   );
 }
@@ -107,7 +107,7 @@ export default function EventRow({
       return (
         <div className="flex items-start gap-2 text-chat text-destructive">
           <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
-          <span className="min-w-0 whitespace-pre-wrap">{payload.message}</span>
+          <span className="min-w-0 whitespace-pre-wrap wrap-anywhere">{payload.message}</span>
         </div>
       );
 

--- a/apps/desktop/src/components/chat/Markdown.tsx
+++ b/apps/desktop/src/components/chat/Markdown.tsx
@@ -141,6 +141,18 @@ function MarkdownImpl({ children, streaming = false, className }: MarkdownProps)
         // opposite the middle of a paragraph beside it.
         "[&_td]:align-top",
 
+        // Prose has the defect the table cells above had, one level out: a bare
+        // path in a sentence has no break opportunity, so it runs past the
+        // column and scrolls the whole transcript sideways. Streamdown already
+        // carries `wrap-anywhere` on links, so only what it leaves plain is
+        // named here — element by element rather than on the container, since
+        // `overflow-wrap` inherits and a code block is meant to scroll its
+        // lines rather than break them.
+        "[&_p]:wrap-anywhere [&_li]:wrap-anywhere [&_blockquote]:wrap-anywhere",
+        "[&_h1]:wrap-anywhere [&_h2]:wrap-anywhere [&_h3]:wrap-anywhere",
+        "[&_h4]:wrap-anywhere [&_h5]:wrap-anywhere [&_h6]:wrap-anywhere",
+        "[&_[data-streamdown=inline-code]]:wrap-anywhere",
+
         // Streamdown sets its own vertical rhythm; strip the leading and
         // trailing margin so a message sits flush in the transcript's gap.
         "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",

--- a/apps/desktop/src/components/chat/QueuedMessages.tsx
+++ b/apps/desktop/src/components/chat/QueuedMessages.tsx
@@ -20,7 +20,8 @@ export default function QueuedMessages({ messages }: { messages: QueuedMessage[]
       {messages.map((message, i) => (
         <div key={message.id} className="flex w-full flex-col items-end gap-1">
           <div className="max-w-[85%] rounded-xl bg-card px-3 py-2 text-chat text-card-foreground opacity-55">
-            <span className="whitespace-pre-wrap">
+            {/* Same bubble, same break rule — see `UserMessage`. */}
+            <span className="whitespace-pre-wrap wrap-anywhere">
               {highlightSegments(message.text).map((segment, s) => {
                 if (segment.kind === "mention") {
                   const { dir, name } = splitMention(segment.text);

--- a/apps/desktop/src/components/chat/Reasoning.tsx
+++ b/apps/desktop/src/components/chat/Reasoning.tsx
@@ -53,7 +53,7 @@ export default function Reasoning({
           )}
         </button>
 
-        <p className="mt-1 whitespace-pre-wrap text-chat text-muted-foreground italic">
+        <p className="mt-1 whitespace-pre-wrap wrap-anywhere text-chat text-muted-foreground italic">
           {shown}
         </p>
       </div>
@@ -77,7 +77,7 @@ export default function Reasoning({
       </button>
 
       {open && (
-        <p className="mt-1 whitespace-pre-wrap text-chat text-muted-foreground italic">
+        <p className="mt-1 whitespace-pre-wrap wrap-anywhere text-chat text-muted-foreground italic">
           {trimmed}
         </p>
       )}

--- a/apps/desktop/src/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/components/chat/UserMessage.tsx
@@ -72,7 +72,14 @@ export default function UserMessage({
 
       {text && (
         <div className="max-w-[85%] rounded-xl bg-card px-3 py-2 text-card-foreground">
-          <span className="text-chat whitespace-pre-wrap">
+          {/* `wrap-anywhere` because a pasted path or URL has no whitespace to
+              wrap at, and the bubble's `max-w` caps the box and not what is
+              drawn in it — so the glyphs run out over the transcript's own
+              background and set the scroll width of the whole column, moving
+              every other message sideways. Anywhere rather than `break-words`:
+              only `anywhere` shrinks min-content width, which is the part that
+              sets that scroll width. */}
+          <span className="text-chat whitespace-pre-wrap wrap-anywhere">
             {/* Plain runs concatenate back to `text` exactly, so the spacing the
                 user typed survives — nothing here is rebuilt from a parse.
                 A mention is the one run drawn shorter than it was sent: the


### PR DESCRIPTION
A pasted path or URL has no whitespace to wrap at, and the user bubble's `max-w` caps the box rather than what is drawn in it — so the glyphs ran out over the transcript's own background and set the scroll width of the whole column, moving every other message sideways.

`wrap-anywhere` on the text span, next to `whitespace-pre-wrap`. Anywhere rather than `break-words`: only `anywhere` shrinks min-content width, which is the part that sets that scroll width. Same rule `Markdown.tsx` already carries on `th`/`td`.

Swept the rest of the transcript for the same defect — every surface drawing arbitrary text with no scroll or truncate of its own:

- **UserMessage** — the reported bubble.
- **QueuedMessages** — same bubble, same user text, a moment early.
- **EventRow** — the error row, and the wrapping-row variant, where `min-w-0` shrank the box but left the text with no break point.
- **Reasoning** — both thinking paragraphs.
- **Markdown** — `p` / `li` / `blockquote` / `h1`–`h6` / inline code. Named element by element rather than set on the container, since `overflow-wrap` inherits and a code block is meant to scroll its lines, not break them. Streamdown already carries the rule on links.

Tool rows, the `from` attribution row and the missing-image row already `truncate`; every `<pre>` already has its own `overflow-x-auto`, so those are contained.

Verified by `tsc && vite build`, `pnpm test` (200 pass), and by checking each rule emits real CSS in the bundle — not by eye in a live session.

Fixes DRA-46

🤖 Generated with [Claude Code](https://claude.com/claude-code)