### PR TITLE
Pick a free dev port instead of failing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,9 @@ cd apps/desktop && pnpm tauri dev
 
 That = real entry point — build and run Rust app, start Vite via `beforeDevCommand`. `pnpm tauri` = shim ([scripts/tauri.mjs](apps/desktop/scripts/tauri.mjs)) merging `tauri.dev.conf.json` into `dev` subcommand only, so dev app carry own name and icon and `build` untouched. Tauri CLI merge extra config only when named on command line, and pick up no dev-flavoured config on own — hence shim, not config convention.
 
-- `pnpm dev` — frontend only, port 1420 (`strictPort: true`, so busy port = hard failure). `invoke` do nothing in plain browser, so only useful for pure-CSS/layout work.
+**Shim also pick dev port, and it only side that can.** Vite and Tauri have to agree on one, and both start from here — so shim probe upward from 1420, hand winner to Vite as `DRAY_DEV_PORT` and to Tauri as second `--config` carrying `build.devUrl`. Merged in order, so port land over dev flavour. Busy 1420 was hard failure before, which = one worktree's dev build refusing to start because another's already running — ordinary case with several session open. `strictPort: true` **stay** on Vite side and should: port already known free, and Vite wandering off it leave Tauri loading URL nothing serve. Probe bind wildcard not `localhost`, since server holding only `[::1]` leave `127.0.0.1` free and one-family probe answer "yes" for port dev server then fail to take.
+
+- `pnpm dev` — frontend only, port 1420 unless `DRAY_DEV_PORT` say otherwise (`strictPort: true`, so busy port = hard failure — nothing picking port for it here). `invoke` do nothing in plain browser, so only useful for pure-CSS/layout work.
 - `pnpm build` — `tsc && vite build`. `pnpm tauri build` for bundled app.
 - `cd apps/desktop/src-tauri && cargo test` — Rust tests (253: parser + mapper + event-model compatibility, plus git and file index). Single test: `cargo test parses_complex_fixture`.
 - `cd apps/desktop/src-tauri && cargo check` — fast type check, no linking whole app.

--- a/apps/desktop/scripts/tauri.mjs
+++ b/apps/desktop/scripts/tauri.mjs
@@ -2,14 +2,82 @@
 // `pnpm tauri` shim. The Tauri CLI merges an extra config only when it is named
 // on the command line, and the name has to be per-subcommand — so `dev` gets the
 // dev flavour (its own product name and icon) while `build` stays untouched.
+//
+// It also picks the dev server's port, because Vite and Tauri have to agree on
+// one and only this side can choose it before either starts.
 import { spawn } from "node:child_process";
+import { createConnection } from "node:net";
 
-const args = process.argv.slice(2);
-if (args[0] === "dev" && !args.some((a) => a === "-c" || a === "--config")) {
-  args.push("--config", "src-tauri/tauri.dev.conf.json");
+const BASE_PORT = 1420;
+const PORT_TRIES = 20;
+
+/// Whether anything is already listening on `host:port`.
+///
+/// Asked by dialling it rather than by trying to bind it. Binding is the obvious
+/// probe and it lies here: Node sets `SO_REUSEADDR`, so a wildcard bind succeeds
+/// against a port a server already holds on one address — which reported 1420
+/// free while Vite was listening on `[::1]:1420`, and handed back the very port
+/// that had just failed.
+function inUse(port, host) {
+  return new Promise((resolve) => {
+    const probe = createConnection({ port, host });
+    const done = (answer) => {
+      probe.destroy();
+      resolve(answer);
+    };
+    probe.setTimeout(300);
+    probe.once("connect", () => done(true));
+    probe.once("timeout", () => done(true));
+    // Refused is the one answer that means nobody is there. Anything else —
+    // unreachable family, no route — says nothing about the port, and skipping
+    // it costs one number out of twenty.
+    probe.once("error", (err) => done(err.code !== "ECONNREFUSED"));
+  });
 }
 
-const child = spawn("tauri", args, { stdio: "inherit" });
+/// Whether nothing holds `port` on either loopback family.
+///
+/// Both asked, because Vite binds `localhost` and which family that resolves to
+/// is not ours to assume — a server on `[::1]` leaves `127.0.0.1` free, and a
+/// probe of one family alone answers "yes" for a port Vite would then fail on.
+async function isFree(port) {
+  return !(await inUse(port, "127.0.0.1")) && !(await inUse(port, "::1"));
+}
+
+/// The first free port at or above [`BASE_PORT`].
+///
+/// A busy 1420 used to be a hard failure, which is one worktree's dev build
+/// refusing to start because another's is already running — the ordinary case
+/// with several sessions open, and nothing about it is worth stopping for.
+/// `strictPort` on the Vite side still holds and still should: this chooses the
+/// port up front, where that stops Vite wandering onto a different one than
+/// Tauri was told to load.
+async function pickPort() {
+  for (let port = BASE_PORT; port < BASE_PORT + PORT_TRIES; port++) {
+    if (await isFree(port)) return port;
+  }
+  throw new Error(
+    `no free port in ${BASE_PORT}..${BASE_PORT + PORT_TRIES - 1} for the dev server`,
+  );
+}
+
+const args = process.argv.slice(2);
+const env = { ...process.env };
+
+if (args[0] === "dev" && !args.some((a) => a === "-c" || a === "--config")) {
+  const port = await pickPort();
+  // Read by `vite.config.ts` for the server it starts, and handed to Tauri as
+  // the URL it loads. Both from this one value, so they cannot disagree.
+  env.DRAY_DEV_PORT = String(port);
+  if (port !== BASE_PORT) {
+    console.log(`  Info Port ${BASE_PORT} is taken; using ${port} for the dev server`);
+  }
+  // Merged in order, so the port lands over whatever the dev flavour says.
+  args.push("--config", "src-tauri/tauri.dev.conf.json");
+  args.push("--config", JSON.stringify({ build: { devUrl: `http://localhost:${port}` } }));
+}
+
+const child = spawn("tauri", args, { stdio: "inherit", env });
 child.on("exit", (code, signal) => {
   if (signal) process.kill(process.pid, signal);
   process.exit(code ?? 1);

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -6,6 +6,9 @@ import tailwindcss from "@tailwindcss/vite";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+// Set by `scripts/tauri.mjs`, which is the only place that can know the port
+// before either server starts. Absent under a bare `pnpm dev`.
+const devPort = Number(process.env.DRAY_DEV_PORT) || 1420;
 
 const url = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
@@ -63,16 +66,22 @@ export default defineConfig(async () => ({
   //
   // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
-  // 2. tauri expects a fixed port, fail if that port is not available
+  // 2. tauri and vite have to agree on one port, so `scripts/tauri.mjs` picks a
+  //    free one and hands it to both — this side through the env, tauri's own
+  //    through `build.devUrl`. `strictPort` stays: the port is already known to
+  //    be free, and letting Vite move off it would leave Tauri loading a URL
+  //    nothing is serving. 1420 is only the fallback for `pnpm dev` on its own.
   server: {
-    port: 1420,
+    port: devPort,
     strictPort: true,
     host: host || false,
     hmr: host
       ? {
           protocol: "ws",
           host,
-          port: 1421,
+          // Alongside the server's own, so a second dev build's HMR socket
+          // doesn't land on the first one's page.
+          port: devPort + 1,
         }
       : undefined,
     watch: {


### PR DESCRIPTION
A busy 1420 was a hard failure, which is one worktree's dev build refusing to start because another's is already running — the ordinary case with several sessions open, and nothing about it worth stopping for.

`scripts/tauri.mjs` now probes upward from 1420 and hands the winner to both sides: to Vite through `DRAY_DEV_PORT`, and to Tauri as a second `--config` carrying `build.devUrl`. One value, so the two cannot disagree about which port the app loads.

```
  Info Port 1420 is taken; using 1421 for the dev server
  ➜  Local:   http://localhost:1421/
```

### Two things worth knowing

**`strictPort: true` stays on the Vite side, and should.** The port is already known free by the time Vite sees it, and letting Vite wander onto another one would leave Tauri loading a URL nothing serves. The shim chooses; Vite obeys.

**The port is probed by dialling it, not by binding it.** Binding is the obvious check and it lies here: Node sets `SO_REUSEADDR`, so a wildcard bind succeeds against a port a server already holds on one address. The first version of this reported 1420 free while Vite was listening on `[::1]:1420` and handed back the very port that had just failed. Both loopback families are asked, since Vite binds `localhost` and which family that resolves to is not ours to assume.

`ECONNREFUSED` is the one answer that means nobody is there — anything else says nothing about the port, and skipping it costs one number out of twenty.

### Scope

- A bare `pnpm dev` is unchanged: nothing picks a port for it, so it still takes 1420 and still fails hard if that is busy.
- HMR's port follows the server's, so a second dev build's HMR socket can't land on the first one's page.
- `CLAUDE.md` documented the old hard failure; updated.

Housekeeping, so no Linear issue — this changes how we work, not what ships.

Verified live: with another worktree holding 1420, this came up on 1421 and the app launched against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)