### PR TITLE
fix(orchestration): give the dev build its own socket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,12 @@ Hover-pause drop in `done` and have to: past that press no target left to protec
 
 **Unix socket, not HTTP port.** `~/.dray/dray.sock` — nothing on network reach it at all, no port to pick, collide on, or accidentally expose. Stale socket unlinked at bind: socket file outlive process that made it, so crash leave one behind and bind fail "address in use".
 
+**Dev build listen on `dray-dev.sock`, and that what make unlinking safe.** One path for both build mean whichever start last own channel: `bind` unlink other's socket, so release app left behind keep listener no `dray` ever reach again, and reader have to quit and restart it — every time they run `pnpm tauri dev`, which while building this app = all day. Silent both way, since neither app read socket it no longer own. `tauri::is_dev()` pick name (`dray_proto::socket_path`), same call notification path already branch on.
+
+**Child get `DRAY_ENDPOINT` injected, not left to CLI's default.** CLI resolve release socket, rightly — `dray` typed in terminal mean app reader installed — so dev app's own agent would file its session into release app's sidebar. Endpoint = one value already ([above](#orchestration)), so this = one `.env` beside `DRAY_SESSION_ID` and nothing above it change.
+
+Two build now run side by side and **share `~/.dray`** — same index, same session logs. `INDEX_LOCK` = in-process mutex, so cross-process write = last-writer-wins on whole file. Not split, deliberately: separate dev store hide exactly session reader testing against. Live with it or split store, don't add file lock for it.
+
 **Boundary = directory's `0700`, not socket's `0600`.** `bind` apply process umask, so socket land world-writable under permissive one and stay that way until chmod run moment later — window another local account connect through and reach session creation unauthenticated. Measured: umask 022 give 0755, umask 000 give 0777. Directory cannot have that window, since connecting need search permission on every dir in path — so `0700` settle it *before socket exist*. Socket's own `0600` stay as second line, not only one.
 
 **`~/.dray` narrowed in `get_home_app_dir`, and that fix privacy bug too.** It was `0755`, so every transcript — holding whole files agent read and wrote — readable by any local account.

--- a/apps/desktop/src-tauri/src/harness/claude_code/claude_code.rs
+++ b/apps/desktop/src-tauri/src/harness/claude_code/claude_code.rs
@@ -150,7 +150,17 @@ pub async fn init(
 
     // Resolved rather than spawned by bare name: a bundled `.app` launched from
     // Finder inherits launchd's `PATH`, which holds no `claude`.
-    let mut child = Command::new(crate::binpath::claude().await)
+    let mut command = Command::new(crate::binpath::claude().await);
+
+    // Which app the agent's own `dray` calls reach. Set because dev and release
+    // builds listen on different sockets and the CLI's default names the
+    // release one — without this a dev session's agent would file its work into
+    // the release app's sidebar.
+    if let Some(endpoint) = crate::orchestration::child_endpoint() {
+        command.env("DRAY_ENDPOINT", endpoint);
+    }
+
+    let mut child = command
         .args(args)
         .current_dir(cwd)
         // How the CLI knows which session is calling it, which is what links a

--- a/apps/desktop/src-tauri/src/orchestration.rs
+++ b/apps/desktop/src-tauri/src/orchestration.rs
@@ -7,7 +7,8 @@
 //! itself goes through [`SessionManager::send_msg`], the same function the
 //! composer reaches, so a session created here is not a second kind of session.
 //!
-//! Newline-delimited JSON over a unix socket at `~/.dray/dray.sock`, one
+//! Newline-delimited JSON over a unix socket at `~/.dray/dray.sock` — or
+//! `dray-dev.sock` for a dev build, see [`socket_path`] — one
 //! request per connection. Nothing on the network can reach it at all, and
 //! access control is the containing directory's `0700` — see
 //! [`serve`](serve) for why the socket's own mode cannot be the boundary.
@@ -51,13 +52,34 @@ const MAX_DEPTH: usize = 2;
 /// insurance: a cycle here would hang the caller's turn rather than fail it.
 const MAX_WALK: usize = 64;
 
+/// The socket this build listens on: `dray-dev.sock` under `pnpm tauri dev`,
+/// `dray.sock` otherwise.
+///
+/// Split by build because the release app is normally running while this one is
+/// being developed, and one path between them means whichever started last owns
+/// the channel — `bind` unlinks the other's socket, so the app left behind
+/// keeps a listener no `dray` will ever reach again.
+pub fn socket_path() -> Option<std::path::PathBuf> {
+    dray_proto::socket_path(tauri::is_dev())
+}
+
+/// What a spawned agent's `DRAY_ENDPOINT` is set to.
+///
+/// Injected rather than left to the CLI's own default, so a session started by
+/// the dev app reaches the dev app. Without it every `dray` call inside a dev
+/// session would go to the release app's socket and create sessions in the
+/// wrong sidebar.
+pub fn child_endpoint() -> Option<String> {
+    socket_path().map(|path| path.to_string_lossy().into_owned())
+}
+
 /// Binds the socket and serves it for the life of the process.
 ///
 /// Errors are logged and swallowed by the caller: orchestration is a side
 /// channel, and an app that refuses to start because a socket is in use would
 /// be trading the whole product for a feature.
 pub async fn serve(app: AppHandle) -> Result<()> {
-    let path = dray_proto::default_socket_path().context("could not resolve the socket path")?;
+    let path = socket_path().context("could not resolve the socket path")?;
 
     // Creates `~/.dray` and narrows it to `0700`, which is what actually
     // guards this socket. `bind` applies the process umask, so under a
@@ -93,9 +115,10 @@ pub async fn serve(app: AppHandle) -> Result<()> {
 
     // A socket file outlives the process that made it — a crash or a SIGKILL
     // leaves one behind, and binding onto it fails with "address in use". The
-    // file is not a lock and holds nothing, so removing it is safe: a *live*
-    // Dray would still hold the second instance off, because two processes
-    // cannot both have the app's single-instance state anyway.
+    // file is not a lock and holds nothing, so removing it is safe *because
+    // this path names one build*: unlinking can only ever take the channel from
+    // another copy of the same build, never from the release app a dev one is
+    // running beside.
     tokio::fs::remove_file(&path).await.ok();
 
     let listener = UnixListener::bind(&path)

--- a/crates/dray-proto/src/lib.rs
+++ b/crates/dray-proto/src/lib.rs
@@ -39,6 +39,16 @@ pub const PROTOCOL_VERSION: u32 = 2;
 /// Where the app listens, unless [`endpoint`] is overridden.
 pub const SOCKET_NAME: &str = "dray.sock";
 
+/// Where a `pnpm tauri dev` build listens instead.
+///
+/// One name per build, because the socket is a single file: a dev app binding
+/// the release app's path unlinks it and takes the channel over, so from then
+/// on every `dray` call reaches the dev app and the release app's own agents
+/// write into a socket nothing is listening on. Restarting the release app
+/// takes it back the same way. Two names let the two run side by side, which
+/// is the ordinary state while developing this app.
+pub const SOCKET_NAME_DEV: &str = "dray-dev.sock";
+
 /// A line longer than this is refused unread. The socket is `0600`, so this is
 /// hygiene rather than a threat model — but a length-prefixed-by-newline
 /// protocol with no cap is one malformed writer away from an allocation the
@@ -222,7 +232,17 @@ pub fn endpoint() -> Option<String> {
 /// agrees with the app's own `get_home_app_dir`, which is what creates the
 /// directory this sits in.
 pub fn default_socket_path() -> Option<PathBuf> {
-    Some(dirs::home_dir()?.join(".dray").join(SOCKET_NAME))
+    socket_path(false)
+}
+
+/// The socket one build of the app listens on.
+///
+/// The CLI never asks for the dev one: `dray` typed in a terminal means the app
+/// the reader installed, and a dev app hands its own children `DRAY_ENDPOINT`
+/// rather than leaving them to guess which build spawned them.
+pub fn socket_path(dev: bool) -> Option<PathBuf> {
+    let name = if dev { SOCKET_NAME_DEV } else { SOCKET_NAME };
+    Some(dirs::home_dir()?.join(".dray").join(name))
 }
 
 /// One request or response as it goes on the wire. Newline-delimited JSON, the
@@ -372,6 +392,14 @@ mod tests {
         let line = encode_line(&Response::error("nope")).unwrap();
         assert!(line.ends_with('\n'));
         assert_eq!(line.matches('\n').count(), 1);
+    }
+
+    #[test]
+    fn dev_and_release_sockets_are_different_files() {
+        // The whole point: a dev app must not be able to unlink the socket the
+        // installed app is serving on.
+        assert_ne!(socket_path(true), socket_path(false));
+        assert_eq!(socket_path(false), default_socket_path());
     }
 
     #[test]


### PR DESCRIPTION
Both builds bound `~/.dray/dray.sock`, and `serve` unlinks a stale socket before binding — so starting `pnpm tauri dev` took the channel from the running release app. Every `dray` call from then on reached the dev app, and the release app kept a listener nothing would ever connect to. Silent both ways, and the only cure was quitting and restarting the release app on every dev run.

Dev now listens on `dray-dev.sock`, picked by `tauri::is_dev()` — the same call the notification path already branches on. Release keeps `dray.sock`.

Spawned children get `DRAY_ENDPOINT` injected, so a dev session's agent reaches the dev app rather than filing its work into the release app's sidebar. The CLI's own default still names the release socket, which is right for `dray` typed in a terminal.

Known consequence, left alone: the two builds now run side by side and share `~/.dray`, so index writes are last-writer-wins across processes. A separate dev store would hide the sessions being tested against.

Fixes DRA-51

🤖 Generated with [Claude Code](https://claude.com/claude-code)