### PR TITLE
Dev badge: sidebar bottom, muted, named by branch

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -27,7 +27,6 @@ import RightPanel, {
   type PanelTab,
 } from "@/components/RightPanel";
 import Sidebar, {
-  DevBadge,
   SidebarToggle,
   filterSessions,
   sortSessions,
@@ -647,8 +646,11 @@ function App() {
                 fullscreen ? "-ml-1" : "pl-(--traffic-lights-w)",
               )}
             >
+              {/* No dev badge beside it: the badge lives at the sidebar's
+                  bottom edge now and shows nothing while the sidebar is
+                  collapsed, the same bargain `UpdateRow` makes — neither is
+                  urgent enough to earn a second home in this header. */}
               <SidebarToggle onToggle={toggleSidebar} collapsed />
-              {import.meta.env.DEV && <DevBadge className="ml-1" />}
             </div>
           )}
 

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -444,19 +444,38 @@ export function SettingsButton({ onOpen }: { onOpen: () => void }) {
   );
 }
 
-/// Marks a dev build so it can't be mistaken for the installed app. Gated on
-/// `import.meta.env.DEV`, which Vite folds to a constant — the badge and this
-/// component are dropped from a production bundle entirely.
-export function DevBadge({ className }: { className?: string }) {
+/// What the dev badge says for a given branch.
+///
+/// On `main` it stays bare: that is the common case, and naming the default
+/// branch is a word the reader skips every time to reach the one that matters.
+/// A worktree's branch is already `worktree-<name>`, so the prefix goes and the
+/// badge names the tree the way the sidebar and `dray ls` do — stripped after
+/// the `main` test, or a tree named `main` would read as no branch at all.
+export function devBadgeLabel(branch: string | null): string {
+  if (branch === null || branch === "" || branch === "main") return "Dev";
+  return `Dev · ${branch.replace(/^worktree-/, "")}`;
+}
+
+/// Marks a dev build so it can't be mistaken for the installed app, and names
+/// the checkout it runs from — with several worktrees open, two dev builds are
+/// otherwise identical.
+///
+/// Gated on `import.meta.env.DEV`, which Vite folds to a constant, so this
+/// component and the branch it reads both drop out of a production bundle.
+///
+/// Muted, and at the sidebar's bottom edge: it marks the build rather than
+/// offering anything to act on, so it belongs with the standing information and
+/// not beside the app's name, and the orange it wore made the corner's quietest
+/// fact its loudest. One line — a long branch truncates rather than pushing the
+/// row, with `title` restoring it.
+export function DevBadge() {
   return (
-    <span
-      className={cn(
-        "rounded bg-orange-500/15 px-1.5 py-0.5 font-mono text-[10px] leading-none font-medium tracking-wide text-orange-500 uppercase",
-        className,
-      )}
+    <div
+      title={__DEV_BRANCH__ ?? undefined}
+      className="shrink-0 truncate px-3.5 pb-2 font-mono text-[10px] leading-none text-muted-foreground/60"
     >
-      Dev
-    </span>
+      {devBadgeLabel(__DEV_BRANCH__)}
+    </div>
   );
 }
 
@@ -551,7 +570,6 @@ export default function Sidebar({
         )}
         data-tauri-drag-region="deep"
       >
-        {import.meta.env.DEV && <DevBadge className="mr-auto" />}
         {/* The toggle holds the strip's outer edge in both layouts and settings
             sit inboard of it, so the one control also drawn in the app header
             never changes which end of the row it is at. */}
@@ -770,6 +788,10 @@ export default function Sidebar({
         manual={updateManual}
         onInstall={onInstallUpdate}
       />
+
+      {/* Under the update row, and last in the column: both are standing
+          information, and this is the half nobody is waiting on. */}
+      {import.meta.env.DEV && <DevBadge />}
     </aside>
   );
 }

--- a/apps/desktop/src/lib/devBadge.test.ts
+++ b/apps/desktop/src/lib/devBadge.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { devBadgeLabel } from "@/components/Sidebar";
+
+describe("devBadgeLabel", () => {
+  it("names the branch", () => {
+    expect(devBadgeLabel("dra-56-pinned-group")).toBe("Dev · dra-56-pinned-group");
+  });
+
+  it("stays bare on main", () => {
+    expect(devBadgeLabel("main")).toBe("Dev");
+  });
+
+  it("stays bare with no branch to name", () => {
+    expect(devBadgeLabel(null)).toBe("Dev");
+    expect(devBadgeLabel("")).toBe("Dev");
+  });
+
+  it("drops a worktree branch's prefix", () => {
+    expect(devBadgeLabel("worktree-gentle-denim-fjord")).toBe(
+      "Dev · gentle-denim-fjord",
+    );
+  });
+
+  // The `main` test reads the branch, not the name left after stripping, so a
+  // worktree called `main` still says which tree it is.
+  it("keeps a worktree named main", () => {
+    expect(devBadgeLabel("worktree-main")).toBe("Dev · main");
+  });
+});

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+/// The branch the dev server was started on, read once at config load in
+/// `vite.config.ts` and folded to a constant by `define` — so the dev badge
+/// that reads it costs a production bundle nothing. `null` outside a repository
+/// and on a detached HEAD.
+declare const __DEV_BRANCH__: string | null;

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { cpSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { configDefaults, defineConfig, type Plugin } from "vitest/config";
@@ -41,9 +42,35 @@ function fileIcons(): Plugin {
   return { name: "dray-file-icons", buildStart: stage };
 }
 
+/// The branch this dev server was started on, for the dev badge to name.
+///
+/// Read here rather than over the Tauri bridge so `define` can fold it to a
+/// constant and it drops out of a production bundle with the badge that reads
+/// it — same reason the icon staging above runs at config load, one build step
+/// and no runtime spawn. The cost is that it is fixed when the server starts,
+/// so switching branches under a running `pnpm tauri dev` leaves the badge
+/// stale until restart.
+///
+/// `null` outside a repository, and for a detached HEAD, where git answers
+/// with the word `HEAD` rather than a name.
+function devBranch(): string | null {
+  try {
+    const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd: url("."),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return branch === "" || branch === "HEAD" ? null : branch;
+  } catch {
+    return null;
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react(), tailwindcss(), fileIcons()],
+
+  define: { __DEV_BRANCH__: JSON.stringify(devBranch()) },
 
   resolve: {
     alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },


### PR DESCRIPTION
## TLDR for human

- Dev badge moved out of the sidebar header to the sidebar's bottom edge, under `UpdateRow`, muted to `text-muted-foreground/60`.
- It now reads `Dev · <branch>` — bare on `main`, and a worktree's `worktree-<name>` shown as `<name>`.
- Branch read once by `vite.config.ts` at config load and `define`d as a constant, so it folds out of a production bundle with the badge. No Tauri command, no runtime spawn.
- The second copy in the app header (drawn while the sidebar is collapsed) is gone — see below.

---

`DevBadge` said `Dev` and no more, in orange, beside the app's name. With
several worktrees open two dev builds look identical, and the badge was the
loudest thing in the corner for a fact nobody checks twice.

**Where the value comes from.** `git rev-parse --abbrev-ref HEAD`, run at config
load in `vite.config.ts` — the same place the file-icon staging runs, and for
the same reason — handed to the app as `__DEV_BRANCH__` through `define`. It is
a constant, so it folds away with `import.meta.env.DEV` and neither the badge
nor the branch string reaches a production bundle (checked: the branch name does
not appear in `dist`). `null` outside a repository and on a detached HEAD, where
git answers with the word `HEAD` rather than a name.

Cost, worth naming: the value is fixed when the dev server starts, so switching
branches under a running `pnpm tauri dev` leaves it stale until restart.

**Label rule** is `devBadgeLabel`, pure and tested. `main` stays bare; the
`worktree-` prefix is stripped *after* the `main` test, so a worktree named
`main` still reads `Dev · main` rather than looking like no branch at all.

**One judgment call not in the issue.** `DevBadge` had a second call site in
`App.tsx`, drawn in the app header while the sidebar is collapsed. That home is
the one the issue moves the badge away from, so it is removed rather than left
pointing at the old placement — the same bargain `UpdateRow` already makes
("show nothing while the sidebar is collapsed... not urgent enough to earn a
second home in the header"), and the dev badge is the quieter of the two. So a
collapsed sidebar now marks the build nowhere; say the word if you want it back.

`pnpm test` (243) and `pnpm build` pass. `sessionGroups` and the search row
untouched.

Fixes DRA-59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
