### PR TITLE
Linear issue tracker integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,6 +391,160 @@ If it come back: commit = `add -A -- <paths>` then `commit -m … -- <paths>`, b
 
 **Selected file derived, never stored.** `find(path) ?? files[0]` — file that stop being changed can't leave pane pointing at nothing, and first-by-position right here where turn panel refuse it: diff have own pane, so opening one hide nothing.
 
+## Issues
+
+**Surface say "issue", implementation say Linear, and only one row say both.** Vocabulary live in [issues/issues.rs](apps/desktop/src-tauri/src/issues/issues.rs), wire in [linear.rs](apps/desktop/src-tauri/src/issues/linear.rs). Second tracker = module plus variant on `IssueTracker`, not rename of every panel — which why `IssueRef` carry tracker even while there one. Word "Linear" reach reader in exactly two place: connect form, where it name what key being asked for, and failure Linear itself caused.
+
+**Connection workspace-wide, no project ↔ team mapping.** Repo bound to nothing; picker and page read what connected user assigned. Mapping = thing to add when it earn itself, not thing to guess at now.
+
+**Key live in `~/.dray/credentials.json` at `0600`, account cache in `settings.json`.** Two read together: credentials say whether key exist, settings say whose it is, and cached account with no key behind it read as **disconnected** — key *is* connection.
+
+**Keychain tried first and retreated from, deliberately.** macOS tie grant to exact binary that asked, so every rebuild = new application to ACL and grant never stick — authorization dialog several times an hour on any machine where app being *built*. Signing with stable Developer ID settle it for shipped build and do nothing for anyone working on app. Cost of retreat worth stating: key readable by anything running as user, where keychain entry not. What make it tolerable = company it keep — `~/.dray` already `0700` and hold every transcript, which = every file agent read or wrote on this machine. Read-only tracker key not most sensitive thing in that directory by wide margin, and `gh`/`npm`/`aws` make same trade.
+
+**Own file, not field on `settings.json`, for two reason that both bite.** Settings rewritten by every analytics toggle and read on launch path where parse failure fall back to defaults — which would silently *forget* key. And `get_settings` hand that struct to frontend, which credential must never ride along with.
+
+**Mode set on temp file before anything written into it**, not on final one after rename: `fs::write` create at process umask, so setting it afterward leave window where key sit world-readable. Narrow, avoidable for one call, and pinned by test — failure silent otherwise, since world-readable key behave identically in every other respect.
+
+Personal API key not OAuth, deliberately: Linear OAuth want client secret, secret want server to hold it, so that = drayhq.com work. Key path want neither. Connect form = where OAuth button land if that change.
+
+**Connect live on issues page, disconnect in settings, and split not arbitrary.** Page = surface with nothing to show without key, so field that fix it belong there and empty state *is* form. Settings row draw only when something connected — row offering to connect thing reader never seen = row they cannot judge, and second form = second place for one slot. Two error sentence that name cure therefore point at page, never at dialog.
+
+**Disconnect ask first**, arming confirm that replace button — same shape sidebar's delete and PR panel's merge use. Key not recoverable from here: taking it back mean finding Linear's own settings page and minting new one, which = long way to be sent by button pressed on way to somewhere else.
+
+**Linear's mark drawn in exactly two place**, connect heading and settings row ([LinearIcon](apps/desktop/src/components/LinearIcon.tsx)) — same two place word "Linear" reach reader, and for same reason. `currentColor` not brand purple: both sit in row of muted chrome, and single saturated logo = loudest thing on surface whose job is to be quiet.
+
+**Validated before saved.** Key stored untried = one reader find out about next time they open picker, by which point they left form and failure look like feature broken. `verify` also answer identity, which what row draw.
+
+**Write to either side forget every cached issue.** `useIntegrations`' `connect`/`disconnect` call `forgetIssues()`, and it correctness not speed: every cached answer was read with old key, `not_connected` failure page's empty state drawn from included — so without it, connecting leave reader looking at form they just filled in.
+
+**Tag carry title itself, and that why there no block underneath.** `#DRA-53 Add issue tracker integration` = whole shape, everywhere: picked from composer's `#` menu, typed by hand, or appended by CLI's `--issue` (`tag_text` in Rust, `issueTag` in [issue.ts](apps/desktop/src/lib/issue.ts), pinned both side). Title being *in text* = what make feature cheap — model read it, transcript paint it, and composer's overlay stay in register with textarea underneath because nothing painted that isn't really there.
+
+First version appended "Linked issues" block after prompt and stripped it back off bubble. Both gone: block restated what tag already say, and strip = pattern match that fail silently the day block get reworded.
+
+Description still not injected, and that separate call: agent have tracker's own MCP server and fetch what it want in shape it want, where description pasted in = wall of text at top of every prompt, stale moment somebody edit issue, and paid for again on every follow-up. Session may be started against three issue at once, so three tag beat three paragraph.
+
+**Resolution best effort, always.** Unreachable Linear, revoked key, tag naming issue that not exist — all leave tag as text, record no link, say nothing. Send must never fail because issue tracker down: that make tracker dependency of typing.
+
+**One tagging rule per side of bridge.** Everything app send tag in prompt *text* — composer picker being only route — so `send_msg` command pass empty issue list always. CLI's `--issue` = other caller and name them outright, because flag not prose. Both merge inside `expand_tags`, deduplicated, and named-not-in-text one get their `#ID Title` appended so both caller end at same shape.
+
+**`dray issue link` write down what it given and ask tracker nothing.** Link = local record — this session about that work — so making it need reachable Linear and stored key meant it could fail for reason nothing to do with what it record. Caller = agent that just read issue through tracker's own MCP, so it hold title and url already; asking second system for what caller have in hand = round trip whose only contribution = way to fail. Hence `IssueInput { identifier, title?, url? }` on wire, and `--title`/`--url` on CLI.
+
+Absent metadata = **ordinary, not error**: bare identifier still usable link. `tag_text` drop trailing space (`#DRA-53`), `issueUrl` read empty url as none so tag stay text rather than button opening nowhere. Both stated twice — Rust and [issue.ts](apps/desktop/src/lib/issue.ts) — same reason every other tag rule is.
+
+**`--title` and `--url` describe one issue, so several identifier + either = refusal.** Applying one title to all, or silently to first, = wrong link reading exactly like right one.
+
+**Resolution still live, on other route.** `expand_tags` run in *app* on send and do read Linear, because `#DRA-53` in prose carry no title with it. So two route: prose resolved, CLI blind. `issues::link` and `link_issue` command existed as third route nothing took and were removed with it.
+
+**v4 = `LinkIssues.identifiers` → `issues`.** Field renamed not extended, so two shape cannot be confused on wire: old app handed new one find no `identifiers` and refuse, which = loud failure wanted here.
+
+**Tag shape stated twice and tested twice.** Rust `issue_tags`/`parse_identifier` decide what get *linked*; [issue.ts](apps/desktop/src/lib/issue.ts)'s `parseIdentifier` and `highlightSegments` decide what get *painted*. Neither can call other — one run before prompt sent, one after — so rule = team key plus number, `#` must open word, and bracketing punctuation (`(#DRA-53)`) count as opening it. Drift show as word coloured like address that link nothing, or reverse. `#fff` and markdown heading both stay prose, both direction pinned.
+
+**Composer's placeholder name `#` only while connected.** Unconnected reader offered tag they cannot use learn app missing feature rather than that they haven't set one up. Picker itself need no such gate — it simply find nothing.
+
+**Every user-facing string collected in [COPY-ISSUES.md](apps/desktop/COPY-ISSUES.md)**, grouped by surface with reason beside each. Reword there and here together, or doc become second copy free to disagree with screen.
+
+**Tag in sent bubble = button, and link come from event not from text.** `issueUrl` look identifier up in `user_message.issues`, so what open = url tracker itself gave at send time. Tag whose issue never resolved — unreachable tracker, identifier that don't exist — stay coloured text rather than becoming link to nowhere. Tooltip name host off that url (`Open DRA-53 in linear.app`), so self-hosted tracker name itself.
+
+**Upload live *in* description, and drawn there — not listed beside it.** Linear put both in description's markdown: image as `![](…)`, file as `[name](…)`, both pointing at `uploads.linear.app`. So there no attachment list to build — override `img` and `a` on that one `Markdown` and leave everything else exactly as it was, since ordinary link in issue = ordinary link and rewriting it take app's own link dialog off it.
+
+**Upload sit behind same auth API do, which why webview cannot fetch either.** `<img src>` resolve to 401 and browser draw its own broken box — reading as "Dray cannot show this" rather than "this need key". `fetch_issue_asset` put key on that request and hand back `data:` URL; only then is there something `src` can point at. `csp: null` in tauri.conf, so `data:` need no scope entry.
+
+**Host checked exactly, and that not defensive.** Description = text somebody else wrote, and it name URL this fetch get handed — so without check, issue could name any host and have app post credential to it. Compared on **parsed host**, never prefix: `uploads.linear.app.evil.test` pass `starts_with` and is not Linear. Stated twice (Rust `is_upload` decide where key go, [IssuePanel](apps/desktop/src/components/IssuePanel.tsx)'s copy decide what get drawn as asset), pinned on Rust side.
+
+**Image open full size in transcript's own lightbox.** Earn its place here more than there: pane = third of window, so screenshot of screen unreadable at only width it can be given. **One image per lightbox**, not description's whole set — these spread through prose rather than gathered in row, so there no set arrow would step through.
+
+**Image render as image, everything else as file card.** Card = icon, name, size, download glyph on hover — whole row = control, so glyph = hint about what click do not second target. Fallback one direction only: anything webview won't draw (unknown format, SVG, failed fetch) *become* card, since file somebody can download beat grey box. `onError` = second net under mime check, because mime can say `image/svg+xml` and still not render.
+
+**Size capped before body read.** `content_length` checked first so oversized file refused rather than read into memory then rejected — same reading `cat-file --batch-check` exist for on git side; arrived length capped again, for server that send none. Asset cached per URL across mount, `null` included: description re-render on every keystroke in search box, and each would otherwise re-download every screenshot in it.
+
+**Panel read Linear's API with stored key. MCP nowhere near it.** Two channel answering two question and they never touch: key fill *this app's* screens (description, attachment, comment, status), MCP let *agent* read same issue in its own turn. That why connect form say MCP out loud — reader who set up one and not other otherwise find out from model working off one-line title.
+
+**Panel row order = priority, identifier, status, title.** Same left-to-right issues page read in, so two surface scan alike. Priority lead because it one fixed-width mark and ragged left edge read as disorder; title last since it only part giving way to truncation. Priority drawn even before detail land (`none`), so row don't reflow when read arrive.
+
+**Issues pane say "Details" where tab row would be (`heading`).** One thing in it and nothing to switch to, so row of one tab = control that cannot do anything and keycap beside it name chord stepping between one place and itself — but *empty* strip worse than either, reading as chrome that failed to load. So row keep height, lose control, say what pane is. Strip cannot simply collapse: it what clear titlebar, and without it pane's first row sit level with traffic lights on far side.
+
+**And it lose its bottom rule.** That line separate row of *controls* from what they act on; over heading belonging to thing underneath it, it cut title off own body.
+
+**⌘E only ever close there.** Nothing for it to reopen — row = what pick issue — so toggle that could open have to guess which one, and last pick rarely one wanted on way back. Closing = half with unambiguous meaning.
+
+**Guard live on chord, not only on `handleTogglePanel`.** ⌘E bind **raw** `togglePanel` deliberately — `handleTogglePanel` pick tab on way open, right for button reader aimed at and wrong for chord that draw nothing. So guard put in that function alone = button honour it while chord sail past into pane not on screen. Same for ⌘1/⌘2: view tab row not drawn there, so switching invisible tab look like nothing happening then show up as wrong view on way back.
+
+**Panel tab = `issue`, drawn immediately before Subagents, hidden with no link.** Rows drawn from session's own `IssueRef`s, so tab exist moment prompt tag one and need no read to wait on; detail (description, status, comments) fetched per identifier and fill in. Description drawn here where PR panel deliberately leave PR body out, and difference = who wrote it: PR body = reader's own text restating diff beside it, issue description = somebody else's and whole reason tab exist.
+
+**MCP = one sentence in connect form, and no check anywhere.** Key fill *Dray's* screens and give agent nothing; agent reading issue in full, or moving one, want Linear's MCP server. Said in empty state where somebody already setting this up, linked to Linear's own docs, and said **once**.
+
+Live check existed and was removed. `mcp.rs` ran `claude mcp list`, cached per directory 5 min, and drew notice in issue panel — wrong place twice over: reader open that panel to read *issue*, not audit own tooling, and by time session tagged the moment to say it long past. Cost was better part of ten second per uncached read, for line that belong in setup. Whole module deleted; `git log` hold it if health check ever earn a surface of its own.
+
+**Right pane hidden while page up, and preference kept.** `panelShown = panelOpen && !issuesOpen` — two different question, and folding them = bug: page fill main column, so pane left open beside it went on describing session reader had *left*, with nothing on screen saying whose changes and whose PR those were. Everything that draw or read read `panelShown`; `panelOpen` stay standing preference, so coming back restore pane as it was. ⌘E no-op there too — toggling thing not on screen flip preference reader cannot see effect of.
+
+**Header name page while it up.** `SessionHeader` take `standIn`, and `App` pass `"Issues"`: page fill main column but = not session and never become one, so header otherwise sit at "New session" over list of issues — naming thing reader not looking at.
+
+**Issues page = sidebar row under New task, main column view.** Not session, so opening it **keep selection** — session reader was in still there coming back, and page hidden not unmounted so its filters and scroll survive trip. Sidebar's *highlight* still go though (`selectedSessionId={issuesOpen ? null : …}`): column showing issues, so lit row name session nowhere on screen. Two different question, and folding them cost trip back. Row drawn whether or not tracker connected: page's own empty state = where connecting offered, and row that appear only after you found settings dialog can only be found by people who not need it.
+
+**Page read, and clicking row open it in pane beside list.** Row opened tracker in browser first, and that = trip taken for something app already had: pane draw description, people, attachment and conversation off *same key* list was read with. Linear stay one click away — pane's own row carry button — but it second thing offered, not first. Dray still write to tracker nowhere at all: no status move, no comment, no attachment, and skill say so out loud, because agent assuming otherwise tell user their issue moved when nothing of sort happened.
+
+**Pane describe whatever main column show, and that one rule cover both case.** Session on screen → session's panel; issues page → picked issue. Same `RightPanel` frame, one tab, `onTabChange` no-op — second panel component = second set of chrome to keep in step. Also *why* session's pane hidden on that page: left up it went on describing changes and PR belonging to work reader had left.
+
+**Picked issue held as whole row, not identifier.** List already read every field header draw, so pane complete before own detail read land — same bargain session panel make with session's links. `useSessionIssues` serve both, since a page pick = one-element link list.
+
+**Toggle drawn only once something open to close.** Nothing on that page can *open* pane — row do that — so toggle at rest = control with one dead state. ⌘E close pick for same reason, and ⌘R follow session rule: pane win where open, list otherwise.
+
+**No Start button, and removing it was the fix not the gap.** It create session, so it must name project — and page workspace-wide, so button either guess which repo work belong in or grow picker of own beside every row. Tagging with `#` in composer already start work against issue, from place that know which project it in.
+
+**Two chip, everything else behind one control.** Assigned / Created = two question worth one press: what mine to do, what did I ask for. Team and project narrow *within* whichever chip on, so they sit in menu — more control across header = more thing to read past on every visit to change none of them. Team or project list with **one entry not offered at all**, and menu with neither **hidden outright**: filter whose only option = one you already have = control that cannot do anything, and this solo tool often pointed at single team. Trigger lit while anything on, so list narrowed on previous visit say so rather than read as empty workspace.
+
+**Settled half = second read, asked for only on expand.** Done and Cancelled header always drawn and always start closed; opening either fire one `list_issues` with `settled: true`. `IssueQuery.settled` = which *half* to read, not flag widening single read — backend answer complement (`state.type` `in` vs `nin`), so page never pull whole workspace back to fill two group it drew collapsed. No load-more: one capped page, and cap named rather than paged. Header carry **no count until loaded** — zero there = claim, not blank, hence `loaded` on hook separate from `issues.length`. Priority sort skipped on that half: priority on closed issue = fact about decision already taken, and sorting by it bury thing that just landed.
+
+**Grouped by state *kind*, not by state name.** Name = per-team prose ("Shipping", "In Review", "Icebox"), so grouping on it turn list spanning three team into dozen heading for what really same few state. Kind = fixed six-way vocabulary, which what make grouping stable across whole workspace. Order = In Progress, Triage, Todo, Backlog, Done, Cancelled, Other — order work move through, which also order attention should reach it in. Order *within* bucket left exactly as arrived, since backend already sorted by priority and re-sorting = second opinion on same question.
+
+**Search bar carry no fill and no border, glyph instead.** It one control always in same place, so it need no edge to be found — and filled field above borderless list draw box round least interesting third of page. Magnifier do work border was doing: say "type here" without enclosing anything. Override need **`dark:bg-transparent` as well as `bg-transparent`** — base `Input` carry `dark:bg-input/30`, more specific rule, which win; plain override therefore read as removed in source while fill still on screen.
+
+**Refresh sit far right, not among chip, and ⌘R reach it.** It act on whole page where chip narrow it, so in that row it read as third chip. Chord = same one right panel use and `App` pick between them (`issuesOpen` win, since page = what reader looking at). Page hand its `refresh` up through ref not state: handle re-made every hook run, and state there = render of whole app per keystroke in search box.
+
+**Group gap = hair, not band.** Two collapsed header a row apart read as adrift, and `mb-4` between them left more space than either header occupy. Gap only have to say "different bucket".
+
+**Status glyph on heading, never on row.** Row already gathered under heading that carry one, so second copy per row say what row's own position just said. Heading also carry **no fill** — tinted band across page draw box round quietest line on it — and group separated by gap instead.
+
+**Priority glyph on every row including "none".** Glyph appearing on only some row shift every title beside it, and ragged left edge read as disorder not information. Linear draw no-priority as three flat dash for exactly this reason: column same width on every row, and *height* of bars = signal.
+
+**Glyph set = Linear's own paths, redrawn** ([IssueStateIcon](apps/desktop/src/components/IssueStateIcon.tsx)). Two vocabulary reader arriving from tracker already know by shape — part-filled ring = progress, rising bars = priority — and lucide stand-in for either = second vocabulary to learn for no gain. Shape from **kind**, colour from **state's own** where caller have one (panel, picker); heading name kind, so it fall back to Linear's default per kind. Ring wedge computed from fraction rather than stroke-dasharray: dashed stroke read as dotted outline at 14px.
+
+**Row's hover hint sit before project, avatar and date.** Nothing else on row say click leave app, so hint name it — and placed there it take its width from title, which truncate, so marks on right stay put instead of sliding sideways under cursor.
+
+**Date = "Today", "Yesterday", then "Aug 23"** (`calendarDay`, [format.ts](apps/desktop/src/lib/format.ts)). Deliberately not `relativeTime` next to it: that count elapsed time, right for session that moved four minutes ago and wrong for issue — "20m" and "1d" invite arithmetic, and nobody reading backlog want to work out which afternoon "2d" was. Calendar day = unit tracker itself use. Year appended only past this year, and comparison count **midnights not hours**, so 11pm yesterday read as Yesterday at 1am.
+
+**Debounce gate on there being text, not on there being cache to protect.** First version gated on both, which debounced nothing that matter: every keystroke make key nothing cached under, so every one take un-debounced path and fire own request — exact run debounce exist to collapse. 300ms here against picker's 200ms, since this = box whole phrase get typed into.
+
+**Cache short-circuit must clear `loading` itself.** Only path that clear it without request having finished — cancelled read never reach own `finally`. Backspacing to already-cached query cancel in-flight read for longer one then short-circuit, so spinner turned forever with nothing behind it until some later read happened to end.
+
+**Reads cached module-level, keyed on whole query, capped at 12.** Same bargain `useChanges` make: switching chip, opening page, coming back from session all hit cache, and 60s freshness window decide whether refetch run underneath. Failed read **change nothing** — no entry written, no stamp — so blip leave last good list on screen. `forgetIssues()` = one escape hatch, called from both integration write.
+
+**Refresh forget, then bump — and bump alone must never gate cache.** `generation` re-arm effect; `forgetIssues()` beside it = what make read actually happen, since effect's rule = "fetch what not fresh". Counter only ever go up, so reading it as "don't use cache" left every later chip flip and every later visit to page refetching for rest of session.
+
+**Opened issue cached separately, keyed by identifier, capped at 24.** List cache cannot serve it — one hold row, other hold whole body with description and comments — and two read on different rhythm, so second map beside first rather than second use of it. Cap higher because key = *one issue* not one whole query, so reader working through handful fill it faster. Without it panel re-downloaded description on every tab switch, every reselect, and every second visit to row on page: "reading the issue…" over text already read. Only identifier past freshness window asked for, so session tagged with three issues and two of them just read cost one request. `forgetIssues()` clear both map — key that changed make every cached answer meaningless whichever shape it in.
+
+**Cached answer picked *during render*, not in effect.** `useEffect` run after paint, so state alone left one frame of previous issue's description under new issue's title — most visible on page, where picking row = key change and nothing else. Hence `Read` carry key it was built for and mismatch resolved off cache in render.
+
+**`loading` stay "a read is out", unmasked by what already cached.** Every reader of it per-issue and each draw own body when it have one, so session holding one cached issue and one still arriving need it true — else second row read as unreadable rather than pending. Refresh **forget then bump**: effect's own rule = "fetch what not fresh", and dropping stamp what make that rule answer yes.
+
+**Filters live in `useIssues`, not in view.** Default = assigned to me, unfinished, priority order. `IssuePriority` = enum not Linear's `0..4` integer, because `0` = *no* priority and ordering by wire number put least urgent issue at top of page. Sorted in Rust after read, since Linear order by `createdAt`/`updatedAt` and nothing else — API order asked for as tiebreak inside level. `IssueScope` = `Assigned`/`Created`/`All` and it what chip write; `assignee.isMe`/`creator.isMe` = filter Linear take, no user id lookup needed.
+
+**`Issue` and `IssueDetail` separate types, not one with empty fields.** List query ask for no description and no comments; struct carrying them anyway hand panel issue whose body silently missing. Every field read out of `Value` field-by-field, `map_model_usage`'s reason: schema Linear extend must cost one absent field, never whole list failing to deserialize and leaving page empty.
+
+**GraphQL fail with 200 and zero exit**, same trap `gh` document — `errors` checked before `data`, and auth failure recognised both by status *and* by sentence, since Linear report bad key as ordinary GraphQL error too.
+
+**Issue looked up by team key and number, not by handing identifier to `issue(id:)`.** That argument = UUID; whether it also resolve human identifier = convenience nothing in schema promise. Filter on two halves exactly as precise and documented.
+
+**Link = copy, not pointer.** `IssueRef` hold identifier, title, url, tracker id — so sidebar and prompt need no network call, and row still draw with tracker unreachable. It go stale (retitled issue keep old words until panel read it back), which right way round. Re-tagging **replace** entry with same id rather than append, so stale title refresh instead of issue drawn twice.
+
+**Unlink match tracker id *or* human identifier.** Two caller hold different things: panel have whole ref and pass id, person at CLI type `DRA-53`. Neither spelling collide — one = UUID.
+
+**Fork inherit links; relayed message carry none.** Fork continue same conversation so it against same work. `dray send`'s prompt tag whatever its own text tag and must not re-aim session it arrive at.
+
+**Protocol at v4.** v3 = `issues` and `LinkIssues`; v4 = that request's reshape, above.
+
+**v3 bump for `issues` and `LinkIssues`.** Same test `from` earned bump on: old app ignoring `issues` start session against no issue, with no line in prompt saying what work about, and answer **identically to success**. Wrong work that look like right work = what earn bump.
+
 ## Handing work back
 
 **Composer hide row of end-of-turn action behind itself.** [HandoffRow](apps/desktop/src/components/composer/HandoffRow.tsx) sit above composer card, clipped to sliver, open on hover. Buttons = Commit, Commit & push, Push/Publish branch, Create PR, Draft PR.
@@ -745,7 +899,9 @@ Asymmetry = point: appending to private file atomic, rewriting shared one not.
 
 **Gear share titlebar strip with sidebar toggle, and order swap in fullscreen.** Strip `justify-end` normally (clearing traffic lights), `justify-start` in fullscreen (they gone). Toggle also drawn in app header when sidebar collapsed, so it must hold strip's outer edge in both layouts and never change which end it at; gear have no second home and move instead.
 
-**Row shape = `SettingRow`**, label and reason left, control right. Two rules it encode: description **not optional** — it where "why is this off by default" live — and setting that cannot apply on this platform **disabled, not hidden**, since row that vanish read as setting app forgot and sentence under it = only place reason can be said.
+**Row shape = `SettingRow`**, label and control on top line, reason full width beneath. Side by side was first shape and it broke on widest control: two button push sentence into third of dialog, where four word take three line and row height jump every time control change. Description = prose and want measure; control = fixed thing and want edge to sit against.
+
+Two rules it encode: description **not optional** — it where "why is this off by default" live — and setting that cannot apply on this platform **disabled, not hidden**, since row that vanish read as setting app forgot and sentence under it = only place reason can be said.
 
 **Analytics row = two sentence: what it for, what it never touch.** Second one = row's whole job. "Analytics" read as behavioural tracking to most people, and for tool that watch you work on own code, saying plainly conversation and activity not collected = part worth space. Deliberately **not** itemised — listing every field read as something to be wary of rather than something to skim, which why row don't name ping, version or OS one by one.
 
@@ -1008,7 +1164,9 @@ Several things deliberately unfinished — don't mistake for bugs:
   and sidebar draw no link between the two. Both wanted a field each if it ever
   earn one; neither is missing machinery.
 
-- **Handoff row have no Revert, no Amend, no Stash.** Each destroy or rewrite work, and button that send prompt for one = button whose blast radius decided by model. Reader can still type it.
+- **Dray never write to issue tracker.** Tag record link on session and nothing else — no status move, no comment, no attachment linking session or PR back to issue. Every one = write, and write want rule for when it fire; reader can ask agent instead, which have tracker's MCP.
+- **No issue-side project mapping.** Connection workspace-wide, so picker and page never narrowed by which repo session run in. Filter row cover it by hand. Repo ↔ team mapping = field on `Project` if it earn one.
+- - **Handoff row have no Revert, no Amend, no Stash.** Each destroy or rewrite work, and button that send prompt for one = button whose blast radius decided by model. Reader can still type it.
 
 - **Repo view read, commit and push — no fetch, no pull, no discard.** Ahead count against *last known* upstream, so branch someone else pushed to read as level until push itself fail. Discard-changes and stage-hunk deliberately absent: both destroy work.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,7 @@ If it come back: commit = `add -A -- <paths>` then `commit -m … -- <paths>`, b
 
 **Own file, not field on `settings.json`, for two reason that both bite.** Settings rewritten by every analytics toggle and read on launch path where parse failure fall back to defaults — which would silently *forget* key. And `get_settings` hand that struct to frontend, which credential must never ride along with.
 
-**Mode set on temp file before anything written into it**, not on final one after rename: `fs::write` create at process umask, so setting it afterward leave window where key sit world-readable. Narrow, avoidable for one call, and pinned by test — failure silent otherwise, since world-readable key behave identically in every other respect.
+**Mode ride the *create*, on temp file** — not set after write, not on final file after rename. `fs::write` create at process umask, so every other order leave window where key sit world-readable: chmod after write close wide window and leave narrow one, where `OpenOptions::mode` leave none at all, since file never exist at wider mode for single byte to be written into. `create_new` beside it because `mode` apply only to file this call create, and temp file left by crashed write could be somebody else's at whatever mode they chose. Pinned by test — failure silent otherwise, since world-readable key behave identically in every other respect.
 
 Personal API key not OAuth, deliberately: Linear OAuth want client secret, secret want server to hold it, so that = drayhq.com work. Key path want neither. Connect form = where OAuth button land if that change.
 
@@ -424,6 +424,8 @@ First version appended "Linked issues" block after prompt and stripped it back o
 Description still not injected, and that separate call: agent have tracker's own MCP server and fetch what it want in shape it want, where description pasted in = wall of text at top of every prompt, stale moment somebody edit issue, and paid for again on every follow-up. Session may be started against three issue at once, so three tag beat three paragraph.
 
 **Resolution best effort, always.** Unreachable Linear, revoked key, tag naming issue that not exist — all leave tag as text, record no link, say nothing. Send must never fail because issue tracker down: that make tracker dependency of typing.
+
+**Best effort stop short of losing named issue.** Tag reader typed already *in* prompt, so unresolved one cost its title and nothing else. One arriving through `--issue` not: dropping it left model prompt with no mention of work at all, and **answered identically to success** — same test that earn protocol bump. So named issue that resolve to nothing get appended bare (`#DRA-53`) and linked bare, exactly as `dray issue link` write one. `wanted_tags` and `apply_tags` split out from read for this: what happen when nothing resolve = case worth pinning, and it one test process cannot reach by asking Linear.
 
 **One tagging rule per side of bridge.** Everything app send tag in prompt *text* — composer picker being only route — so `send_msg` command pass empty issue list always. CLI's `--issue` = other caller and name them outright, because flag not prose. Both merge inside `expand_tags`, deduplicated, and named-not-in-text one get their `#ID Title` appended so both caller end at same shape.
 
@@ -449,13 +451,17 @@ Absent metadata = **ordinary, not error**: bare identifier still usable link. `t
 
 **Upload sit behind same auth API do, which why webview cannot fetch either.** `<img src>` resolve to 401 and browser draw its own broken box — reading as "Dray cannot show this" rather than "this need key". `fetch_issue_asset` put key on that request and hand back `data:` URL; only then is there something `src` can point at. `csp: null` in tauri.conf, so `data:` need no scope entry.
 
+**Scheme checked with host, and it half easiest to leave out.** Host check alone accept `http://uploads.linear.app/…`, and that request carry key in cleartext for anyone on path — description = text somebody else wrote, so right host over wrong scheme = one line of markdown away. Rejected not upgraded: rewriting URL somebody else supplied to make it acceptable = guess about what they meant, and Linear's own uploads are HTTPS.
+
 **Host checked exactly, and that not defensive.** Description = text somebody else wrote, and it name URL this fetch get handed — so without check, issue could name any host and have app post credential to it. Compared on **parsed host**, never prefix: `uploads.linear.app.evil.test` pass `starts_with` and is not Linear. Stated twice (Rust `is_upload` decide where key go, [IssuePanel](apps/desktop/src/components/IssuePanel.tsx)'s copy decide what get drawn as asset), pinned on Rust side.
 
 **Image open full size in transcript's own lightbox.** Earn its place here more than there: pane = third of window, so screenshot of screen unreadable at only width it can be given. **One image per lightbox**, not description's whole set — these spread through prose rather than gathered in row, so there no set arrow would step through.
 
 **Image render as image, everything else as file card.** Card = icon, name, size, download glyph on hover — whole row = control, so glyph = hint about what click do not second target. Fallback one direction only: anything webview won't draw (unknown format, SVG, failed fetch) *become* card, since file somebody can download beat grey box. `onError` = second net under mime check, because mime can say `image/svg+xml` and still not render.
 
-**Size capped before body read.** `content_length` checked first so oversized file refused rather than read into memory then rejected — same reading `cat-file --batch-check` exist for on git side; arrived length capped again, for server that send none. Asset cached per URL across mount, `null` included: description re-render on every keystroke in search box, and each would otherwise re-download every screenshot in it.
+**Failed upload cached too, and only generation get it back.** Not caching one worse than it look — failed fetch retried on every render of description holding it, which = retry per keystroke in search box. But `null` kept forever = screenshot reconnect and Refresh both fail to recover, leaving reader pressing button that provably do nothing. So entry carry generation, and older one = miss.
+
+**Size capped before body read, and body *streamed* to that cap.** `content_length` checked first so oversized file refused rather than read into memory then rejected — same reading `cat-file --batch-check` exist for on git side. But advertised length = courtesy: server may send none, or send one that lie, and `.bytes()` drain whole body into memory *before* anything could reject it. So chunk loop stop at cap, which = cap actually being enforced. Asset cached per URL across mount, `null` included: description re-render on every keystroke in search box, and each would otherwise re-download every screenshot in it.
 
 **Panel read Linear's API with stored key. MCP nowhere near it.** Two channel answering two question and they never touch: key fill *this app's* screens (description, attachment, comment, status), MCP let *agent* read same issue in its own turn. That why connect form say MCP out loud — reader who set up one and not other otherwise find out from model working off one-line title.
 
@@ -489,6 +495,8 @@ Live check existed and was removed. `mcp.rs` ran `claude mcp list`, cached per d
 
 **Toggle drawn only once something open to close.** Nothing on that page can *open* pane — row do that — so toggle at rest = control with one dead state. ⌘E close pick for same reason, and ⌘R follow session rule: pane win where open, list otherwise.
 
+**Every route to a session go through one helper.** `goToSession` in `App` close page then navigate, and chord, sidebar row, New Task, notice card and settle-then-follow all take it. Two sidebar button closed page and chord beside them did not, which made ⌘N and ⌘⇧↑/↓ read as **inert**: they moved selection under column still full of issues, and change only showed up on way back. Page itself left as it was — filter and scroll come back with it — so this navigation, not dismissal.
+
 **No Start button, and removing it was the fix not the gap.** It create session, so it must name project — and page workspace-wide, so button either guess which repo work belong in or grow picker of own beside every row. Tagging with `#` in composer already start work against issue, from place that know which project it in.
 
 **Two chip, everything else behind one control.** Assigned / Created = two question worth one press: what mine to do, what did I ask for. Team and project narrow *within* whichever chip on, so they sit in menu — more control across header = more thing to read past on every visit to change none of them. Team or project list with **one entry not offered at all**, and menu with neither **hidden outright**: filter whose only option = one you already have = control that cannot do anything, and this solo tool often pointed at single team. Trigger lit while anything on, so list narrowed on previous visit say so rather than read as empty workspace.
@@ -517,6 +525,8 @@ Live check existed and was removed. `mcp.rs` ran `claude mcp list`, cached per d
 
 **Cache short-circuit must clear `loading` itself.** Only path that clear it without request having finished — cancelled read never reach own `finally`. Backspacing to already-cached query cancel in-flight read for longer one then short-circuit, so spinner turned forever with nothing behind it until some later read happened to end.
 
+**One generation counter over every issue cache** ([issue.ts](apps/desktop/src/lib/issue.ts)). Bumped whenever answer to "who are we, what may we read" change — key connected, key disconnected, reader pressing Refresh. List, opened body and fetched upload each stamp entry with generation it was read under, and read that start under older one **refused rather than written**. Same counter `usePrMarks` keep, against same failure: clearing cache not enough on own, since read issued *before* clear land after it and put entry straight back — and damaging half not stale row but **stamp**, which tell every later reader answer current and suppress read that would correct it. Also `useSyncExternalStore`d, so hook holding answer read under old key re-read rather than sit on it until something remount it.
+
 **Reads cached module-level, keyed on whole query, capped at 12.** Same bargain `useChanges` make: switching chip, opening page, coming back from session all hit cache, and 60s freshness window decide whether refetch run underneath. Failed read **change nothing** — no entry written, no stamp — so blip leave last good list on screen. `forgetIssues()` = one escape hatch, called from both integration write.
 
 **Refresh forget, then bump — and bump alone must never gate cache.** `generation` re-arm effect; `forgetIssues()` beside it = what make read actually happen, since effect's rule = "fetch what not fresh". Counter only ever go up, so reading it as "don't use cache" left every later chip flip and every later visit to page refetching for rest of session.
@@ -534,6 +544,12 @@ Live check existed and was removed. `mcp.rs` ran `claude mcp list`, cached per d
 **GraphQL fail with 200 and zero exit**, same trap `gh` document — `errors` checked before `data`, and auth failure recognised both by status *and* by sentence, since Linear report bad key as ordinary GraphQL error too.
 
 **Issue looked up by team key and number, not by handing identifier to `issue(id:)`.** That argument = UUID; whether it also resolve human identifier = convenience nothing in schema promise. Filter on two halves exactly as precise and documented.
+
+**Send answer with links as written, every path.** Created, live, queued, resumed — `#DRA-53` expanded and recorded on all four, and frontend have no other way to learn what prompt just linked. Without it tag typed into existing session persisted in Rust and reached panel only on reselect or restart: Issue tab went on drawing old links while index on disk held new. Whole list not delta, for `link_session_issue`'s reason — re-tag *replace* entry, so what changed = not set caller could work out from its own request.
+
+**Link matched on tracker id *or* identifier, within tracker — both directions.** Two writer put different things in `id`: resolved link carry Linear's UUID, blind one (`dray issue link`, or tag no key could resolve) carry identifier itself. Keyed on `id` alone, `DRA-53` linked blind and `DRA-53` resolved moment later = two row for one issue. Unlink already read it this way; link now match same.
+
+**Detail read by UUID first, identifier as fallback.** Identifier not stable — issue moved to another team renumber, `DRA-53` become `ENG-12` — so lookup by recorded spelling answer "no such issue" for work very much still there. UUID survive move. Fallback not other way round because identifier = *only* thing blind link carry, so `id` that not UUID name nothing Linear-side and skipped rather than asked about (`is_stable_id`). Empty UUID answer fall through too.
 
 **Link = copy, not pointer.** `IssueRef` hold identifier, title, url, tracker id — so sidebar and prompt need no network call, and row still draw with tracker unreachable. It go stale (retitled issue keep old words until panel read it back), which right way round. Re-tagging **replace** entry with same id rather than append, so stale title refresh instead of issue drawn twice.
 

--- a/apps/cli/skill/SKILL.md
+++ b/apps/cli/skill/SKILL.md
@@ -45,6 +45,42 @@ Options:
 | `--effort <level>` | `low`, `medium`, `high`, `xhigh`, `max`. Defaults to the current session's. |
 | `--harness <name>` | `claude_code`. Defaults to the current session's. |
 | `--from <session\|ref>` | Start the worktree on existing work instead of `origin/<default>`. |
+| `--issue <ID>` | The issue this work is against, like `DRA-53`. Repeat for several. |
+
+### Tagging a session with its issue
+
+```bash
+dray new --issue DRA-53 "Add the issue panel described in DRA-53"
+dray issue link <session-id> DRA-53 --title "Add the issue panel" --url https://linear.app/acme/issue/DRA-53
+dray issue link <session-id> DRA-53 DRA-54
+dray issue unlink <session-id> DRA-54
+```
+
+A tagged session shows an **Issue** tab in the user's panel, and its prompt gains
+one line per issue: the identifier and the title, nothing else.
+
+`dray issue link` **writes down what you give it and asks the tracker nothing.**
+So pass `--title` and `--url` — you have just read the issue and they cost you
+nothing, where without them the tag is a bare `#DRA-53` that links nowhere. They
+describe one issue, so name one issue when you use them.
+
+That line is deliberately thin. **Read the issue yourself** through the tracker's
+own MCP server — `linear-server` for Linear — which is where the description,
+the comments, the links and the current status live. The line in the prompt is an
+address, not a briefing.
+
+If that MCP server is not connected, say so rather than guessing: you have the
+title and the identifier and nothing behind them. `claude mcp list` says which
+servers are reachable.
+
+`--issue`, and a `#DRA-53` written into a prompt, are the other half and they
+*do* need the user to have connected a tracker in Dray — that is where the title
+is looked up. If they have not, the tag stays plain text, the session still runs,
+and nothing fails. Report it rather than working around it.
+
+You can also write `#DRA-53` straight into a prompt — `dray new`, `dray send`, or
+the user's own composer. Dray resolves the tag and links it exactly as `--issue`
+does.
 
 ### Each session gets its own worktree
 
@@ -168,6 +204,10 @@ nothing was sent, so retrying after the fix is safe.
 
 ## Limits
 
+- **Dray does not write to the tracker.** Tagging records the link on the
+  session and nothing else: no status change, no comment, no attachment. If the
+  user wants the issue moved or commented on, do it through the tracker's own
+  MCP server.
 - **No reading transcripts.** You can create, list and message. You cannot read
   what another session said — ask it to send you a summary instead.
 - **Two levels deep.** A session you create may create sessions of its own; those

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -10,7 +10,8 @@
 
 use clap::{Args, Parser, Subcommand};
 use dray_proto::{
-    encode_line, CreateSession, Envelope, ListSessions, Request, Response, SendMessage,
+    encode_line, CreateSession, Envelope, IssueInput, LinkIssues, ListSessions, Request, Response,
+    SendMessage,
     SessionSummary,
 };
 use std::ffi::OsStr;
@@ -52,6 +53,9 @@ enum Command {
     Ls(Ls),
     /// Send a message into a session that already exists.
     Send(Send),
+    /// Tag a session with the issue its work is against.
+    #[command(subcommand)]
+    Issue(IssueCommand),
     /// Upgrade this binary to the newest release.
     Update(Update),
     /// Manage the Claude Code skill that documents this CLI.
@@ -88,6 +92,10 @@ struct New {
     /// origin/<default>.
     #[arg(long, value_name = "SESSION|REF")]
     from: Option<String>,
+
+    /// The issue this work is against, like DRA-53. Repeat for several.
+    #[arg(long = "issue", value_name = "ISSUE")]
+    issues: Vec<String>,
 }
 
 #[derive(Args)]
@@ -124,6 +132,32 @@ struct Ls {
 }
 
 #[derive(Subcommand)]
+enum IssueCommand {
+    /// Tag a session with one or more issues.
+    Link(IssueLinkArgs),
+    /// Remove issues from a session. The issues themselves are untouched.
+    Unlink(IssueLinkArgs),
+}
+
+#[derive(Args)]
+struct IssueLinkArgs {
+    /// The session, as printed by `dray ls`.
+    session_id: String,
+
+    /// Issue identifiers, like DRA-53.
+    #[arg(required = true, value_name = "ISSUE")]
+    identifiers: Vec<String>,
+
+    /// The issue's title, so the tag reads as more than an identifier.
+    #[arg(long, value_name = "TITLE")]
+    title: Option<String>,
+
+    /// The issue's web address, so the tag becomes a link.
+    #[arg(long, value_name = "URL")]
+    url: Option<String>,
+}
+
+#[derive(Subcommand)]
 enum SkillCommand {
     /// Write the skill to ~/.claude/skills/dray/, where Claude Code finds it.
     Install,
@@ -144,6 +178,8 @@ fn run() -> Result<(), String> {
         Command::New(args) => new(args),
         Command::Ls(args) => ls(args),
         Command::Send(args) => send_message(args),
+        Command::Issue(IssueCommand::Link(args)) => link_issues(args, false),
+        Command::Issue(IssueCommand::Unlink(args)) => link_issues(args, true),
         Command::Update(args) => update(args),
         Command::Skill(SkillCommand::Install) => install_skill(),
     }
@@ -158,6 +194,7 @@ fn new(args: New) -> Result<(), String> {
         harness: args.harness,
         parent_session_id: parent_session_id(),
         from: args.from,
+        issues: args.issues,
     });
 
     match send(request)? {
@@ -180,6 +217,53 @@ fn new(args: New) -> Result<(), String> {
                     None => String::new(),
                 }
             );
+            Ok(())
+        }
+        Response::Error { message } => Err(message),
+        other => Err(unexpected(&other)),
+    }
+}
+
+/// Tags or untags a session, printing what it carries afterwards.
+///
+/// The whole list rather than what changed, because that is what the app
+/// answers with — and a caller that tagged three issues wants to see three,
+/// not to reconcile a diff against what it believed.
+fn link_issues(args: IssueLinkArgs, unlink: bool) -> Result<(), String> {
+    // One title belongs to one issue. Refused rather than applied to all of
+    // them or silently to the first: both are a wrong link that reads exactly
+    // like a right one, which is the failure this whole protocol is arranged
+    // to avoid.
+    if args.identifiers.len() > 1 && (args.title.is_some() || args.url.is_some()) {
+        return Err("--title and --url describe one issue, so name one".into());
+    }
+
+    let issues = args
+        .identifiers
+        .into_iter()
+        .map(|identifier| IssueInput {
+            identifier,
+            title: args.title.clone(),
+            url: args.url.clone(),
+        })
+        .collect();
+
+    let request = Request::LinkIssues(LinkIssues {
+        session_id: args.session_id,
+        issues,
+        unlink,
+    });
+
+    match send(request)? {
+        Response::Linked { issues } => {
+            if issues.is_empty() {
+                eprintln!("No issues on this session.");
+                return Ok(());
+            }
+
+            for issue in issues {
+                println!("{}: {}", issue.identifier, issue.title);
+            }
             Ok(())
         }
         Response::Error { message } => Err(message),
@@ -222,6 +306,7 @@ fn unexpected(response: &Response) -> String {
         Response::Created { .. } => "a create",
         Response::Listed { .. } => "a list",
         Response::Sent { .. } => "a send",
+        Response::Linked { .. } => "an issue link",
         Response::Error { .. } => "an error",
     };
     format!("the app answered {kind} to a different command — versions may disagree")
@@ -317,8 +402,7 @@ fn scratch_dir() -> Result<PathBuf, String> {
 
     let path = std::env::temp_dir().join(format!("dray-update-{}", std::process::id()));
 
-    std::fs::create_dir(&path)
-        .map_err(|e| format!("could not create {}: {e}", path.display()))?;
+    std::fs::create_dir(&path).map_err(|e| format!("could not create {}: {e}", path.display()))?;
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))
         .map_err(|e| format!("could not restrict {}: {e}", path.display()))?;
 
@@ -406,7 +490,8 @@ fn install_skill() -> Result<(), String> {
         .join("skills")
         .join("dray");
 
-    std::fs::create_dir_all(&dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("could not create {}: {e}", dir.display()))?;
 
     let path = dir.join("SKILL.md");
     std::fs::write(&path, SKILL).map_err(|e| format!("could not write {}: {e}", path.display()))?;
@@ -450,7 +535,9 @@ fn send(request: Request) -> Result<Response, String> {
 /// spawns; absent when a person runs this in their own terminal, which is
 /// ordinary rather than an error.
 fn parent_session_id() -> Option<String> {
-    std::env::var("DRAY_SESSION_ID").ok().filter(|v| !v.is_empty())
+    std::env::var("DRAY_SESSION_ID")
+        .ok()
+        .filter(|v| !v.is_empty())
 }
 
 /// `--project` if given, else the repo the current directory sits in.
@@ -519,6 +606,30 @@ mod tests {
     #[test]
     fn the_command_tree_is_well_formed() {
         Cli::command().debug_assert();
+    }
+
+    /// The title belongs to one issue. Applying it to all of them, or silently
+    /// to the first, is a wrong link that reads exactly like a right one.
+    #[test]
+    fn metadata_describes_one_issue() {
+        let args = Cli::try_parse_from([
+            "dray", "issue", "link", "s1", "DRA-53", "DRA-54", "--title", "One",
+        ])
+        .unwrap();
+
+        let Command::Issue(IssueCommand::Link(args)) = args.command else {
+            panic!("expected an issue link");
+        };
+
+        assert!(link_issues(args, false).is_err());
+    }
+
+    /// A bare identifier is still a usable link — the tag just reads `#DRA-53`
+    /// with nothing after it. Refusing one would make the flags mandatory in
+    /// everything but name.
+    #[test]
+    fn identifiers_alone_are_accepted() {
+        assert!(Cli::try_parse_from(["dray", "issue", "link", "s1", "DRA-53", "DRA-54"]).is_ok());
     }
 
     #[test]

--- a/apps/desktop/COPY-ISSUES.md
+++ b/apps/desktop/COPY-ISSUES.md
@@ -1,0 +1,316 @@
+# Issue tracker — every string, for review
+
+Every user-facing string the Linear integration adds, with where it is drawn and
+why it says what it says. Nothing here is settled: mark up anything and I'll
+change it in one pass.
+
+The one rule holding across the whole list: the surface says **issue**, never
+Linear — except where the reader is being asked about Linear specifically (the
+connect form, and a failure Linear itself caused). Trackers are pluggable; the
+vocabulary should not have to change when a second one lands.
+
+---
+
+## Sidebar
+
+**Nav row, below "New task"**
+
+> Issues
+
+Always drawn, connected or not. The page is where connecting happens, so hiding
+it until connected would hide its own entrance.
+
+---
+
+## Issues page — nothing connected
+
+**Heading** — with Linear's mark beside it
+
+> Connect Linear
+
+**Subtext, under the heading**
+
+> Paste a personal API key with read access. Dray only reads — it never changes an issue.
+
+Two sentences, the shape the analytics row uses: what it needs, and what it will
+never do. "Read access" is the whole point of the first — it is the smallest
+thing that works, and saying so makes pasting a credential into a desktop app a
+smaller decision. The second is what stops anyone expecting their issue to move
+to In Progress on its own.
+
+**Key field placeholder**
+
+> lin_api_…
+
+**Submit button** — idle, then while the key is being checked
+
+> Connect
+> Connecting…
+
+**Link below the form**
+
+> Create a key in Linear
+
+**Note under it**, above a rule — the other half of the setup
+
+> This key is read-only, and it is for Dray. To let the agent read and manage issues in chat, add [Linear's MCP server](https://linear.app/docs/mcp) to your CLI.
+
+Said here and only here. The key fills Dray's own screens and gives the agent
+nothing; someone who finds that out later finds it out from a model working off
+a one-line title, which is the expensive way. No check behind it — a live health
+check was built and removed, since this is setup advice rather than a fault to
+report.
+
+Opens `https://linear.app/settings/account/security`. A link rather than
+instructions: the path through Linear's settings is theirs to change, and a
+stale sentence here is worse than none.
+
+**Refusals, under the field**
+
+> Paste a Linear API key first.
+
+> Linear rejected that key. Check it was copied whole and has not been revoked.
+
+> Could not reach Linear: {detail}
+
+The middle one names the two things that actually go wrong — a paste that lost
+its tail, and a key revoked months ago.
+
+---
+
+## Issues page — connected
+
+**Scope chips**
+
+> Assigned to me
+> Created
+
+The two questions worth one press: what is mine to do, and what did I ask for.
+"Assigned to me" spelled out rather than "Assigned", which on its own leaves the
+reader to guess assigned *to whom*.
+
+**Search field placeholder**
+
+> Search issues
+
+**Filter menu** (behind the sliders icon; hidden entirely when there is nothing
+left to narrow by — a team or project list with one entry is not offered)
+
+> Team
+> All teams
+> Project
+> All projects
+
+**Group headers** — the state buckets, in this order, count beside each
+
+> In Progress
+> Triage
+> Todo
+> Backlog
+> Done
+> Cancelled
+> Other
+
+Grouped on the state's *kind*, not its name, so a team that calls its in-progress
+column "Shipping" still lands under In Progress. "Other" only ever holds a state
+Linear added that we don't model.
+
+**Done and Cancelled are always drawn and always start closed**, and nothing is
+fetched for them until one is opened. Until then they carry no count — a zero
+would be a claim, not a blank. While the read is out:
+
+> Reading…
+
+And when a group turns out to hold nothing:
+
+> Nothing here.
+
+**Empty list** — three cases
+
+> No issue matches that.
+> Nothing you filed is open.
+> Nothing assigned to you.
+
+**Failed read, above the list** (what was already read stays on screen)
+
+> Linear rejected the saved key. Disconnect it in Settings, then paste a new one.
+> Could not reach Linear.
+> No issue tracker connected.
+
+**Icon labels** (screen readers and tooltips)
+
+> Refresh   ⌘R
+> Filters
+
+Refresh sits at the far right of the chip row, not among the chips: it acts on
+the whole page rather than narrowing it. ⌘R reaches it while the page is up, the
+same chord that re-reads the right panel — it means "re-read what I am looking
+at", never a specific thing.
+
+---
+
+## Composer
+
+**Placeholder, new task, tracker connected**
+
+> Describe a task. #issues. @files. /skills and commands.
+
+**Placeholder, new task, nothing connected**
+
+> Describe a task. @files. /skills and commands.
+
+`#` is named only where it would do something. Offered to someone unconnected,
+it teaches them the app is broken rather than that they haven't set it up.
+
+**Picker header, on `#`**
+
+> Issues
+
+---
+
+## Right panel — Issue tab
+
+Two things open this: a session tagged with issues, and a row picked on the
+Issues page. Same panel either way — it describes whatever the main column is
+showing. A page pick has no session behind it, so it draws no Remove button.
+
+**Tab label**, over a session
+
+> Issue
+
+**Heading**, over a picked issue — where the tab row would be, since there is
+only one thing in the pane and nothing to switch to
+
+> Details
+
+**No issue tagged**
+
+> No issue on this session. Tag one with `#` in the composer.
+
+The status is drawn as a glyph at the head of each row and **its name appears
+nowhere** — the row already says it, and a word under the glyph saying the same
+thing was the fact twice. The glyph keeps an `aria-label` so a screen reader
+still gets the name.
+
+**Uploads inside the description**, where Linear puts them. Images draw as
+images; anything else draws as a card with its name, its size, and a download
+glyph that appears under the cursor. While the bytes are on their way, and when
+they could not be fetched:
+
+> Loading…
+> Unavailable
+
+**While a row is open**
+
+> Reading the issue…
+> Could not read this issue.
+> No description.
+
+**Failed read**
+
+> Connect Linear on the Issues page to see this issue.
+> Linear rejected the saved key. Disconnect it in Settings, then paste a new one on the Issues page.
+> Could not reach Linear.
+
+**Row buttons** (hover, and their tooltips)
+
+> Remove {DRA-53}
+> Remove {DRA-53} from this session
+> Open {DRA-53} in the browser
+
+---
+
+## User message
+
+An issue tag in a sent message is a button. Its tooltip:
+
+> Open {DRA-53} in {linear.app}
+
+The hostname is read off the issue's own URL rather than written here, so a
+self-hosted tracker names itself.
+
+---
+
+## Main column header
+
+**While the issues page is up**, where a session would otherwise be named
+
+> Issues
+
+The page fills the column but is not a session and never becomes one, so the
+header would otherwise sit at "New session" over a list of issues.
+
+---
+
+## Settings dialog
+
+Drawn **only when something is connected** — connecting happens on the Issues
+page, and a settings row offering to connect something the reader has never seen
+is a row they cannot judge.
+
+**Label**
+
+> Issue tracker
+
+**Subtext** — with Linear's mark beside it
+
+> {Acme}, as {Yogesh}
+
+**Button**
+
+> Disconnect
+
+**Once pressed**, the row asks before it acts — the key is not recoverable from
+here, so taking it back means a trip to Linear for a new one.
+
+> Dray will forget the key. Sessions keep the issues they are tagged with.
+
+> Cancel
+> Disconnect
+
+---
+
+## CLI — `dray`
+
+**`dray new --issue <ISSUE>`**
+
+> The issue this work is against, like DRA-53. Repeat for several.
+
+**`dray issue`**
+
+> Tag a session with the issue its work is against.
+
+**`dray issue link` / `dray issue unlink`**
+
+> Tag a session with one or more issues.
+> Remove issues from a session. The issues themselves are untouched.
+
+**Its flags**
+
+> The issue's title, so the tag reads as more than an identifier.
+> The issue's web address, so the tag becomes a link.
+
+**Refused when they would describe more than one issue**
+
+> --title and --url describe one issue, so name one
+
+**After a link or unlink**, the session's whole issue list, one per line:
+
+> DRA-53: Add issue tracker integration
+
+**When there are none left**
+
+> No issues on this session.
+
+---
+
+## What a tag looks like, everywhere
+
+One shape, whoever wrote it — picked from the composer's `#` menu, typed by
+hand, or appended by the CLI's `--issue`:
+
+> #DRA-53 Add issue tracker integration
+
+The title is in the text rather than drawn beside it. That is what lets the
+model read it, the transcript paint it, and the composer's overlay stay in
+register with the textarea underneath.

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -529,6 +529,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +983,7 @@ dependencies = [
  "fff-search",
  "libc",
  "notify-rust",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -1560,8 +1572,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1583,8 +1597,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1948,6 +1965,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2529,6 +2547,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac-notification-sys"
@@ -3494,6 +3518,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3534,6 +3614,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3647,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3688,6 +3794,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3695,6 +3803,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3702,6 +3811,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3841,6 +3951,7 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5683,6 +5794,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5743,6 +5864,15 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -50,3 +50,10 @@ notify-rust = { version = "4.18", features = ["preview-macos-un"] }
 # app key is compiled in from `APTABASE_KEY`; an absent key leaves the plugin
 # registered and inert, which is what dev builds run with. See analytics.rs.
 tauri-plugin-aptabase = "1.0.0"
+# Linear's GraphQL API, and the only service this app talks to directly — `gh`
+# and `claude` are reached by spawning them instead. `rustls` rather than the
+# platform TLS so a Linux build needs no OpenSSL. See issues/linear.rs.
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }

--- a/apps/desktop/src-tauri/src/events/events.rs
+++ b/apps/desktop/src-tauri/src/events/events.rs
@@ -24,7 +24,7 @@ pub use usage::{ContextWindow, ModelUsage, RateLimit, Usage};
 
 // `Harness` is a harness concept, not an event one; it lives in `crate::harness`
 // and is used here only as a field type.
-use crate::harness::Harness;
+use crate::{harness::Harness, issues::IssueRef};
 
 /// One normalized event: an envelope (who, when, what order, which conversation)
 /// wrapping a [`payload`](Self::payload) (what happened).
@@ -116,6 +116,16 @@ pub enum AgentEventPayload {
         text: String,
         #[serde(default)]
         images: Vec<ImageRef>,
+        /// The issues this prompt was tagged with, resolved against the tracker
+        /// as it was sent.
+        ///
+        /// A field rather than something to be parsed back out of `text`, for
+        /// the reason `from` below gives: the block appended to the prompt is
+        /// prose, and a transcript that recovered it with a pattern would fail
+        /// silently the first time the wording moved. The bubble rebuilds the
+        /// exact string from *these* and drops it only if the text ends with it.
+        #[serde(default)]
+        issues: Vec<IssueRef>,
         /// The working tree as it stood when this prompt was sent, as a git
         /// tree id — the "before" side the changes panel diffs against.
         ///
@@ -851,11 +861,21 @@ mod tests {
             serde_json::from_str(r#"{"type":"user_message","text":"hi"}"#).unwrap();
         assert!(matches!(
             v,
-            // `baseline`, `queued` and `from` default too: every prompt logged
-            // before each of those existed must not fail the line.
-            AgentEventPayload::UserMessage { ref text, ref images, ref baseline, queued, ref from }
-                if text == "hi" && images.is_empty() && baseline.is_none() && !queued
-                    && from.is_none()
+            // `baseline`, `queued`, `from` and `issues` default too: every
+            // prompt logged before each of those existed must not fail the line.
+            AgentEventPayload::UserMessage {
+                ref text,
+                ref images,
+                ref baseline,
+                queued,
+                ref from,
+                ref issues,
+            } if text == "hi"
+                && images.is_empty()
+                && baseline.is_none()
+                && !queued
+                && from.is_none()
+                && issues.is_empty()
         ));
 
         let v: AgentEventPayload = serde_json::from_str(

--- a/apps/desktop/src-tauri/src/harness/claude_code/mapper.rs
+++ b/apps/desktop/src-tauri/src/harness/claude_code/mapper.rs
@@ -821,6 +821,9 @@ fn user_message(text: String) -> AgentEventPayload {
     AgentEventPayload::UserMessage {
         text,
         images: vec![],
+        // Nothing to link: a tag is resolved where a prompt is *sent*, and this
+        // one arrived off the wire rather than being one this app issued.
+        issues: vec![],
         // No baseline: only a prompt the app itself sent has a snapshot behind
         // it, taken at the moment it was sent. A user line arriving from the
         // CLI is one this app never issued, so there is no "before" to name.

--- a/apps/desktop/src-tauri/src/issues/issues.rs
+++ b/apps/desktop/src-tauri/src/issues/issues.rs
@@ -1,0 +1,900 @@
+//! The issue a session is working on, whoever tracks it.
+//!
+//! Linear is the only tracker wired up, and it is the only word in here that
+//! says so: everything a reader sees is an *issue*, and everything below this
+//! file's vocabulary lives in `linear.rs`. A second tracker is a module and a
+//! variant, not a rename of every surface — which is why [`IssueRef`] carries
+//! its own [`IssueTracker`] even while there is one.
+//!
+//! Two halves, and they answer different questions. The **connection** is the
+//! account, and it is workspace-wide: no project is bound to a team, so the
+//! picker and the issues page read whatever the connected user is assigned. The
+//! **link** is per session, recorded on its index entry, and it is what draws
+//! the panel's tab and what a tag resolves to.
+
+#[path = "linear.rs"]
+pub mod linear;
+
+use std::{collections::HashMap, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use ts_rs::TS;
+
+use crate::{settings, store, store::get_home_app_dir};
+
+/// Who tracks the issue. One variant today; it is on the wire and on disk so a
+/// session linked to a Linear issue stays readable once there are two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "snake_case")]
+pub enum IssueTracker {
+    Linear,
+}
+
+/// What a session records about an issue it is working on.
+///
+/// Deliberately a *copy*, not a pointer: the title and the URL are what the
+/// sidebar and the prompt block need, and re-reading the tracker to draw a row
+/// would put a network call behind a session opening. It goes stale — a
+/// retitled issue keeps the old words here until the panel reads it back — and
+/// that is the right way round, since the alternative is a row that cannot be
+/// drawn while the workspace is unreachable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IssueRef {
+    pub tracker: IssueTracker,
+    /// The tracker's own stable id, which survives a move between teams where
+    /// `identifier` does not.
+    pub id: String,
+    /// What a person calls it: `DRA-53`.
+    pub identifier: String,
+    pub title: String,
+    pub url: String,
+}
+
+/// Where an issue has got to, folded from the tracker's own vocabulary.
+///
+/// Linear reports a workflow state's `type`, which is this set exactly — the
+/// state's *name* is per-team prose ("In Review", "Shipping") and belongs on
+/// screen, not in a match arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "snake_case")]
+pub enum IssueStateKind {
+    Triage,
+    Backlog,
+    Unstarted,
+    Started,
+    Completed,
+    Canceled,
+    /// A state type we don't model. Drawn from `name` like any other, so a
+    /// vocabulary Linear adds later costs a glyph rather than the whole read.
+    Other,
+}
+
+impl IssueStateKind {
+    /// Whether the work is over, either way it went. What "unfinished" means in
+    /// the issues page's default filter.
+    pub fn settled(self) -> bool {
+        matches!(self, Self::Completed | Self::Canceled)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IssueState {
+    pub name: String,
+    pub kind: IssueStateKind,
+    /// The tracker's own colour, so a status reads the same here as it does in
+    /// the app the reader also has open.
+    pub color: String,
+}
+
+/// Linear's five levels, by name rather than by its `0..4` integer — where `0`
+/// is *no* priority and therefore sorts nothing like a number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "snake_case")]
+pub enum IssuePriority {
+    Urgent,
+    High,
+    Medium,
+    Low,
+    None,
+}
+
+impl IssuePriority {
+    /// Wire integer to level. Anything outside the documented range reads as
+    /// `None`, which sorts last rather than first.
+    pub fn from_wire(value: i64) -> Self {
+        match value {
+            1 => Self::Urgent,
+            2 => Self::High,
+            3 => Self::Medium,
+            4 => Self::Low,
+            _ => Self::None,
+        }
+    }
+
+    /// Sort key, urgent first and unprioritized last. The whole reason this is
+    /// an enum: ordering by Linear's own integer puts "No priority" at the top.
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::Urgent => 0,
+            Self::High => 1,
+            Self::Medium => 2,
+            Self::Low => 3,
+            Self::None => 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IssuePerson {
+    pub name: String,
+    /// `None` for an account with no picture, which the panel draws as an
+    /// initial rather than as a gap — same bargain the PR panel makes.
+    pub avatar: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IssueLabel {
+    pub name: String,
+    pub color: String,
+}
+
+/// One row in a list, and everything a row draws.
+///
+/// Distinct from [`IssueDetail`] rather than one type with empty fields: a list
+/// read does not ask for descriptions or comments, and a struct that carries
+/// them anyway hands the panel an issue whose body is silently missing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct Issue {
+    pub tracker: IssueTracker,
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub url: String,
+    pub state: IssueState,
+    pub priority: IssuePriority,
+    pub assignee: Option<IssuePerson>,
+    pub labels: Vec<IssueLabel>,
+    /// Team key (`DRA`) — what the identifier is built from, so a row filtered
+    /// across teams still says which one it belongs to.
+    pub team: Option<String>,
+    pub project: Option<String>,
+    pub updated_at: String,
+}
+
+impl Issue {
+    /// The subset a session records. Built here rather than in the frontend so
+    /// there is one answer to "what does a link hold".
+    pub fn to_ref(&self) -> IssueRef {
+        IssueRef {
+            tracker: self.tracker,
+            id: self.id.clone(),
+            identifier: self.identifier.clone(),
+            title: self.title.clone(),
+            url: self.url.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IssueComment {
+    pub author: IssuePerson,
+    pub body: String,
+    pub created_at: String,
+    pub url: Option<String>,
+}
+
+/// One issue, opened. The panel's read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IssueDetail {
+    #[serde(flatten)]
+    #[ts(flatten)]
+    pub issue: Issue,
+    /// Markdown, as the tracker holds it. `None` for an issue nobody wrote one
+    /// for, which the panel says plainly rather than drawing an empty box.
+    pub description: Option<String>,
+    pub comments: Vec<IssueComment>,
+}
+
+/// Whose issues to list.
+///
+/// The tracker's own two answers to "my issues", and a third for looking past
+/// them. Deliberately not a pair of booleans: assigned *and* created is a
+/// question nobody asks, and two flags can express it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "snake_case")]
+pub enum IssueScope {
+    #[default]
+    Assigned,
+    Created,
+    All,
+}
+
+/// What the issues page can narrow to, and what the picker asks with.
+#[derive(Debug, Clone, Default, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase", default)]
+pub struct IssueQuery {
+    /// Free text. Matched against title and identifier; an empty query is the
+    /// resting state and lists rather than searches.
+    pub text: Option<String>,
+    pub scope: IssueScope,
+    /// Linear team id.
+    pub team_id: Option<String>,
+    pub project_id: Option<String>,
+    /// Which half of the workspace to read: the unfinished issues, or the done
+    /// and cancelled ones.
+    ///
+    /// Two reads rather than one flag that widens a single read, because the
+    /// settled half is most of a workspace and is nearly always dead weight —
+    /// so the page draws its groups collapsed and asks for them only when one
+    /// is opened. Splitting it here rather than filtering client-side is what
+    /// makes that possible: a read that never happens costs nothing, and the
+    /// two answers cache under separate keys.
+    pub settled: bool,
+}
+
+/// The filter row's options, read once per connection rather than per keystroke.
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IssueFilters {
+    pub teams: Vec<IssueGroup>,
+    pub projects: Vec<IssueGroup>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IssueGroup {
+    pub id: String,
+    pub name: String,
+}
+
+/// The connected account, as the settings row draws it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct TrackerAccount {
+    pub tracker: IssueTracker,
+    pub user_id: String,
+    pub user_name: String,
+    pub org_name: String,
+}
+
+/// Why there is nothing to show.
+///
+/// Typed for [`PrUnavailable`](crate::github::PrUnavailable)'s reason: the
+/// frontend acts differently on each. `NotConnected` is the resting state of an
+/// app nobody has connected — an empty state pointing at settings, never an
+/// error — where `Unauthorized` means a key that has been revoked or rotated
+/// and is the one the reader has to do something about.
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "snake_case", tag = "kind", content = "detail")]
+pub enum IssueUnavailable {
+    NotConnected,
+    Unauthorized,
+    /// The workspace could not be reached — offline, or the API is down.
+    Offline(String),
+    Other(String),
+}
+
+impl IssueUnavailable {
+    pub fn other(e: impl std::fmt::Display) -> Self {
+        Self::Other(e.to_string())
+    }
+}
+
+/// Written for whoever reads it as a sentence — a CLI user, or an agent
+/// reading tool output. The frontend draws its own words instead, because a
+/// panel can point at the settings row and a terminal cannot.
+impl std::fmt::Display for IssueUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotConnected => write!(
+                f,
+                "Dray is not connected to an issue tracker. Connect Linear in Dray's settings."
+            ),
+            Self::Unauthorized => write!(
+                f,
+                "Linear rejected the stored key. Reconnect it in Dray's settings."
+            ),
+            Self::Offline(detail) => write!(f, "Could not reach Linear: {detail}"),
+            Self::Other(detail) => write!(f, "{detail}"),
+        }
+    }
+}
+
+impl std::error::Error for IssueUnavailable {}
+
+// ── the connection ───────────────────────────────────────────────────────────
+
+/// Where the key lives: `~/.dray/credentials.json`, `0600`.
+///
+/// **Not the OS keychain, and that was a considered retreat.** macOS ties a
+/// keychain grant to the exact binary that asked for it, so every rebuild is a
+/// new application as far as the ACL is concerned and the grant never sticks —
+/// which on a development machine is an authorisation dialog several times an
+/// hour, forever. Signing with a stable Developer ID settles it for a shipped
+/// build and does nothing for anyone working on the app.
+///
+/// What the retreat costs is worth stating plainly: this key is readable by
+/// anything running as the user, where a keychain entry is not. What makes it
+/// tolerable is the company it keeps — `~/.dray` is `0700` and already holds
+/// every transcript, which is to say every file the agent has read or written
+/// on this machine. A read-only issue-tracker key is not the most sensitive
+/// thing in that directory by a wide margin. `gh`, `npm` and `aws` all make the
+/// same trade.
+///
+/// Its own file rather than a field on `settings.json`, for two reasons that
+/// both bite: settings are rewritten by every analytics toggle and read on the
+/// launch path where a parse failure falls back to defaults — which would
+/// silently forget the key — and `get_settings` hands that struct to the
+/// frontend, which a credential must never ride along with.
+const CREDENTIALS_FILE: &str = "credentials.json";
+
+/// Serializes writers, like every other whole-file rewrite here.
+static CREDENTIALS_LOCK: Mutex<()> = Mutex::const_new(());
+
+impl IssueTracker {
+    /// The key this tracker's credential is filed under. Stable across
+    /// renames of the enum, because it is written to disk.
+    fn credential_key(self) -> &'static str {
+        match self {
+            Self::Linear => "linear",
+        }
+    }
+}
+
+async fn credentials_path() -> Result<PathBuf, String> {
+    get_home_app_dir()
+        .await
+        .map(|dir| dir.join(CREDENTIALS_FILE))
+        .map_err(|e| format!("could not open the Dray directory: {e}"))
+}
+
+async fn read_credentials() -> HashMap<String, String> {
+    let Ok(path) = credentials_path().await else {
+        return HashMap::new();
+    };
+
+    match tokio::fs::read_to_string(&path).await {
+        Ok(text) => serde_json::from_str(&text).unwrap_or_else(|e| {
+            // A file that exists and cannot be parsed reads as no key, which
+            // presents as "not connected" and is curable by connecting again.
+            eprintln!("[credentials parse err] {e}");
+            HashMap::new()
+        }),
+        // Absent is the ordinary case, and says nothing worth logging.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+        Err(e) => {
+            eprintln!("[credentials read err] {e}");
+            HashMap::new()
+        }
+    }
+}
+
+/// The key for a tracker, or `None` for one nothing is stored under.
+///
+/// Unreadable reads as *not connected* rather than as an error — the cure is
+/// the same either way, which is to connect again.
+pub async fn read_key(tracker: IssueTracker) -> Option<String> {
+    read_credentials()
+        .await
+        .get(tracker.credential_key())
+        .map(|key| key.trim().to_string())
+        .filter(|key| !key.is_empty())
+}
+
+/// Writes the file whole at `0600`, temp file included.
+///
+/// The mode is set on the **temp** file before anything is written into it, not
+/// on the final one after the rename: `fs::write` creates at the process umask,
+/// so setting it afterwards leaves a window in which the key sits on disk
+/// world-readable. Narrow, and avoidable for one extra call.
+async fn write_credentials(next: &HashMap<String, String>) -> Result<(), String> {
+    write_credentials_at(&credentials_path().await?, next).await
+}
+
+/// Takes the path so a test can round-trip against a tempdir and read the mode
+/// back, rather than writing into the real `~/.dray`.
+async fn write_credentials_at(
+    path: &std::path::Path,
+    next: &HashMap<String, String>,
+) -> Result<(), String> {
+    let tmp = path.with_extension("json.tmp");
+
+    let body = serde_json::to_string_pretty(next).map_err(|e| e.to_string())?;
+
+    tokio::fs::write(&tmp, &body)
+        .await
+        .map_err(|e| format!("could not write the credentials file: {e}"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600)).await
+        {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(format!("could not secure the credentials file: {e}"));
+        }
+    }
+
+    if let Err(e) = tokio::fs::rename(&tmp, path).await {
+        // Or the next write inherits a stale temp file holding an old key.
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(format!("could not replace the credentials file: {e}"));
+    }
+
+    Ok(())
+}
+
+async fn write_key(tracker: IssueTracker, key: &str) -> Result<(), String> {
+    let _guard = CREDENTIALS_LOCK.lock().await;
+
+    let mut next = read_credentials().await;
+    next.insert(tracker.credential_key().to_string(), key.to_string());
+
+    write_credentials(&next).await
+}
+
+async fn delete_key(tracker: IssueTracker) -> Result<(), String> {
+    let _guard = CREDENTIALS_LOCK.lock().await;
+
+    let mut next = read_credentials().await;
+    // Already gone is what the caller asked for, and rewriting the file to say
+    // the same thing is work with no reader.
+    if next.remove(tracker.credential_key()).is_none() {
+        return Ok(());
+    }
+
+    write_credentials(&next).await
+}
+
+// ── what a tag puts in front of the model ────────────────────────────────────
+
+/// A tag as it is written into a prompt: the identifier, then the title.
+///
+/// Identifier and title, and deliberately nothing else. The agent has the
+/// tracker's own MCP server to read descriptions, comments and links with, and
+/// it fetches what it needs in the shape it wants — where a description pasted
+/// in here is a wall of text at the top of every prompt, stale the moment
+/// somebody edits the issue, and paid for again on every follow-up. The
+/// identifier is the address; the title is what makes the prompt readable
+/// before anything has been fetched.
+///
+/// The same string the composer's picker writes, so a tag typed by hand, picked
+/// from the menu, or named with `--issue` all read identically in the
+/// transcript and to the model. That is what retired the separate block this
+/// used to append: with the title in the tag, the block had nothing left to
+/// say, and a transcript that had to strip its own prompt back apart is a
+/// pattern match waiting to eat somebody's sentence.
+pub fn tag_text(issue: &IssueRef) -> String {
+    // A link made without a title — `dray issue link` writes down what it is
+    // given — leaves the identifier standing alone rather than a trailing
+    // space nobody typed. Matches `issueTag` in issue.ts, which has to agree
+    // with this or a tag reads one way in the composer and another once sent.
+    if issue.title.trim().is_empty() {
+        return format!("#{}", issue.identifier);
+    }
+
+    format!("#{} {}", issue.identifier, issue.title)
+}
+
+/// Every `#ABC-123` in a prompt, in the order they appear and without repeats.
+///
+/// The rule is the token's, the same one `@` mentions follow on the other side
+/// of the bridge: a `#` has to *open* a word, so a colour like `#fff` mid
+/// sentence stays prose — and what follows has to be a team key and a number,
+/// which is what keeps a markdown heading out.
+pub fn issue_tags(prompt: &str) -> Vec<String> {
+    let mut found: Vec<String> = Vec::new();
+
+    for token in prompt.split_whitespace() {
+        // Leading punctuation is stripped so `(#DRA-1)` tags; trailing is left
+        // to `parse_identifier`, which stops at the first non-digit anyway.
+        let token = token.trim_start_matches(['(', '[', '"', '\'']);
+        let Some(rest) = token.strip_prefix('#') else {
+            continue;
+        };
+
+        if let Some(id) = parse_identifier(rest) {
+            if !found.iter().any(|seen| seen == &id) {
+                found.push(id);
+            }
+        }
+    }
+
+    found
+}
+
+/// `DRA-53` out of `DRA-53),` — or `None` when what follows the `#` is not an
+/// identifier at all.
+///
+/// Uppercased, because Linear's own identifiers are and a tag typed in lower
+/// case has to reach the same issue as one picked from the menu.
+pub fn parse_identifier(text: &str) -> Option<String> {
+    let (key, number) = text.split_once('-')?;
+
+    if key.is_empty() || !key.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    // A team key always starts with a letter, which is what keeps `#1-2` out.
+    if !key.chars().next()?.is_ascii_alphabetic() {
+        return None;
+    }
+
+    let digits: String = number.chars().take_while(char::is_ascii_digit).collect();
+    if digits.is_empty() {
+        return None;
+    }
+
+    Some(format!("{}-{}", key.to_uppercase(), digits))
+}
+
+/// The prompt as the model will see it, and every issue it is against.
+///
+/// Two sources, one answer: the `#ABC-123` tags already in the text, and
+/// identifiers named outright — `dray new --issue`, or the issues page starting
+/// a session from a row. A named issue that is not already tagged in the text
+/// is **appended as a tag**, in the same `#DRA-53 Title` form the composer's
+/// picker writes, so there is one shape a tag takes and one thing the
+/// transcript has to draw. Nothing is appended for an issue the text already
+/// names: the reader wrote it, and repeating it under their own sentence is the
+/// same fact twice.
+///
+/// **Best effort, always.** A send must never fail because Linear is
+/// unreachable, a key has been revoked, or a tag names an issue that does not
+/// exist: the tag stays in the text, the link is not recorded, and nothing is
+/// said. The reverse — refusing the prompt — would make an issue tracker a
+/// dependency of typing.
+///
+/// Sequential rather than concurrent: a prompt carries a handful of tags at
+/// most, and one at a time keeps the order they were written in.
+pub async fn expand_tags(prompt: &str, named: &[String]) -> (String, Vec<IssueRef>) {
+    let tagged = issue_tags(prompt);
+
+    let mut wanted: Vec<(String, bool)> = tagged.iter().map(|id| (id.clone(), true)).collect();
+    for identifier in named {
+        // Through the same parse the text goes through: a caller may write
+        // `#DRA-53` or `dra-53`, and both have to reach the issue the picker
+        // would have.
+        if let Some(id) = parse_identifier(identifier.trim_start_matches('#')) {
+            if !wanted.iter().any(|(seen, _)| seen == &id) {
+                wanted.push((id, false));
+            }
+        }
+    }
+
+    if wanted.is_empty() {
+        return (prompt.to_string(), Vec::new());
+    }
+
+    let Some(key) = read_key(IssueTracker::Linear).await else {
+        return (prompt.to_string(), Vec::new());
+    };
+
+    let mut resolved = Vec::new();
+    let mut appended = Vec::new();
+
+    for (tag, in_text) in wanted {
+        match linear::get_issue(&key, &tag).await {
+            Ok(detail) => {
+                let reference = detail.issue.to_ref();
+                if !in_text {
+                    appended.push(tag_text(&reference));
+                }
+                resolved.push(reference);
+            }
+            Err(e) => eprintln!("[issue tag {tag}] {e:?}"),
+        }
+    }
+
+    let text = if appended.is_empty() {
+        prompt.to_string()
+    } else {
+        format!("{prompt}\n\n{}", appended.join("\n"))
+    };
+
+    (text, resolved)
+}
+
+// ── commands ─────────────────────────────────────────────────────────────────
+
+/// What the settings dialog draws. `None` is a tracker nobody has connected.
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IntegrationsView {
+    pub linear: Option<TrackerAccount>,
+}
+
+/// The connected accounts.
+///
+/// Read from two files at once, deliberately: `credentials.json` says whether
+/// there is a key, and `settings.json` remembers whose it is. A cached account with
+/// no key behind it reads as disconnected — the key *is* the connection, and
+/// the cache only saves a round trip to draw a name.
+#[tauri::command]
+pub async fn get_integrations() -> IntegrationsView {
+    let cached = settings::read().await.linear_account;
+    let connected = read_key(IssueTracker::Linear).await.is_some();
+
+    IntegrationsView {
+        linear: connected.then_some(cached).flatten(),
+    }
+}
+
+/// Validates a personal API key, then saves it.
+///
+/// Validated first, always: a key stored without being tried is one the reader
+/// finds out about the next time they open the picker, by which point they have
+/// left settings and the failure looks like the feature being broken. The
+/// identity comes back from the same call, which is what the row draws.
+#[tauri::command]
+pub async fn connect_linear(key: String) -> Result<IntegrationsView, String> {
+    let key = key.trim().to_string();
+    if key.is_empty() {
+        return Err("Paste a Linear API key first.".into());
+    }
+
+    let account = linear::verify(&key).await.map_err(|e| match e {
+        IssueUnavailable::Unauthorized => {
+            "Linear rejected that key. Check it was copied whole and has not been revoked."
+                .to_string()
+        }
+        IssueUnavailable::Offline(detail) => format!("Could not reach Linear: {detail}"),
+        IssueUnavailable::Other(detail) => detail,
+        IssueUnavailable::NotConnected => "No key.".to_string(),
+    })?;
+
+    write_key(IssueTracker::Linear, &key).await?;
+
+    let mut next = settings::read().await;
+    next.linear_account = Some(account);
+    settings::write(&next).await.map_err(|e| e.to_string())?;
+
+    Ok(get_integrations().await)
+}
+
+/// Forgets the key and the account. Sessions keep their linked issues: a link
+/// records what the work was about, and it stays readable — identifier and
+/// title are already on it — whether or not anyone can still reach the tracker.
+#[tauri::command]
+pub async fn disconnect_linear() -> Result<IntegrationsView, String> {
+    delete_key(IssueTracker::Linear).await?;
+
+    let mut next = settings::read().await;
+    next.linear_account = None;
+    settings::write(&next).await.map_err(|e| e.to_string())?;
+
+    Ok(get_integrations().await)
+}
+
+/// Issues matching `query`, best first.
+///
+/// One command behind both the page and the composer's `#` picker, because they
+/// ask the same question with different filters — two commands would be two
+/// orderings of one list, which reads as the picker disagreeing with the page
+/// about which issue is most urgent.
+#[tauri::command]
+pub async fn list_issues(query: IssueQuery, limit: usize) -> Result<Vec<Issue>, IssueUnavailable> {
+    let key = read_key(IssueTracker::Linear).await.ok_or(IssueUnavailable::NotConnected)?;
+
+    linear::list_issues(&key, &query, limit).await
+}
+
+/// One issue, opened — description and comments included.
+#[tauri::command]
+pub async fn get_issue(identifier: String) -> Result<IssueDetail, IssueUnavailable> {
+    let key = read_key(IssueTracker::Linear).await.ok_or(IssueUnavailable::NotConnected)?;
+
+    linear::get_issue(&key, &identifier).await
+}
+
+/// A file uploaded to an issue, fetched with the stored key.
+///
+/// **The whole reason this command exists.** Linear's uploads live behind the
+/// same auth the API does, so the `<img src>` in a description resolves to a
+/// 401 and the webview draws its broken-image box — which reads as "Dray cannot
+/// show this" rather than "this needs a key". Fetching here and handing back a
+/// `data:` URL is what makes an image in an issue an image on screen.
+///
+/// Bytes rather than a signed URL because Linear issues none, and `data:`
+/// rather than a local file because these are read once and thrown away.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct IssueAsset {
+    /// `image/png`, `text/plain`… as the server reported it.
+    pub mime: String,
+    /// `data:<mime>;base64,…`, ready to put in a `src` or an `href`.
+    pub data_url: String,
+    pub bytes: u64,
+}
+
+/// Anything larger is refused rather than read into memory and turned into a
+/// string a third bigger again. Well past a screenshot, which is what these
+/// nearly always are.
+const MAX_ASSET: u64 = 10 * 1024 * 1024;
+
+#[tauri::command]
+pub async fn fetch_issue_asset(url: String) -> Result<IssueAsset, IssueUnavailable> {
+    let key = read_key(IssueTracker::Linear)
+        .await
+        .ok_or(IssueUnavailable::NotConnected)?;
+
+    linear::fetch_asset(&key, &url, MAX_ASSET).await
+}
+
+/// The teams and projects the filter row offers.
+#[tauri::command]
+pub async fn list_issue_filters() -> Result<IssueFilters, IssueUnavailable> {
+    let key = read_key(IssueTracker::Linear).await.ok_or(IssueUnavailable::NotConnected)?;
+
+    linear::list_filters(&key).await
+}
+
+/// Tags a session with an issue, by identifier.
+///
+/// Reads the issue back before recording it, so the link carries the current
+/// title rather than whatever the caller believed — the CLI passes a string a
+/// person typed, and the picker one it read a moment ago.
+/// Untags a session. The issue itself is untouched — this app never writes to
+/// the tracker, so removing a link is a fact about the session alone.
+#[tauri::command]
+pub async fn unlink_issue(
+    session_id: String,
+    key: String,
+) -> Result<Vec<IssueRef>, IssueUnavailable> {
+    store::unlink_session_issue(&session_id, &key)
+        .await
+        .map_err(IssueUnavailable::other)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn issue_ref(identifier: &str, title: &str) -> IssueRef {
+        IssueRef {
+            tracker: IssueTracker::Linear,
+            id: format!("uuid-{identifier}"),
+            identifier: identifier.into(),
+            title: title.into(),
+            url: format!("https://linear.app/x/issue/{identifier}"),
+        }
+    }
+
+    /// The whole of what this file buys over the keychain it replaced: nobody
+    /// but the owner can read it. Worth a test because the failure is silent —
+    /// a key written at the process umask sits there world-readable and behaves
+    /// identically in every other respect.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_credentials_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!(
+            "dray-credentials-{}-{}",
+            std::process::id(),
+            uuid::Uuid::now_v7()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("credentials.json");
+
+        let mut creds = HashMap::new();
+        creds.insert("linear".to_string(), "lin_api_secret".to_string());
+        write_credentials_at(&path, &creds).await.unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "credentials must be owner-only");
+
+        // And the temp file it landed through is gone, not left beside it
+        // holding the same key at whatever mode the umask gave.
+        assert!(!path.with_extension("json.tmp").exists());
+    }
+
+    #[test]
+    fn a_tag_has_to_open_a_word() {
+        assert_eq!(issue_tags("fix #DRA-53 please"), vec!["DRA-53"]);
+        assert_eq!(issue_tags("#DRA-53"), vec!["DRA-53"]);
+        // A colour, and a markdown heading: both are prose, and neither is an
+        // identifier. This is the whole reason the shape is checked at all.
+        assert!(issue_tags("use #fff for the border").is_empty());
+        assert!(issue_tags("# Heading").is_empty());
+        // Mid-word, so not a tag — the same rule `@` mentions follow.
+        assert!(issue_tags("channel#DRA-1").is_empty());
+    }
+
+    #[test]
+    fn punctuation_around_a_tag_is_not_part_of_it() {
+        assert_eq!(issue_tags("see (#DRA-53), then stop"), vec!["DRA-53"]);
+        assert_eq!(issue_tags("[#dra-7]"), vec!["DRA-7"]);
+    }
+
+    #[test]
+    fn tags_keep_their_order_and_appear_once() {
+        assert_eq!(
+            issue_tags("#DRA-2 then #dra-1 and #DRA-2 again"),
+            vec!["DRA-2", "DRA-1"]
+        );
+    }
+
+    #[test]
+    fn a_number_alone_is_not_an_identifier() {
+        assert!(issue_tags("#53").is_empty());
+        assert!(issue_tags("#1-2").is_empty());
+        assert!(issue_tags("#DRA-").is_empty());
+    }
+
+    /// A tag is an address and a title, and that is the whole of what the model
+    /// is handed. Pinned so nobody "improves" it into a context dump — the agent
+    /// has the tracker's own MCP server for the rest.
+    ///
+    /// The frontend writes this exact string when a row is picked
+    /// ([applyIssue](../../../src/lib/issue.ts)), so the two are pinned on both
+    /// sides: a tag picked from the menu and one appended by `--issue` have to
+    /// be the same thing, or the transcript draws two shapes for one idea.
+    #[test]
+    fn a_tag_is_an_identifier_and_a_title() {
+        let text = tag_text(&issue_ref("DRA-53", "Issue tracker integration"));
+
+        assert_eq!(text, "#DRA-53 Issue tracker integration");
+        assert!(
+            !text.contains("http"),
+            "no urls: the identifier is the address"
+        );
+    }
+
+    #[test]
+    fn a_settled_state_is_the_two_that_end_the_work() {
+        assert!(IssueStateKind::Completed.settled());
+        assert!(IssueStateKind::Canceled.settled());
+        assert!(!IssueStateKind::Started.settled());
+        assert!(!IssueStateKind::Backlog.settled());
+    }
+
+    /// Linear's `0` is "no priority", so ordering by the wire integer puts the
+    /// least urgent issues at the top of the page.
+    #[test]
+    fn priority_ranks_urgent_first_and_unset_last() {
+        let mut levels = vec![
+            IssuePriority::from_wire(0),
+            IssuePriority::from_wire(4),
+            IssuePriority::from_wire(1),
+            IssuePriority::from_wire(9),
+        ];
+        levels.sort_by_key(|p| p.rank());
+
+        assert_eq!(
+            levels,
+            vec![
+                IssuePriority::Urgent,
+                IssuePriority::Low,
+                IssuePriority::None,
+                IssuePriority::None
+            ]
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/issues/issues.rs
+++ b/apps/desktop/src-tauri/src/issues/issues.rs
@@ -407,10 +407,16 @@ pub async fn read_key(tracker: IssueTracker) -> Option<String> {
 
 /// Writes the file whole at `0600`, temp file included.
 ///
-/// The mode is set on the **temp** file before anything is written into it, not
-/// on the final one after the rename: `fs::write` creates at the process umask,
-/// so setting it afterwards leaves a window in which the key sits on disk
-/// world-readable. Narrow, and avoidable for one extra call.
+/// The mode rides the **create**, on the temp file, rather than being set after
+/// the write or on the final file after the rename. `fs::write` creates at the
+/// process umask, so every other order leaves a window in which the key sits on
+/// disk world-readable — a `chmod` after the write closes a wide window and
+/// leaves a narrow one, where `OpenOptions::mode` leaves none at all: the file
+/// never exists with a wider mode for a single byte to be written into.
+///
+/// `mode` applies only to a file this call creates, which is what the
+/// `create_new` beside it guarantees. A temp file left behind by a crashed
+/// write could otherwise be one somebody else made, at whatever mode they chose.
 async fn write_credentials(next: &HashMap<String, String>) -> Result<(), String> {
     write_credentials_at(&credentials_path().await?, next).await
 }
@@ -425,20 +431,34 @@ async fn write_credentials_at(
 
     let body = serde_json::to_string_pretty(next).map_err(|e| e.to_string())?;
 
-    tokio::fs::write(&tmp, &body)
+    // Cleared first, so `create_new` below is answering "did this call make the
+    // file" rather than failing over one a crashed write left behind.
+    let _ = tokio::fs::remove_file(&tmp).await;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    // `mode` is inherent on tokio's own `OpenOptions` under unix — no ext trait
+    // to import, and none to forget.
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options
+        .open(&tmp)
         .await
         .map_err(|e| format!("could not write the credentials file: {e}"))?;
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if let Err(e) =
-            tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600)).await
-        {
-            let _ = tokio::fs::remove_file(&tmp).await;
-            return Err(format!("could not secure the credentials file: {e}"));
-        }
+    let written = async {
+        use tokio::io::AsyncWriteExt;
+        file.write_all(body.as_bytes()).await?;
+        file.sync_all().await
     }
+    .await;
+
+    if let Err(e) = written {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(format!("could not write the credentials file: {e}"));
+    }
+    drop(file);
 
     if let Err(e) = tokio::fs::rename(&tmp, path).await {
         // Or the next write inherits a stale temp file holding an old key.
@@ -569,12 +589,71 @@ pub fn parse_identifier(text: &str) -> Option<String> {
 /// said. The reverse — refusing the prompt — would make an issue tracker a
 /// dependency of typing.
 ///
+/// **Best effort does not extend to losing a named issue.** A tag the reader
+/// wrote is *in the prompt already*, so an unresolved one costs its title and
+/// nothing else. One arriving through `--issue` is not: dropping it left the
+/// model a prompt with no mention of the work at all, and answered identically
+/// to success — the caller asked for a session about `DRA-53` and got one about
+/// nothing. So a named issue that could not be resolved is appended bare and
+/// linked bare, exactly as `dray issue link` writes one. Absent metadata is an
+/// ordinary state here, not an error.
+///
 /// Sequential rather than concurrent: a prompt carries a handful of tags at
 /// most, and one at a time keeps the order they were written in.
-pub async fn expand_tags(prompt: &str, named: &[String]) -> (String, Vec<IssueRef>) {
-    let tagged = issue_tags(prompt);
+/// A link with the identifier and nothing else — what is written down when the
+/// tracker could not be asked, and what `dray issue link` writes when its caller
+/// passes no `--title`. `tag_text` drops the trailing space for one of these and
+/// `issueUrl` reads the empty address as none, so it draws as coloured text
+/// rather than a button opening nowhere.
+fn bare_ref(identifier: String) -> IssueRef {
+    IssueRef {
+        tracker: IssueTracker::Linear,
+        id: identifier.clone(),
+        identifier,
+        title: String::new(),
+        url: String::new(),
+    }
+}
 
-    let mut wanted: Vec<(String, bool)> = tagged.iter().map(|id| (id.clone(), true)).collect();
+pub async fn expand_tags(prompt: &str, named: &[String]) -> (String, Vec<IssueRef>) {
+    let wanted = wanted_tags(prompt, named);
+
+    if wanted.is_empty() {
+        return (prompt.to_string(), Vec::new());
+    }
+
+    // `None` is ordinary: nobody has connected a tracker. The named issues below
+    // still have to reach the prompt, so this is not a return.
+    let key = read_key(IssueTracker::Linear).await;
+
+    let mut resolved = Vec::with_capacity(wanted.len());
+    for (tag, _) in &wanted {
+        resolved.push(match &key {
+            // No id to try: a tag is a spelling, and the whole point of this
+            // call is to find out what it names.
+            Some(key) => match linear::get_issue(key, tag, None).await {
+                Ok(detail) => Some(detail.issue.to_ref()),
+                Err(e) => {
+                    eprintln!("[issue tag {tag}] {e:?}");
+                    None
+                }
+            },
+            None => None,
+        });
+    }
+
+    apply_tags(prompt, &wanted, resolved)
+}
+
+/// Every issue this prompt is about, each paired with whether the text already
+/// names it. Text first, in the order it was written; anything `--issue` named
+/// and the text did not, after.
+fn wanted_tags(prompt: &str, named: &[String]) -> Vec<(String, bool)> {
+    let mut wanted: Vec<(String, bool)> = issue_tags(prompt)
+        .into_iter()
+        .map(|id| (id, true))
+        .collect();
+
     for identifier in named {
         // Through the same parse the text goes through: a caller may write
         // `#DRA-53` or `dra-53`, and both have to reach the issue the picker
@@ -586,28 +665,37 @@ pub async fn expand_tags(prompt: &str, named: &[String]) -> (String, Vec<IssueRe
         }
     }
 
-    if wanted.is_empty() {
-        return (prompt.to_string(), Vec::new());
-    }
+    wanted
+}
 
-    let Some(key) = read_key(IssueTracker::Linear).await else {
-        return (prompt.to_string(), Vec::new());
-    };
-
-    let mut resolved = Vec::new();
+/// Builds the prompt the model is given and the links recorded beside it, from
+/// whatever the tracker managed to answer.
+///
+/// Split from the read above so the rule is testable without a key and without
+/// a network: what happens when nothing resolves is exactly the case worth
+/// pinning, and it is the one a test process cannot reach by asking Linear.
+fn apply_tags(
+    prompt: &str,
+    wanted: &[(String, bool)],
+    resolved: Vec<Option<IssueRef>>,
+) -> (String, Vec<IssueRef>) {
+    let mut links = Vec::new();
     let mut appended = Vec::new();
 
-    for (tag, in_text) in wanted {
-        match linear::get_issue(&key, &tag).await {
-            Ok(detail) => {
-                let reference = detail.issue.to_ref();
-                if !in_text {
-                    appended.push(tag_text(&reference));
-                }
-                resolved.push(reference);
-            }
-            Err(e) => eprintln!("[issue tag {tag}] {e:?}"),
+    for ((tag, in_text), found) in wanted.iter().zip(resolved) {
+        let reference = match found {
+            Some(reference) => reference,
+            // A tag the reader typed is already in the text and already says
+            // what it says, so an unresolved one is left alone. A named one has
+            // nothing in the text at all, so it goes in bare.
+            None if *in_text => continue,
+            None => bare_ref(tag.clone()),
+        };
+
+        if !*in_text {
+            appended.push(tag_text(&reference));
         }
+        links.push(reference);
     }
 
     let text = if appended.is_empty() {
@@ -616,7 +704,7 @@ pub async fn expand_tags(prompt: &str, named: &[String]) -> (String, Vec<IssueRe
         format!("{prompt}\n\n{}", appended.join("\n"))
     };
 
-    (text, resolved)
+    (text, links)
 }
 
 // ── commands ─────────────────────────────────────────────────────────────────
@@ -705,11 +793,19 @@ pub async fn list_issues(query: IssueQuery, limit: usize) -> Result<Vec<Issue>, 
 }
 
 /// One issue, opened — description and comments included.
+///
+/// `id` is optional because the caller does not always have one: the panel is
+/// drawing a link that already carries the tracker's own id, while the page is
+/// opening a row it just read. Passing it is what keeps an issue readable after
+/// it moves team and its identifier renumbers.
 #[tauri::command]
-pub async fn get_issue(identifier: String) -> Result<IssueDetail, IssueUnavailable> {
+pub async fn get_issue(
+    identifier: String,
+    id: Option<String>,
+) -> Result<IssueDetail, IssueUnavailable> {
     let key = read_key(IssueTracker::Linear).await.ok_or(IssueUnavailable::NotConnected)?;
 
-    linear::get_issue(&key, &identifier).await
+    linear::get_issue(&key, &identifier, id.as_deref()).await
 }
 
 /// A file uploaded to an issue, fetched with the stored key.
@@ -790,6 +886,47 @@ mod tests {
     /// but the owner can read it. Worth a test because the failure is silent —
     /// a key written at the process umask sits there world-readable and behaves
     /// identically in every other respect.
+    #[test]
+    fn a_named_issue_reaches_the_prompt_even_when_nothing_resolves() {
+        let wanted = wanted_tags("do the thing", &["DRA-53".into()]);
+        // No tracker connected, a revoked key, an unreachable Linear — every
+        // one of them arrives here as `None`, and this is the case that used to
+        // drop the issue and answer identically to success.
+        let (text, issues) = apply_tags("do the thing", &wanted, vec![None]);
+
+        assert!(text.contains("#DRA-53"), "the tag is missing from {text:?}");
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].identifier, "DRA-53");
+        // Bare — an identifier and no more, exactly as `dray issue link` writes
+        // one with no `--title`.
+        assert!(issues[0].title.is_empty());
+        assert!(issues[0].url.is_empty());
+    }
+
+    #[test]
+    fn a_tag_the_reader_typed_is_left_where_it_is() {
+        let prompt = "look at #DRA-53 please";
+        let wanted = wanted_tags(prompt, &[]);
+        let (text, issues) = apply_tags(prompt, &wanted, vec![None]);
+
+        // Already in the text, so nothing is appended and nothing is doubled.
+        assert_eq!(text, prompt);
+        // And nothing is recorded: the tag says what it says without a link
+        // behind it, where a named issue would have been lost entirely.
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn a_named_issue_the_text_already_names_is_not_appended_twice() {
+        let prompt = "look at #DRA-53 please";
+        let wanted = wanted_tags(prompt, &["dra-53".into()]);
+
+        // One entry, not two: `--issue` naming what the text already names is
+        // the same issue, however it was spelled.
+        assert_eq!(wanted, vec![("DRA-53".to_string(), true)]);
+        assert_eq!(apply_tags(prompt, &wanted, vec![None]).0, prompt);
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn the_credentials_file_is_owner_only() {

--- a/apps/desktop/src-tauri/src/issues/linear.rs
+++ b/apps/desktop/src-tauri/src/issues/linear.rs
@@ -118,7 +118,26 @@ query($filter:IssueFilter,$first:Int!){
  }}}
 "#;
 
-/// One issue, opened.
+/// The same issue by its stable id, which is what a link records.
+///
+/// Tried first wherever one is held, because the identifier is not stable:
+/// moving an issue to another team renumbers it, `DRA-53` becomes `ENG-12`, and
+/// a lookup by the recorded spelling then answers "no such issue" for work that
+/// is very much still there. The UUID survives that move.
+const ISSUE_BY_ID: &str = r#"
+query($id:String!){
+ issue(id:$id){
+  id identifier title url priority updatedAt description
+  state{name type color}
+  assignee{name avatarUrl}
+  labels(first:10){nodes{name color}}
+  team{key}
+  project{name}
+  comments(first:50){nodes{body createdAt url user{name avatarUrl}}}
+ }}
+"#;
+
+/// One issue, opened by its human identifier.
 ///
 /// Looked up by team key and number rather than by handing the identifier to
 /// `issue(id:)`: that argument is the UUID, and whether it also resolves a
@@ -144,15 +163,23 @@ query($key:String!,$number:Float!){
 /// to it. The key travels to Linear or nowhere.
 const UPLOADS_HOST: &str = "uploads.linear.app";
 
-/// Whether `url` is one of Linear's own uploads, host-exactly.
+/// Whether `url` is one of Linear's own uploads, over HTTPS, host-exactly.
 ///
 /// Compared against the parsed host rather than by `starts_with` on the string:
 /// `https://uploads.linear.app.evil.test/x` passes a prefix test and is not
 /// Linear, and that is the whole point of the check.
+///
+/// The scheme is half of it, and the half that is easy to leave out. A host
+/// check alone accepts `http://uploads.linear.app/…`, and that request carries
+/// the key in cleartext for anyone on the path to read — an issue description is
+/// text somebody else wrote, so naming the right host over the wrong scheme is
+/// one line of markdown away. Rejected rather than upgraded to HTTPS: rewriting
+/// a URL somebody else supplied to make it acceptable is a guess about what they
+/// meant, and Linear's own uploads are HTTPS.
 pub fn is_upload(url: &str) -> bool {
     reqwest::Url::parse(url)
         .ok()
-        .and_then(|parsed| parsed.host_str().map(|host| host == UPLOADS_HOST))
+        .map(|parsed| parsed.scheme() == "https" && parsed.host_str() == Some(UPLOADS_HOST))
         .unwrap_or(false)
 }
 
@@ -203,13 +230,24 @@ pub async fn fetch_asset(
         .filter(|mime| !mime.is_empty())
         .unwrap_or_else(|| "application/octet-stream".to_string());
 
-    let body = response
-        .bytes()
+    // Streamed rather than `.bytes()`, and that is the cap actually being
+    // enforced. The advertised length above is a courtesy — a server may send
+    // none, or send one that lies — and `.bytes()` drains the whole body into
+    // memory *before* anything could reject it, so a file with no
+    // `Content-Length` was read in full however large it was. Same reading
+    // `cat-file --batch-check` exists for on the git side: refuse on the way in,
+    // not after.
+    let mut body: Vec<u8> = Vec::new();
+    let mut response = response;
+    while let Some(chunk) = response
+        .chunk()
         .await
-        .map_err(|e| IssueUnavailable::Offline(e.to_string()))?;
-
-    if body.len() as u64 > max_bytes {
-        return Err(IssueUnavailable::Other("that file is too large".into()));
+        .map_err(|e| IssueUnavailable::Offline(e.to_string()))?
+    {
+        if body.len() as u64 + chunk.len() as u64 > max_bytes {
+            return Err(IssueUnavailable::Other("that file is too large".into()));
+        }
+        body.extend_from_slice(&chunk);
     }
 
     Ok(IssueAsset {
@@ -279,8 +317,37 @@ pub async fn list_issues(
     Ok(issues)
 }
 
-/// One issue by identifier (`DRA-53`), with its description and comments.
-pub async fn get_issue(key: &str, identifier: &str) -> Result<IssueDetail, IssueUnavailable> {
+/// One issue, with its description and comments.
+///
+/// `id` is the stable id off a link that was resolved once, and it is tried
+/// first: the identifier renumbers when an issue moves team, so a session linked
+/// to `DRA-53` that has since become `ENG-12` reads as an issue that no longer
+/// exists. The identifier is the fallback and not the other way round because it
+/// is the *only* thing a blind link carries — `dray issue link DRA-53` writes the
+/// identifier into both fields, so an `id` that is not a UUID names nothing on
+/// Linear's side and is skipped rather than asked about.
+///
+/// A UUID lookup that comes back empty falls through to the identifier too. The
+/// two disagree only for a link written against an issue since deleted, which is
+/// a corner worth answering with whatever is live rather than with nothing.
+pub async fn get_issue(
+    key: &str,
+    identifier: &str,
+    id: Option<&str>,
+) -> Result<IssueDetail, IssueUnavailable> {
+    if let Some(id) = id.filter(|id| is_stable_id(id)) {
+        match query(key, ISSUE_BY_ID, json!({ "id": id })).await {
+            Ok(data) => {
+                if let Some(node) = data.get("issue").filter(|node| !node.is_null()) {
+                    return read_detail(node, identifier);
+                }
+            }
+            // Not fatal: the identifier below is a second way to ask the same
+            // question, and answering it beats reporting the first attempt.
+            Err(e) => eprintln!("[issue {identifier}] by id: {e:?}"),
+        }
+    }
+
     let (team, number) = split_identifier(identifier).ok_or_else(|| {
         IssueUnavailable::Other(format!("{identifier} is not an issue identifier"))
     })?;
@@ -292,7 +359,20 @@ pub async fn get_issue(key: &str, identifier: &str) -> Result<IssueDetail, Issue
         .cloned()
         .ok_or_else(|| IssueUnavailable::Other(format!("No issue {identifier}")))?;
 
-    let issue = map_issue(&node)
+    read_detail(&node, identifier)
+}
+
+/// Whether `id` is Linear's own id rather than an identifier a blind link wrote
+/// into the same field. A UUID and a `DRA-53` cannot be confused for each other,
+/// which is the property `unlink_session_issue` already leans on.
+fn is_stable_id(id: &str) -> bool {
+    id.len() == 36
+        && id.split('-').map(str::len).eq([8, 4, 4, 4, 12])
+        && id.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+}
+
+fn read_detail(node: &Value, identifier: &str) -> Result<IssueDetail, IssueUnavailable> {
+    let issue = map_issue(node)
         .ok_or_else(|| IssueUnavailable::Other(format!("Could not read {identifier}")))?;
 
     Ok(IssueDetail {
@@ -305,7 +385,7 @@ pub async fn get_issue(key: &str, identifier: &str) -> Result<IssueDetail, Issue
             .map(str::trim)
             .filter(|body| !body.is_empty())
             .map(str::to_string),
-        comments: map_comments(&node),
+        comments: map_comments(node),
     })
 }
 
@@ -630,6 +710,20 @@ mod tests {
         assert!(!is_upload("https://api.linear.app/graphql"));
         assert!(!is_upload("/relative/path.png"));
         assert!(!is_upload("not a url"));
+        // Right host, wrong scheme: that request would put the key on the wire
+        // in cleartext.
+        assert!(!is_upload("http://uploads.linear.app/a/b/c.png"));
+    }
+
+    #[test]
+    fn only_a_uuid_is_worth_asking_linear_about() {
+        // What a resolved link records.
+        assert!(is_stable_id("9c1a7f2e-0b64-4c3a-9f1d-7e5b2a8c4d61"));
+        // What a blind `dray issue link DRA-53` writes into the same field.
+        assert!(!is_stable_id("DRA-53"));
+        assert!(!is_stable_id(""));
+        // Right shape, wrong alphabet — a lookup on this can only 404.
+        assert!(!is_stable_id("9c1a7f2e-0b64-4c3a-9f1d-7e5b2a8c4dzz"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/issues/linear.rs
+++ b/apps/desktop/src-tauri/src/issues/linear.rs
@@ -1,0 +1,764 @@
+//! Linear, over its GraphQL API.
+//!
+//! The one file in the app that talks to a service directly rather than
+//! shelling out to a CLI the way `gh` and `claude` are reached — Linear ships
+//! no CLI to borrow auth from, so the key is ours to hold and the wire is ours
+//! to parse. Everything it answers is turned into the vocabulary next door
+//! before it leaves; nothing above this file knows a `LinearIssue` exists.
+//!
+//! **Two wire facts shape the whole module.** A failed GraphQL query answers
+//! `200` with `{"data":null,"errors":[…]}`, so the status code proves nothing
+//! and `errors` is checked first — the same trap [`github`](crate::github)
+//! documents. And every field is read *out of a `Value`* rather than derived
+//! onto a struct: a schema Linear extends must cost one absent field, never a
+//! whole list that fails to deserialize and leaves the page empty.
+
+use std::{sync::OnceLock, time::Duration};
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use serde_json::{json, Value};
+
+use super::{
+    Issue, IssueAsset, IssueComment, IssueDetail, IssueFilters, IssueGroup, IssueLabel, IssuePerson,
+    IssuePriority, IssueQuery, IssueScope, IssueState, IssueStateKind, IssueTracker,
+    IssueUnavailable, TrackerAccount,
+};
+
+const API: &str = "https://api.linear.app/graphql";
+
+/// Long enough for a cold query against a large workspace, short enough that a
+/// picker keystroke cannot hang the composer's list for a minute.
+const TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Shared, because a `Client` owns the connection pool: minting one per
+/// keystroke would open a TLS connection per keystroke.
+fn client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(TIMEOUT)
+            .user_agent(concat!("Dray/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .expect("reqwest client")
+    })
+}
+
+/// One query, with the errors already read.
+///
+/// The key travels in `Authorization` bare, not as a `Bearer` — that is how
+/// Linear takes a *personal* key, and the OAuth spelling is refused.
+async fn query(key: &str, document: &str, variables: Value) -> Result<Value, IssueUnavailable> {
+    let response = client()
+        .post(API)
+        .header("Authorization", key)
+        .json(&json!({ "query": document, "variables": variables }))
+        .send()
+        .await
+        .map_err(|e| IssueUnavailable::Offline(e.to_string()))?;
+
+    let status = response.status();
+    // Read before branching on the status: an error body is where Linear says
+    // *why*, and a 400 with a readable sentence beats "400" on its own.
+    let body: Value = response.json().await.unwrap_or(Value::Null);
+
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(IssueUnavailable::Unauthorized);
+    }
+
+    if let Some(message) = first_error(&body) {
+        // Linear reports a bad key as an ordinary GraphQL error too, so the
+        // sentence is what tells the two apart at 200.
+        let lower = message.to_lowercase();
+        if lower.contains("authentication") || lower.contains("unauthorized") {
+            return Err(IssueUnavailable::Unauthorized);
+        }
+        return Err(IssueUnavailable::Other(message));
+    }
+
+    if !status.is_success() {
+        return Err(IssueUnavailable::Other(format!("Linear answered {status}")));
+    }
+
+    Ok(body.get("data").cloned().unwrap_or(Value::Null))
+}
+
+fn first_error(body: &Value) -> Option<String> {
+    let errors = body.get("errors")?.as_array()?;
+    let first = errors.first()?;
+
+    Some(
+        first
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("Linear rejected the query")
+            .to_string(),
+    )
+}
+
+// ── queries ──────────────────────────────────────────────────────────────────
+
+/// Who the key belongs to. Also what validates it: there is no cheaper call,
+/// and it answers with everything the settings row draws.
+const VIEWER: &str = r#"
+query{viewer{id name organization{name}}}
+"#;
+
+/// Every field a row draws, and none it doesn't — no description and no
+/// comments, which are [`ISSUE`]'s and cost the better part of the payload.
+const ISSUES: &str = r#"
+query($filter:IssueFilter,$first:Int!){
+ issues(filter:$filter,first:$first,orderBy:updatedAt){nodes{
+  id identifier title url priority updatedAt
+  state{name type color}
+  assignee{name avatarUrl}
+  labels(first:10){nodes{name color}}
+  team{key}
+  project{name}
+ }}}
+"#;
+
+/// One issue, opened.
+///
+/// Looked up by team key and number rather than by handing the identifier to
+/// `issue(id:)`: that argument is the UUID, and whether it also resolves a
+/// human identifier is a convenience nothing in the schema promises. A filter
+/// on the two halves is exactly as precise and is documented.
+const ISSUE: &str = r#"
+query($key:String!,$number:Float!){
+ issues(filter:{team:{key:{eq:$key}},number:{eq:$number}},first:1){nodes{
+  id identifier title url priority updatedAt description
+  state{name type color}
+  assignee{name avatarUrl}
+  labels(first:10){nodes{name color}}
+  team{key}
+  project{name}
+  comments(first:50){nodes{body createdAt url user{name avatarUrl}}}
+ }}}
+"#;
+
+/// Where Linear serves uploaded files. Checked before anything is fetched with
+/// the key attached: this command takes a URL out of an issue's own markdown,
+/// and markdown is text somebody else wrote — so without this, an issue
+/// description could name any host it liked and have the app post a credential
+/// to it. The key travels to Linear or nowhere.
+const UPLOADS_HOST: &str = "uploads.linear.app";
+
+/// Whether `url` is one of Linear's own uploads, host-exactly.
+///
+/// Compared against the parsed host rather than by `starts_with` on the string:
+/// `https://uploads.linear.app.evil.test/x` passes a prefix test and is not
+/// Linear, and that is the whole point of the check.
+pub fn is_upload(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(|host| host == UPLOADS_HOST))
+        .unwrap_or(false)
+}
+
+/// One uploaded file as a `data:` URL.
+pub async fn fetch_asset(
+    key: &str,
+    url: &str,
+    max_bytes: u64,
+) -> Result<IssueAsset, IssueUnavailable> {
+    if !is_upload(url) {
+        return Err(IssueUnavailable::Other(
+            "that file is not hosted by Linear".into(),
+        ));
+    }
+
+    let response = client()
+        .get(url)
+        .header("Authorization", key)
+        .send()
+        .await
+        .map_err(|e| IssueUnavailable::Offline(e.to_string()))?;
+
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(IssueUnavailable::Unauthorized);
+    }
+    if !status.is_success() {
+        return Err(IssueUnavailable::Other(format!("Linear answered {status}")));
+    }
+
+    // The advertised length first, so an oversized file is refused before its
+    // body is read rather than after — the same reading `cat-file --batch-check`
+    // exists for on the git side. A server that sends no length is still capped
+    // below, on what actually arrived.
+    if let Some(len) = response.content_length() {
+        if len > max_bytes {
+            return Err(IssueUnavailable::Other("that file is too large".into()));
+        }
+    }
+
+    let mime = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        // Split on `;` because the header carries charset with it, and a
+        // `data:` URL wants the type alone.
+        .map(|value| value.split(';').next().unwrap_or(value).trim().to_string())
+        .filter(|mime| !mime.is_empty())
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+
+    let body = response
+        .bytes()
+        .await
+        .map_err(|e| IssueUnavailable::Offline(e.to_string()))?;
+
+    if body.len() as u64 > max_bytes {
+        return Err(IssueUnavailable::Other("that file is too large".into()));
+    }
+
+    Ok(IssueAsset {
+        data_url: format!("data:{mime};base64,{}", BASE64.encode(&body)),
+        mime,
+        bytes: body.len() as u64,
+    })
+}
+
+/// The filter row's options. Archived teams and projects are left out by
+/// Linear's own defaults, which is the right way round — a filter offering a
+/// team nobody works in is a row to skip past.
+const FILTERS: &str = r#"
+query{
+ teams(first:100){nodes{id name}}
+ projects(first:100){nodes{id name}}}
+"#;
+
+/// Validates `key` and answers with whose it is.
+pub async fn verify(key: &str) -> Result<TrackerAccount, IssueUnavailable> {
+    let data = query(key, VIEWER, json!({})).await?;
+    let viewer = data
+        .get("viewer")
+        .ok_or_else(|| IssueUnavailable::Other("Linear answered with no account".into()))?;
+
+    Ok(TrackerAccount {
+        tracker: IssueTracker::Linear,
+        user_id: text(viewer, "id"),
+        user_name: text(viewer, "name"),
+        org_name: viewer
+            .get("organization")
+            .map(|org| text(org, "name"))
+            .unwrap_or_default(),
+    })
+}
+
+/// Issues matching `query`, most urgent first.
+///
+/// Sorted here rather than by the API. Linear orders by `createdAt` or
+/// `updatedAt` and nothing else, and "what should I pick up" is a priority
+/// question — so the API's own order is asked for as the *tiebreak* (newest
+/// touched first) and the levels are applied over it.
+pub async fn list_issues(
+    key: &str,
+    filters: &IssueQuery,
+    limit: usize,
+) -> Result<Vec<Issue>, IssueUnavailable> {
+    let data = query(
+        key,
+        ISSUES,
+        json!({ "filter": build_filter(filters), "first": limit.clamp(1, 250) }),
+    )
+    .await?;
+
+    let mut issues = nodes(&data, "issues")
+        .iter()
+        .filter_map(map_issue)
+        .collect::<Vec<_>>();
+
+    // Stable, so the API's newest-first order survives inside a level. Only on
+    // the unfinished half: priority on a closed issue is a fact about a decision
+    // already taken, and sorting by it buries the thing that just landed.
+    if !filters.settled {
+        issues.sort_by_key(|issue| issue.priority.rank());
+    }
+
+    Ok(issues)
+}
+
+/// One issue by identifier (`DRA-53`), with its description and comments.
+pub async fn get_issue(key: &str, identifier: &str) -> Result<IssueDetail, IssueUnavailable> {
+    let (team, number) = split_identifier(identifier).ok_or_else(|| {
+        IssueUnavailable::Other(format!("{identifier} is not an issue identifier"))
+    })?;
+
+    let data = query(key, ISSUE, json!({ "key": team, "number": number })).await?;
+
+    let node = nodes(&data, "issues")
+        .first()
+        .cloned()
+        .ok_or_else(|| IssueUnavailable::Other(format!("No issue {identifier}")))?;
+
+    let issue = map_issue(&node)
+        .ok_or_else(|| IssueUnavailable::Other(format!("Could not read {identifier}")))?;
+
+    Ok(IssueDetail {
+        issue,
+        // Linear sends an empty string for an issue nobody wrote a description
+        // for, and an empty box on screen says less than a sentence saying so.
+        description: node
+            .get("description")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|body| !body.is_empty())
+            .map(str::to_string),
+        comments: map_comments(&node),
+    })
+}
+
+pub async fn list_filters(key: &str) -> Result<IssueFilters, IssueUnavailable> {
+    let data = query(key, FILTERS, json!({})).await?;
+
+    Ok(IssueFilters {
+        teams: map_groups(&data, "teams"),
+        projects: map_groups(&data, "projects"),
+    })
+}
+
+// ── building the filter ──────────────────────────────────────────────────────
+
+/// [`IssueQuery`] as Linear's `IssueFilter`.
+///
+/// Every clause is additive and every one is optional, so the resting state —
+/// assigned to me, not yet finished — is what an empty query produces. Text is
+/// matched against the title *or* the description: an issue is usually found by
+/// a word in its body, and searching titles alone reads as the picker not
+/// finding issues that plainly exist.
+fn build_filter(query: &IssueQuery) -> Value {
+    let mut filter = serde_json::Map::new();
+
+    match query.scope {
+        IssueScope::Assigned => {
+            filter.insert("assignee".into(), json!({ "isMe": { "eq": true } }));
+        }
+        IssueScope::Created => {
+            filter.insert("creator".into(), json!({ "isMe": { "eq": true } }));
+        }
+        IssueScope::All => {}
+    }
+
+    // Always one side or the other, never both. `in` on the settled read rather
+    // than dropping the clause: an unbounded read would hand the page the whole
+    // workspace to filter down to two groups it drew collapsed.
+    let settled = ["completed", "canceled"];
+    filter.insert(
+        "state".into(),
+        if query.settled {
+            json!({ "type": { "in": settled } })
+        } else {
+            json!({ "type": { "nin": settled } })
+        },
+    );
+
+    if let Some(team) = query.team_id.as_deref().filter(|id| !id.is_empty()) {
+        filter.insert("team".into(), json!({ "id": { "eq": team } }));
+    }
+
+    if let Some(project) = query.project_id.as_deref().filter(|id| !id.is_empty()) {
+        filter.insert("project".into(), json!({ "id": { "eq": project } }));
+    }
+
+    if let Some(text) = query
+        .text
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+    {
+        // An identifier typed in full is an address, not a search: `DRA-53`
+        // should reach DRA-53 rather than every issue mentioning it. Matched
+        // alongside the text clauses rather than instead of them, since a
+        // half-typed key is still prose.
+        let mut any = vec![
+            json!({ "title": { "containsIgnoreCase": text } }),
+            json!({ "description": { "containsIgnoreCase": text } }),
+        ];
+
+        if let Some((team, number)) = split_identifier(text) {
+            any.push(json!({ "team": { "key": { "eq": team } }, "number": { "eq": number } }));
+        }
+
+        filter.insert("or".into(), Value::Array(any));
+    }
+
+    Value::Object(filter)
+}
+
+/// `DRA-53` → `("DRA", 53)`. `None` for anything that isn't one, which is what
+/// keeps a half-typed query out of the identifier clause.
+fn split_identifier(text: &str) -> Option<(String, f64)> {
+    let (key, number) = text.trim().split_once('-')?;
+    if key.is_empty() || !key.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+
+    Some((key.to_uppercase(), number.parse::<u32>().ok()? as f64))
+}
+
+// ── wire → vocabulary ────────────────────────────────────────────────────────
+
+/// A connection's `nodes`, or nothing. Every connection Linear answers with is
+/// nullable, so this being tolerant is what keeps an issue with no labels from
+/// costing the row it is on.
+fn nodes<'a>(parent: &'a Value, field: &str) -> &'a [Value] {
+    parent
+        .get(field)
+        .and_then(|c| c.get("nodes"))
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+fn text(value: &Value, field: &str) -> String {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn optional(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// `None` only for a node missing its identifier — a row that cannot be
+/// addressed is one no tag could ever reach, so it is dropped rather than drawn.
+/// Everything else degrades to a default, which costs a field on screen and not
+/// the read.
+fn map_issue(node: &Value) -> Option<Issue> {
+    let identifier = optional(node, "identifier")?;
+
+    Some(Issue {
+        tracker: IssueTracker::Linear,
+        id: text(node, "id"),
+        identifier,
+        title: text(node, "title"),
+        url: text(node, "url"),
+        state: map_state(node.get("state")),
+        priority: IssuePriority::from_wire(
+            node.get("priority").and_then(Value::as_f64).unwrap_or(0.0) as i64,
+        ),
+        assignee: node.get("assignee").and_then(map_person),
+        labels: nodes(node, "labels")
+            .iter()
+            .map(|label| IssueLabel {
+                name: text(label, "name"),
+                color: text(label, "color"),
+            })
+            .collect(),
+        team: node.get("team").map(|team| text(team, "key")),
+        project: node.get("project").map(|project| text(project, "name")),
+        updated_at: text(node, "updatedAt"),
+    })
+}
+
+/// An issue always has a state; a *missing* one is a schema surprise, and
+/// "Unknown" on one row says more than a dropped row does.
+fn map_state(value: Option<&Value>) -> IssueState {
+    let Some(value) = value.filter(|v| !v.is_null()) else {
+        return IssueState {
+            name: "Unknown".into(),
+            kind: IssueStateKind::Other,
+            color: String::new(),
+        };
+    };
+
+    IssueState {
+        name: text(value, "name"),
+        kind: match value
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+        {
+            "triage" => IssueStateKind::Triage,
+            "backlog" => IssueStateKind::Backlog,
+            "unstarted" => IssueStateKind::Unstarted,
+            "started" => IssueStateKind::Started,
+            "completed" => IssueStateKind::Completed,
+            "canceled" => IssueStateKind::Canceled,
+            _ => IssueStateKind::Other,
+        },
+        color: text(value, "color"),
+    }
+}
+
+fn map_person(value: &Value) -> Option<IssuePerson> {
+    if value.is_null() {
+        return None;
+    }
+
+    Some(IssuePerson {
+        name: text(value, "name"),
+        avatar: optional(value, "avatarUrl"),
+    })
+}
+
+/// Oldest first, which is reading order — the same order the PR panel puts a
+/// review thread in.
+fn map_comments(node: &Value) -> Vec<IssueComment> {
+    let mut comments: Vec<IssueComment> = nodes(node, "comments")
+        .iter()
+        .map(|comment| IssueComment {
+            author: comment
+                .get("user")
+                .and_then(map_person)
+                // A comment left by an integration has no user on it, and
+                // "Unknown" beside the text beats a row with a blank byline.
+                .unwrap_or(IssuePerson {
+                    name: "Unknown".into(),
+                    avatar: None,
+                }),
+            body: text(comment, "body"),
+            created_at: text(comment, "createdAt"),
+            url: optional(comment, "url"),
+        })
+        .collect();
+
+    comments.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    comments
+}
+
+fn map_groups(data: &Value, field: &str) -> Vec<IssueGroup> {
+    let mut groups: Vec<IssueGroup> = nodes(data, field)
+        .iter()
+        .filter_map(|node| {
+            let id = optional(node, "id")?;
+            Some(IssueGroup {
+                id,
+                name: text(node, "name"),
+            })
+        })
+        .collect();
+
+    // Alphabetical: a filter menu is read by name, and Linear's own order here
+    // is by creation, which nobody remembers.
+    groups.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    groups
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shape Linear answers a list query with, cut to one node. Hand-written
+    /// rather than captured, because a capture would carry a real workspace's
+    /// issues into the repo — so the fields here are the ones [`ISSUES`] asks
+    /// for, and this test is what keeps the two in step.
+    fn node() -> Value {
+        json!({
+            "id": "3fa1",
+            "identifier": "DRA-53",
+            "title": "Issue tracker integration",
+            "url": "https://linear.app/drayhq/issue/DRA-53",
+            "priority": 2.0,
+            "updatedAt": "2026-08-27T06:11:15.154Z",
+            "description": "Long body the prompt never sees.",
+            "state": { "name": "In Progress", "type": "started", "color": "#f2c94c" },
+            "assignee": { "name": "Yogesh Dhakal", "avatarUrl": "https://x/y.png" },
+            "labels": { "nodes": [{ "name": "Feature", "color": "#bb87fc" }] },
+            "team": { "key": "DRA" },
+            "project": { "name": "Integrations" },
+            "comments": { "nodes": [
+                { "body": "second", "createdAt": "2026-08-27T09:00:00.000Z", "url": null,
+                  "user": { "name": "A", "avatarUrl": null } },
+                { "body": "first", "createdAt": "2026-08-27T08:00:00.000Z", "url": "https://c",
+                  "user": { "name": "B", "avatarUrl": null } }
+            ]}
+        })
+    }
+
+    #[test]
+    fn an_issue_maps_onto_the_vocabulary() {
+        let issue = map_issue(&node()).unwrap();
+
+        assert_eq!(issue.identifier, "DRA-53");
+        assert_eq!(issue.priority, IssuePriority::High);
+        assert_eq!(issue.state.kind, IssueStateKind::Started);
+        assert_eq!(issue.state.name, "In Progress");
+        assert_eq!(issue.team.as_deref(), Some("DRA"));
+        assert_eq!(issue.project.as_deref(), Some("Integrations"));
+        assert_eq!(issue.labels.len(), 1);
+        assert_eq!(issue.assignee.unwrap().name, "Yogesh Dhakal");
+    }
+
+    /// The point of reading fields out of a `Value`: a node stripped to almost
+    /// nothing still draws a row rather than failing the whole list.
+    #[test]
+    fn a_sparse_node_costs_fields_and_not_the_read() {
+        let issue = map_issue(&json!({ "identifier": "DRA-1" })).unwrap();
+
+        assert_eq!(issue.title, "");
+        assert_eq!(issue.priority, IssuePriority::None);
+        assert_eq!(issue.state.kind, IssueStateKind::Other);
+        assert!(issue.assignee.is_none());
+        assert!(issue.labels.is_empty());
+    }
+
+    #[test]
+    fn a_node_with_no_identifier_is_dropped() {
+        assert!(map_issue(&json!({ "title": "no address" })).is_none());
+    }
+
+    #[test]
+    fn comments_come_back_oldest_first() {
+        let comments = map_comments(&node());
+
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].body, "first");
+        assert_eq!(comments[1].body, "second");
+    }
+
+    /// The key travels to Linear or nowhere. A description is text somebody
+    /// else wrote, and it names the URL this fetch is handed — so without the
+    /// host check, an issue could point at any server it liked and have the app
+    /// post a credential to it.
+    #[test]
+    fn only_linears_own_uploads_get_the_key() {
+        assert!(is_upload("https://uploads.linear.app/a/b/c.png"));
+
+        // A prefix test passes this one, which is exactly why the check is on
+        // the parsed host and not on the string.
+        assert!(!is_upload("https://uploads.linear.app.evil.test/x.png"));
+        assert!(!is_upload("https://evil.test/?u=uploads.linear.app"));
+        // The API host is not the upload host, and neither is a bare path.
+        assert!(!is_upload("https://api.linear.app/graphql"));
+        assert!(!is_upload("/relative/path.png"));
+        assert!(!is_upload("not a url"));
+    }
+
+    #[test]
+    fn a_comment_left_by_no_user_still_draws() {
+        let comments = map_comments(&json!({
+            "comments": { "nodes": [{ "body": "hi", "createdAt": "t", "user": null }] }
+        }));
+
+        assert_eq!(comments[0].author.name, "Unknown");
+    }
+
+    /// The resting state, and the one most reads use.
+    #[test]
+    fn the_default_filter_is_mine_and_unfinished() {
+        let filter = build_filter(&IssueQuery::default());
+
+        assert_eq!(filter["assignee"]["isMe"]["eq"], true);
+        assert_eq!(filter["state"]["type"]["nin"][0], "completed");
+        assert_eq!(filter["state"]["type"]["nin"][1], "canceled");
+        assert!(filter.get("or").is_none());
+    }
+
+    /// The settled read is the *complement*, not a widening — or the page would
+    /// have to pull a whole workspace back to fill two collapsed groups.
+    #[test]
+    fn the_settled_read_asks_for_the_other_half() {
+        let filter = build_filter(&IssueQuery {
+            settled: true,
+            ..Default::default()
+        });
+
+        assert_eq!(filter["state"]["type"]["in"][0], "completed");
+        assert_eq!(filter["state"]["type"]["in"][1], "canceled");
+        assert!(filter["state"]["type"].get("nin").is_none());
+    }
+
+    #[test]
+    fn widening_drops_the_clauses_that_narrow() {
+        let filter = build_filter(&IssueQuery {
+            scope: IssueScope::All,
+            ..Default::default()
+        });
+
+        assert!(filter.get("assignee").is_none());
+        assert!(filter.get("creator").is_none());
+    }
+
+    /// The two halves of "my issues", and they are exclusive: an issue you
+    /// filed and somebody else owns is not one you are working on.
+    #[test]
+    fn created_asks_about_the_creator_and_not_the_assignee() {
+        let filter = build_filter(&IssueQuery {
+            scope: IssueScope::Created,
+            ..Default::default()
+        });
+
+        assert_eq!(filter["creator"]["isMe"]["eq"], true);
+        assert!(filter.get("assignee").is_none());
+    }
+
+    #[test]
+    fn text_matches_title_or_body() {
+        let filter = build_filter(&IssueQuery {
+            text: Some("worktree".into()),
+            ..Default::default()
+        });
+
+        let any = filter["or"].as_array().unwrap();
+        assert_eq!(any.len(), 2, "no identifier clause for prose");
+        assert_eq!(any[0]["title"]["containsIgnoreCase"], "worktree");
+        assert_eq!(any[1]["description"]["containsIgnoreCase"], "worktree");
+    }
+
+    /// A whole identifier is an address, so it gets a clause of its own —
+    /// without it, typing `DRA-53` finds every issue that mentions DRA-53 and
+    /// not, reliably, DRA-53.
+    #[test]
+    fn a_whole_identifier_gets_its_own_clause() {
+        let filter = build_filter(&IssueQuery {
+            text: Some("dra-53".into()),
+            ..Default::default()
+        });
+
+        let any = filter["or"].as_array().unwrap();
+        assert_eq!(any.len(), 3);
+        assert_eq!(any[2]["team"]["key"]["eq"], "DRA");
+        assert_eq!(any[2]["number"]["eq"], 53.0);
+    }
+
+    #[test]
+    fn an_empty_query_adds_no_text_clause() {
+        let filter = build_filter(&IssueQuery {
+            text: Some("   ".into()),
+            ..Default::default()
+        });
+
+        assert!(filter.get("or").is_none());
+    }
+
+    #[test]
+    fn identifiers_split_into_a_key_and_a_number() {
+        assert_eq!(split_identifier("DRA-53"), Some(("DRA".into(), 53.0)));
+        assert_eq!(split_identifier("dra-53"), Some(("DRA".into(), 53.0)));
+        assert_eq!(split_identifier("DRA-"), None);
+        assert_eq!(split_identifier("53"), None);
+        assert_eq!(split_identifier("DRA-53x"), None);
+    }
+
+    /// A 200 carrying `errors` is a *failure*, and the status code says nothing
+    /// about it — the one wire fact this module is most likely to be broken by.
+    #[test]
+    fn errors_are_read_before_data() {
+        let body = json!({ "data": null, "errors": [{ "message": "Entity not found" }] });
+        assert_eq!(first_error(&body).as_deref(), Some("Entity not found"));
+
+        assert!(first_error(&json!({ "data": { "viewer": {} } })).is_none());
+        // An error array with an unfamiliar shape still reads as an error.
+        assert!(first_error(&json!({ "errors": [{}] })).is_some());
+    }
+
+    #[test]
+    fn groups_come_back_alphabetical() {
+        let data = json!({ "teams": { "nodes": [
+            { "id": "2", "name": "web" },
+            { "id": "1", "name": "Dray" }
+        ]}});
+
+        let teams = map_groups(&data, "teams");
+        assert_eq!(teams[0].name, "Dray");
+        assert_eq!(teams[1].name, "web");
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -22,6 +22,8 @@ pub mod git;
 pub mod github;
 #[path = "harness/harness.rs"]
 pub mod harness;
+#[path = "issues/issues.rs"]
+pub mod issues;
 #[path = "models/models.rs"]
 pub mod models;
 pub mod notifications;
@@ -62,6 +64,11 @@ async fn send_msg(
             session_id,
             prompt,
             &attachment_paths,
+            // Nothing named: everything the app sends tags its issues in the
+            // prompt text, picker and issues page alike, so there is one rule
+            // on this side of the bridge. `--issue` on the CLI is the other
+            // caller, and it names them because a flag is not prose.
+            &[],
             harness,
             model,
             effort,
@@ -609,6 +616,14 @@ pub fn run() {
             notifications::notify_session,
             updater::check_update,
             updater::install_update,
+            issues::get_integrations,
+            issues::connect_linear,
+            issues::disconnect_linear,
+            issues::list_issues,
+            issues::get_issue,
+            issues::fetch_issue_asset,
+            issues::list_issue_filters,
+            issues::unlink_issue,
             github::prs_for_branch,
             github::pr_marks,
             github::merge_pr,

--- a/apps/desktop/src-tauri/src/orchestration.rs
+++ b/apps/desktop/src-tauri/src/orchestration.rs
@@ -15,14 +15,15 @@
 
 use crate::{
     events::{ApprovalPolicy, MessageSender},
+    issues::{self, IssueRef, IssueTracker},
     models::{default_model, find_model, Effort, ModelId},
     session::{Harness, SessionManager},
     store::{self, SessionIndexItem},
 };
 use anyhow::{bail, Context, Result};
 use dray_proto::{
-    encode_line, CreateSession, Envelope, ListSessions, Request, Response, SendMessage,
-    SessionSummary, MAX_LINE, PROTOCOL_VERSION,
+    encode_line, CreateSession, Envelope, IssueLink, LinkIssues, ListSessions, Request, Response,
+    SendMessage, SessionSummary, MAX_LINE, PROTOCOL_VERSION,
 };
 use std::path::Path;
 use tauri::{AppHandle, Emitter, Manager};
@@ -216,7 +217,72 @@ async fn dispatch(request: Request, app: &AppHandle) -> Result<Response> {
         Request::CreateSession(create) => create_session(create, app).await,
         Request::ListSessions(list) => list_sessions(list).await,
         Request::SendMessage(send) => send_message(send, app).await,
+        Request::LinkIssues(link) => link_issues(link).await,
     }
+}
+
+/// Tags a session that already exists, or untags it.
+///
+/// **Written down as given, with nothing asked of the tracker.** A link is a
+/// local record — this session is about that work — so making it depend on a
+/// reachable Linear and a stored key meant it could fail for reasons that have
+/// nothing to do with what it records. The caller is an agent that has just
+/// read the issue through the tracker's own MCP server and holds the title and
+/// the URL already; asking a second system for what the caller has in hand is a
+/// round trip whose only contribution is a way to fail.
+///
+/// Every issue is applied in turn and the *whole* resulting list comes back, so
+/// a caller sees what the session carries rather than a diff it has to apply to
+/// what it believed. One that fails stops the run: a partial tagging reported
+/// as a success is the shape of failure this protocol exists to avoid, and the
+/// ones already applied are on the session the answer names.
+async fn link_issues(link: LinkIssues) -> Result<Response> {
+    if link.issues.is_empty() {
+        bail!("name at least one issue, like DRA-53");
+    }
+
+    // An unknown session is answered before anything is written, so a typo in
+    // the id cannot half-apply a list.
+    store::get_session_index_item(&link.session_id)
+        .await?
+        .with_context(|| format!("no session {}", link.session_id))?;
+
+    let mut linked = Vec::new();
+    for input in &link.issues {
+        let identifier = issues::parse_identifier(&input.identifier)
+            .with_context(|| format!("{} is not an issue identifier", input.identifier))?;
+
+        linked = if link.unlink {
+            store::unlink_session_issue(&link.session_id, &identifier).await?
+        } else {
+            store::link_session_issue(
+                &link.session_id,
+                IssueRef {
+                    tracker: IssueTracker::Linear,
+                    // No tracker call, so no stable tracker id to record. The
+                    // identifier stands in: `unlink_session_issue` already
+                    // matches on either, so a link made here is removable by
+                    // the panel's button and by `dray issue unlink` alike.
+                    id: identifier.clone(),
+                    identifier,
+                    title: input.title.clone().unwrap_or_default(),
+                    url: input.url.clone().unwrap_or_default(),
+                },
+            )
+            .await?
+        };
+    }
+
+    Ok(Response::Linked {
+        issues: linked
+            .into_iter()
+            .map(|issue| IssueLink {
+                identifier: issue.identifier,
+                title: issue.title,
+                url: issue.url,
+            })
+            .collect(),
+    })
 }
 
 async fn create_session(create: CreateSession, app: &AppHandle) -> Result<Response> {
@@ -284,6 +350,7 @@ async fn create_session(create: CreateSession, app: &AppHandle) -> Result<Respon
             &session_id,
             &create.prompt,
             &[],
+            &create.issues,
             harness,
             model,
             effort,
@@ -469,6 +536,9 @@ async fn send_message(send: SendMessage, app: &AppHandle) -> Result<Response> {
         .send_msg(
             &target.session_id,
             &prompt,
+            &[],
+            // None named: a relayed message carries whatever it tags in its own
+            // text, and must not re-aim the session it arrives at.
             &[],
             target.harness,
             target.model,

--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -13,12 +13,13 @@ use crate::{
         },
         Harness::ClaudeCode,
     },
+    issues::{self, IssueRef},
     models::{find_model, resolve_effort, Effort, Model, ModelId},
     store::{
         append_session_event, append_session_index_item, clear_fork_from, copy_session_log,
-        delete_session, get_session_index_item, list_session_events, relocate_session_to_project,
-        resolve_unclaimed_worktree_name, set_session_status, touch_session_index_item,
-        worktree_path, SessionIndexItem, SessionSnapshot, SessionStatus,
+        delete_session, get_session_index_item, link_session_issue, list_session_events,
+        relocate_session_to_project, resolve_unclaimed_worktree_name, set_session_status,
+        touch_session_index_item, worktree_path, SessionIndexItem, SessionSnapshot, SessionStatus,
     },
 };
 use anyhow::{bail, Context, Result};
@@ -83,6 +84,12 @@ pub struct QueuedMessage {
     /// deleted before the boundary that delivers it.
     #[serde(default)]
     pub from: Option<MessageSender>,
+    /// Resolved when the prompt was typed, not at flush, for `from`'s reason:
+    /// a held prompt can wait out a long turn, and re-reading the tracker at
+    /// the boundary would put a network call — and its failure — inside the
+    /// flush.
+    #[serde(default)]
+    pub issues: Vec<IssueRef>,
 }
 
 /// Held prompts, oldest first. Shared with the stdout task, which is where the
@@ -310,6 +317,11 @@ impl SessionManager {
         // Absolute paths of what the composer had attached. Re-read here rather
         // than uploaded: the frontend holds a thumbnail, not bytes.
         attachment_paths: &[String],
+        // Issues named outright rather than tagged in the text: `dray new
+        // --issue`, and the issues page starting a session from a row. Merged
+        // with the prompt's own `#` tags, which is why one list arrives here
+        // and not two.
+        issue_ids: &[String],
         harness: Harness,
         model: ModelId,
         effort: Option<Effort>,
@@ -339,6 +351,16 @@ impl SessionManager {
     ) -> Result<SendOutcome> {
         let model_spec = find_model(model).with_context(|| format!("unknown model {model:?}"))?;
         let effort = resolve_effort(&model_spec, effort);
+
+        // Resolved once for every path below — created, live, queued and
+        // resumed alike — so a `#DRA-53` means the same thing whichever one the
+        // prompt takes. The prompt comes back with any *named* issue appended as
+        // a tag, so from here `prompt` is what the model will actually be given
+        // and the transcript will actually draw. Best effort by design: an
+        // unreachable tracker leaves the text as it was and costs nothing else.
+        // See [`issues::expand_tags`].
+        let (prompt, issues) = issues::expand_tags(prompt, issue_ids).await;
+        let prompt = prompt.as_str();
 
         if is_new_session {
             let worktree_name = if use_worktree {
@@ -388,7 +410,7 @@ impl SessionManager {
 
             // Indexed before the process spawns, so a session that fails to
             // start is still visible rather than vanishing without a trace.
-            let item = SessionIndexItem::new(
+            let mut item = SessionIndexItem::new(
                 session_id,
                 harness,
                 &session_cwd,
@@ -401,6 +423,10 @@ impl SessionManager {
                 permission_mode,
                 parent_session_id,
             );
+            // Written with the entry rather than linked after it: the row
+            // appears before the child spawns, and a tab that arrived a beat
+            // later would be one more thing moving while the first turn starts.
+            item.issues = issues.clone();
 
             // The one failure that has to undo the tree, and the row that just
             // failed to be written is exactly why: removal is offered from a
@@ -472,7 +498,7 @@ impl SessionManager {
             )
             .await?;
             session
-                .send_msg(prompt, attachment_paths, baseline, from, app)
+                .send_msg(prompt, attachment_paths, &issues, baseline, from, app)
                 .await?;
             // The prompt event is synthesized by `send_msg`, so read the log
             // back rather than returning empty — otherwise the frontend's first
@@ -545,6 +571,17 @@ impl SessionManager {
             None => cwd.to_string(),
         };
 
+        // Recorded before the prompt goes out, and before the queue branch
+        // below returns: a tag on a prompt held behind a running turn still
+        // says what the session is about, and the panel's tab should not wait
+        // on a boundary to appear. Failures are logged and dropped — the link
+        // is a record, and losing one must not cost the send.
+        for issue in &issues {
+            if let Err(e) = link_session_issue(session_id, issue.clone()).await {
+                eprintln!("[issue link err] {e:#}");
+            }
+        }
+
         if let Some(s) = sessions_guard.get_mut(session_id) {
             // Before the send, so the index reflects intent even if writing to
             // the child fails — the prompt event is persisted ahead of stdin too.
@@ -574,11 +611,12 @@ impl SessionManager {
                 // UI states by itself, since a prompt written straight through
                 // draws no pending row and so offers no Esc.
                 if tool_in_flight {
-                    s.queue_and_flush(prompt, attachment_paths, from, app).await;
+                    s.queue_and_flush(prompt, attachment_paths, &issues, from, app)
+                        .await;
                     return Ok(SendOutcome::default());
                 }
 
-                let queued = s.queue_msg(prompt, attachment_paths, from).await;
+                let queued = s.queue_msg(prompt, attachment_paths, &issues, from).await;
                 return Ok(SendOutcome {
                     snapshot: None,
                     queued: Some(queued),
@@ -596,7 +634,8 @@ impl SessionManager {
             // but alive, so the narrower the gap the less of the user's own
             // editing lands on the turn's side of the diff.
             let baseline = git::snapshot_tree(&session_cwd).await;
-            s.send_msg(prompt, attachment_paths, baseline, from, app).await?;
+            s.send_msg(prompt, attachment_paths, &issues, baseline, from, app)
+                .await?;
             return Ok(SendOutcome::default());
         }
 
@@ -649,7 +688,7 @@ impl SessionManager {
         }
 
         session
-            .send_msg(prompt, attachment_paths, baseline, from, app)
+            .send_msg(prompt, attachment_paths, &issues, baseline, from, app)
             .await?;
         sessions_guard.insert(session_id.to_string(), session);
         Ok(SendOutcome::default())
@@ -970,6 +1009,7 @@ impl Session {
         &mut self,
         prompt: &str,
         attachment_paths: &[String],
+        issues: &[IssueRef],
         baseline: Option<String>,
         from: Option<MessageSender>,
         app: &AppHandle,
@@ -978,6 +1018,7 @@ impl Session {
             &self.id,
             prompt,
             attachment_paths,
+            issues,
             baseline,
             false,
             from,
@@ -1004,6 +1045,7 @@ impl Session {
         &self,
         prompt: &str,
         attachment_paths: &[String],
+        issues: &[IssueRef],
         from: Option<MessageSender>,
     ) -> QueuedMessage {
         let message = QueuedMessage {
@@ -1012,6 +1054,7 @@ impl Session {
             text: prompt.to_string(),
             attachment_paths: attachment_paths.to_vec(),
             from,
+            issues: issues.to_vec(),
         };
         self.queued.lock().await.push(message.clone());
         message
@@ -1036,10 +1079,11 @@ impl Session {
         &self,
         prompt: &str,
         attachment_paths: &[String],
+        issues: &[IssueRef],
         from: Option<MessageSender>,
         app: &AppHandle,
     ) {
-        self.queue_msg(prompt, attachment_paths, from).await;
+        self.queue_msg(prompt, attachment_paths, issues, from).await;
         flush_queued(
             &self.id,
             &self.queued,
@@ -1288,6 +1332,10 @@ async fn deliver_prompt(
     session_id: &str,
     prompt: &str,
     attachment_paths: &[String],
+    // Already resolved against the tracker by the caller. Appended to the text
+    // the child is given, so the transcript keeps showing exactly what the
+    // model was told — the same rule a non-image attachment's `@path` follows.
+    issues: &[IssueRef],
     baseline: Option<String>,
     queued: bool,
     from: Option<MessageSender>,
@@ -1302,9 +1350,11 @@ async fn deliver_prompt(
     // a non-image attachment becomes an `@path` mention on the prompt, and
     // the transcript has to show what the model was actually given.
     let prepared = attachments::prepare(session_id, prompt, attachment_paths).await?;
+    let text = prepared.text;
 
     let payload = AgentEventPayload::UserMessage {
-        text: prepared.text.clone(),
+        text: text.clone(),
+        issues: issues.to_vec(),
         images: prepared
             .images
             .iter()
@@ -1343,11 +1393,11 @@ async fn deliver_prompt(
     // shape every fixture captures, kept rather than always sending the
     // one-element block array it is sugar for.
     let content = if prepared.images.is_empty() {
-        json!(prepared.text)
+        json!(text)
     } else {
         let mut blocks = Vec::new();
-        if !prepared.text.is_empty() {
-            blocks.push(json!({"type": "text", "text": prepared.text}));
+        if !text.is_empty() {
+            blocks.push(json!({"type": "text", "text": text}));
         }
         for image in &prepared.images {
             blocks.push(json!({
@@ -1409,6 +1459,7 @@ pub async fn flush_queued(
             session_id,
             &message.text,
             &message.attachment_paths,
+            &message.issues,
             None,
             true,
             message.from,

--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -108,6 +108,19 @@ pub struct SendOutcome {
     /// `Some` when a turn was already running, so the prompt is held rather
     /// than sent. The frontend draws it as pending and can still take it back.
     pub queued: Option<QueuedMessage>,
+    /// Every issue the session is linked to now, as written.
+    ///
+    /// Answered on **every** path — created, live, queued and resumed — because
+    /// a `#DRA-53` is expanded and recorded on every one of them, and the
+    /// frontend has no other way to learn what a prompt just linked. Without it
+    /// a tag typed into an existing session persisted in Rust and reached the
+    /// panel only on a reselect or a restart: the Issue tab went on drawing the
+    /// session's old links while the index on disk held the new ones.
+    ///
+    /// The whole list rather than what this send added, for [`store::
+    /// link_session_issue`]'s reason — re-tagging *replaces* an entry, so what
+    /// changed is not a set the caller can apply on its own.
+    pub issues: Vec<IssueRef>,
 }
 
 /// Drives [`SessionStatus`] from the mapped event stream plus the user's own
@@ -512,6 +525,7 @@ impl SessionManager {
             // Returned so the frontend learns the resolved worktree name and
             // the backend-truncated title rather than guessing either.
             return Ok(SendOutcome {
+                issues: item.issues.clone(),
                 snapshot: Some(SessionSnapshot {
                     index_item: item,
                     events,
@@ -576,9 +590,20 @@ impl SessionManager {
         // says what the session is about, and the panel's tab should not wait
         // on a boundary to appear. Failures are logged and dropped — the link
         // is a record, and losing one must not cost the send.
+        //
+        // What each write answered with is kept, because that is what goes back
+        // to the frontend: re-tagging *replaces* an entry rather than appending
+        // one, so the list as written is not something the caller could work out
+        // from `issues` alone. A session nothing was tagged on answers with the
+        // links it already had, so every path can report the same fact.
+        let mut linked = indexed
+            .as_ref()
+            .map(|item| item.issues.clone())
+            .unwrap_or_default();
         for issue in &issues {
-            if let Err(e) = link_session_issue(session_id, issue.clone()).await {
-                eprintln!("[issue link err] {e:#}");
+            match link_session_issue(session_id, issue.clone()).await {
+                Ok(next) => linked = next,
+                Err(e) => eprintln!("[issue link err] {e:#}"),
             }
         }
 
@@ -613,13 +638,17 @@ impl SessionManager {
                 if tool_in_flight {
                     s.queue_and_flush(prompt, attachment_paths, &issues, from, app)
                         .await;
-                    return Ok(SendOutcome::default());
+                    return Ok(SendOutcome {
+                        issues: linked,
+                        ..Default::default()
+                    });
                 }
 
                 let queued = s.queue_msg(prompt, attachment_paths, &issues, from).await;
                 return Ok(SendOutcome {
                     snapshot: None,
                     queued: Some(queued),
+                    issues: linked,
                 });
             }
 
@@ -636,7 +665,10 @@ impl SessionManager {
             let baseline = git::snapshot_tree(&session_cwd).await;
             s.send_msg(prompt, attachment_paths, &issues, baseline, from, app)
                 .await?;
-            return Ok(SendOutcome::default());
+            return Ok(SendOutcome {
+                issues: linked,
+                ..Default::default()
+            });
         }
 
         touch_session_index_item(session_id, model, effort, permission_mode).await?;
@@ -691,7 +723,10 @@ impl SessionManager {
             .send_msg(prompt, attachment_paths, &issues, baseline, from, app)
             .await?;
         sessions_guard.insert(session_id.to_string(), session);
-        Ok(SendOutcome::default())
+        Ok(SendOutcome {
+            issues: linked,
+            ..Default::default()
+        })
     }
 
     /// Copies a session onto a new id, to be continued separately from the one

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use tokio::{fs, sync::Mutex};
 use ts_rs::TS;
 
-use crate::store::get_home_app_dir;
+use crate::{issues::TrackerAccount, store::get_home_app_dir};
 
 /// Serializes writers. The file is rewritten whole, so a concurrent writer
 /// would drop the other's field — same bargain `projects.json` makes.
@@ -30,6 +30,15 @@ pub struct AppSettings {
     /// [`read`].
     #[serde(default = "enabled_by_default")]
     pub analytics_enabled: bool,
+    /// Who the stored issue-tracker key belongs to.
+    ///
+    /// The account, never the key — that lives in `credentials.json` beside
+    /// this, and never rides the struct handed to the frontend. This is only
+    /// what saves a round trip to draw a name in the settings row. It is
+    /// therefore not the connection: an account here with no key behind it
+    /// reads as disconnected. See [`crate::issues::get_integrations`].
+    #[serde(default)]
+    pub linear_account: Option<TrackerAccount>,
 }
 
 fn enabled_by_default() -> bool {
@@ -40,6 +49,7 @@ impl Default for AppSettings {
     fn default() -> Self {
         Self {
             analytics_enabled: enabled_by_default(),
+            linear_account: None,
         }
     }
 }
@@ -90,6 +100,7 @@ pub async fn read() -> AppSettings {
 fn opted_out() -> AppSettings {
     AppSettings {
         analytics_enabled: false,
+        linear_account: None,
     }
 }
 
@@ -186,6 +197,7 @@ mod tests {
         let dir = tempdir();
         let off = AppSettings {
             analytics_enabled: false,
+            linear_account: None,
         };
 
         write_to(&dir, &off).await.unwrap();

--- a/apps/desktop/src-tauri/src/store.rs
+++ b/apps/desktop/src-tauri/src/store.rs
@@ -606,9 +606,17 @@ pub async fn set_session_flags(
 
 /// Records an issue against a session, answering with the list as written.
 ///
-/// An issue already linked is *replaced* rather than appended, keyed on the
-/// tracker's own id: re-tagging is how a stale title gets refreshed, and the
-/// alternative is one issue drawn twice under two spellings of its name.
+/// An issue already linked is *replaced* rather than appended: re-tagging is how
+/// a stale title gets refreshed, and the alternative is one issue drawn twice
+/// under two spellings of its name.
+///
+/// Matched on the tracker's own id **or** the human identifier, within a
+/// tracker — the same reading [`unlink_session_issue`] takes, and for a sharper
+/// reason. The two write different things into `id`: a resolved link carries
+/// Linear's UUID, while one written blind (`dray issue link`, or a tag no key
+/// could be found for) carries the identifier itself. Keyed on `id` alone,
+/// `DRA-53` linked blind and `DRA-53` resolved a moment later are two rows for
+/// one issue. Neither spelling can collide with the other — one is a UUID.
 ///
 /// `modified` is left alone for [`set_session_flags`]'s reason — it orders the
 /// sidebar, and tagging must not jump the row to the top of it.
@@ -620,11 +628,11 @@ pub async fn link_session_issue(session_id: &str, issue: IssueRef) -> Result<Vec
         bail!("no such session: {session_id}");
     };
 
-    match item
-        .issues
-        .iter_mut()
-        .find(|linked| linked.id == issue.id && linked.tracker == issue.tracker)
-    {
+    match item.issues.iter_mut().find(|linked| {
+        linked.tracker == issue.tracker
+            && (linked.id == issue.id
+                || linked.identifier.eq_ignore_ascii_case(&issue.identifier))
+    }) {
         Some(existing) => *existing = issue,
         None => item.issues.push(issue),
     }

--- a/apps/desktop/src-tauri/src/store.rs
+++ b/apps/desktop/src-tauri/src/store.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 
 use crate::{
     events::{now_rfc3339, AgentEvent, ApprovalPolicy},
+    issues::IssueRef,
     models::{Effort, ModelId},
     session::Harness,
 };
@@ -81,6 +82,15 @@ pub struct SessionIndexItem {
     /// this one is cleared the moment the CLI carries the fork out.
     #[serde(default)]
     pub fork_from: Option<String>,
+    /// The issues this session's work is against, newest link last.
+    ///
+    /// A list because one session really does carry several — three tags in one
+    /// prompt is the case this was built for — and a copy rather than an id,
+    /// so the panel's tab and the sidebar's row can be drawn with the tracker
+    /// unreachable. `serde(default)` so entries written before the field read
+    /// as untagged rather than failing the whole index.
+    #[serde(default)]
+    pub issues: Vec<IssueRef>,
     /// The session whose agent created this one, for a session created over the
     /// orchestration socket rather than by a person in the composer. `Some` is
     /// also what the depth guard reads: a session that was itself spawned may
@@ -262,6 +272,7 @@ impl SessionIndexItem {
             effort,
             permission_mode,
             status: SessionStatus::default(),
+            issues: Vec::new(),
             fork_from: None,
             parent_session_id: parent_session_id.map(str::to_string),
             created: now.clone(),
@@ -309,6 +320,10 @@ impl SessionIndexItem {
             effort: self.effort,
             permission_mode: self.permission_mode,
             status: SessionStatus::default(),
+            // Inherited: a fork continues the same conversation, so it is
+            // against the same work. Tagging one afterwards leaves the other
+            // alone — the copy is a session, not a view of its source.
+            issues: self.issues.clone(),
             fork_from: Some(self.session_id.clone()),
             // Inherited, so the copy sits exactly where the original does: the
             // sidebar draws it beside its source under the same parent, not
@@ -587,6 +602,63 @@ pub async fn set_session_flags(
     write_session_index(&sessions).await?;
 
     Ok(Some(updated))
+}
+
+/// Records an issue against a session, answering with the list as written.
+///
+/// An issue already linked is *replaced* rather than appended, keyed on the
+/// tracker's own id: re-tagging is how a stale title gets refreshed, and the
+/// alternative is one issue drawn twice under two spellings of its name.
+///
+/// `modified` is left alone for [`set_session_flags`]'s reason — it orders the
+/// sidebar, and tagging must not jump the row to the top of it.
+pub async fn link_session_issue(session_id: &str, issue: IssueRef) -> Result<Vec<IssueRef>> {
+    let _guard = INDEX_LOCK.lock().await;
+
+    let mut sessions = list_session_index_items().await?;
+    let Some(item) = sessions.iter_mut().find(|i| i.session_id == session_id) else {
+        bail!("no such session: {session_id}");
+    };
+
+    match item
+        .issues
+        .iter_mut()
+        .find(|linked| linked.id == issue.id && linked.tracker == issue.tracker)
+    {
+        Some(existing) => *existing = issue,
+        None => item.issues.push(issue),
+    }
+
+    let linked = item.issues.clone();
+    write_session_index(&sessions).await?;
+
+    Ok(linked)
+}
+
+/// Removes one link, matched on the tracker's own id *or* the human
+/// identifier.
+///
+/// Both, because the two callers hold different things: the panel has the whole
+/// [`IssueRef`] and passes its id, while a person at the CLI types `DRA-53`.
+/// Neither spelling can collide with the other — one is a UUID.
+///
+/// A key the session never carried is not an error: the caller asked for it to
+/// be gone, and it is.
+pub async fn unlink_session_issue(session_id: &str, key: &str) -> Result<Vec<IssueRef>> {
+    let _guard = INDEX_LOCK.lock().await;
+
+    let mut sessions = list_session_index_items().await?;
+    let Some(item) = sessions.iter_mut().find(|i| i.session_id == session_id) else {
+        bail!("no such session: {session_id}");
+    };
+
+    item.issues
+        .retain(|linked| linked.id != key && !linked.identifier.eq_ignore_ascii_case(key));
+    let linked = item.issues.clone();
+
+    write_session_index(&sessions).await?;
+
+    Ok(linked)
 }
 
 /// Drops one session from the index and deletes its `.jsonl` log. Returns
@@ -1327,6 +1399,7 @@ mod tests {
             event(AgentEventPayload::UserMessage {
                 text: "look at this".into(),
                 images: vec![image("/home/.dray/attachments/parent/a.png")],
+                issues: vec![],
                 baseline: None,
                 queued: false,
                 from: None,

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -84,6 +84,12 @@
      they have to be told apart at a glance rather than read as one run. Same
      lightness and chroma, so neither outranks the other. */
   --accent-mention: oklch(0.82 0.13 230);
+  /* An issue tag. The third token that can share one sentence with the other
+     two (`/review #DRA-53 @src/lib/issue.ts`), so it takes the same lightness
+     and chroma and a hue as far from both as the wheel allows — violet, which
+     is also what every issue tracker's own links are, so the tag reads as one
+     before it is read as a word. */
+  --accent-issue: oklch(0.82 0.13 310);
 
   /* The merge button, and nothing else. GitHub's own green rather than the
      app's emerald: this is the one control that acts on GitHub, and matching
@@ -141,6 +147,7 @@
   --color-accent-thinking: var(--accent-thinking);
   --color-accent-command: var(--accent-command);
   --color-accent-mention: var(--accent-mention);
+  --color-accent-issue: var(--accent-issue);
   --color-accent-merge: var(--accent-merge);
   --color-accent-merge-hover: var(--accent-merge-hover);
   --color-accent-merge-foreground: var(--accent-merge-foreground);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -12,6 +12,8 @@ import NoticeStack from "@/components/NoticeStack";
 import QuitDialog from "@/components/QuitDialog";
 import SettingsDialog from "@/components/SettingsDialog";
 import WorktreeDialog, { type WorktreePrompt } from "@/components/WorktreeDialog";
+import IssuePanel from "@/components/IssuePanel";
+import IssuesView from "@/components/IssuesView";
 import PrPanel from "@/components/PrPanel";
 import { useChanges } from "@/hooks/useChanges";
 import { usePrMarks } from "@/hooks/usePrMarks";
@@ -47,8 +49,10 @@ import { warmHighlighter } from "@/hooks/useHighlighter";
 import { useHotkey } from "@/hooks/useHotkey";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { pushNotice } from "@/hooks/useNotices";
+import { useIntegrations } from "@/hooks/useIntegrations";
+import { useSessionIssues } from "@/hooks/useIssues";
 import { useSessions } from "@/hooks/useSessions";
-import type { WorktreeDisposition } from "@/types/events";
+import type { Issue, WorktreeDisposition } from "@/types/events";
 import { useSlashCommands } from "@/hooks/useSlashCommands";
 import { useUpdater } from "@/hooks/useUpdater";
 import { changeRange, turnChangedTree } from "@/lib/changes";
@@ -104,6 +108,7 @@ function App() {
     handleNewSession,
     setSessionFlags,
     forkSession,
+    unlinkIssue,
     detachSession,
     deleteSession,
     removeWorktree,
@@ -142,6 +147,65 @@ function App() {
   // standing preference, and reopening the app onto a repo view for every
   // session would be wrong more often than right.
   const [viewTabs, setViewTabs] = useState<Record<string, ViewTab>>({});
+  // Whether the issues page is what the main column is showing. Not a session
+  // and not a per-session tab, so it is neither in `viewTabs` nor in the
+  // selection: it is a place the reader goes and comes back from, and the
+  // session they were in is still there when they do.
+  const [issuesOpen, setIssuesOpen] = useState(false);
+
+  /// The issues page's own refresh, so ⌘R can reach it. A ref rather than
+  /// state: the page owns the read and hands its handle up, and re-rendering
+  /// the whole app every time that handle is re-made would be a render per
+  /// keystroke in the page's search box.
+  const issuesRefreshRef = useRef<(() => void) | null>(null);
+
+  /// The issue the pane is showing while the issues page has the column.
+  ///
+  /// Kept as the whole row rather than an identifier: the list already read
+  /// every field a header draws, so the pane can be complete before its own
+  /// detail read lands — the same bargain the session panel makes with a
+  /// session's links.
+  const [pickedIssue, setPickedIssue] = useState<Issue | null>(null);
+
+  /// Whether the right pane is actually on screen, as against whether the
+  /// reader has asked for it.
+  ///
+  /// Two different questions, and conflating them was a bug worth naming: the
+  /// issues page fills the main column, so a pane left open beside it went on
+  /// describing the session the reader had *left* — its changes, its pull
+  /// request, its issue — with nothing on screen to say whose they were. The
+  /// preference is kept, so coming back restores the pane exactly as it was;
+  /// everything that draws or reads reads this instead.
+  const panelShown = panelOpen && !issuesOpen;
+
+  /// The picked issue as a link, which is the shape the panel reads.
+  ///
+  /// Memoized because it is an array: a fresh one each render would re-run the
+  /// detail read on every keystroke in the page's search box.
+  const pickedIssueRefs = useMemo(
+    () =>
+      pickedIssue
+        ? [
+            {
+              tracker: pickedIssue.tracker,
+              id: pickedIssue.id,
+              identifier: pickedIssue.identifier,
+              title: pickedIssue.title,
+              url: pickedIssue.url,
+            },
+          ]
+        : [],
+    [pickedIssue],
+  );
+
+  const pickedIssueData = useSessionIssues(pickedIssueRefs, issuesOpen && !!pickedIssue);
+
+  // Owned here rather than by any one surface: the settings row, the issues
+  // page's own connect form and the composer's placeholder all read it, and a
+  // hook per surface is a second answer to "are we connected" free to disagree
+  // with the first.
+  const integrations = useIntegrations(true);
+  const issuesConnected = !!integrations.integrations?.linear;
 
   // Not persisted: settings are opened to change something and closed again, so
   // reopening the app into them would be the app remembering the wrong half of
@@ -291,7 +355,7 @@ function App() {
   const pullRequests = usePullRequest(
     selectedSession?.cwd ?? "",
     prBranch,
-    panelOpen && (panelTab === "pr" || panelTab === null),
+    panelShown && (panelTab === "pr" || panelTab === null),
     // A pull request appearing is the moment the session stops being about the
     // turn and starts being about landing, so the pane opens onto it rather
     // than waiting to be asked. Fires at most once per PR — see `onOpened`.
@@ -340,7 +404,20 @@ function App() {
   // the next, where a PR is the state of the work.
   const defaultTab: PanelTab = hasOpenPr && hasPrTab ? "pr" : "changes";
 
-  const tabs = tabOrder({ pr: hasPrTab });
+  // Read off the *pick*, not off `activeTab`, which is derived below from the
+  // tab row this feeds. An unset pick does not count here, unlike the PR tab's:
+  // the derived default is never the issue tab, so nothing is being read unless
+  // the reader asked for it.
+  const activeTabIsIssue = panelTab === "issue";
+
+  // Straight off the index entry, which is where a link lives — so the tab is
+  // there the moment a prompt tags one, with no read to wait on.
+  const sessionIssues = selectedSession?.issues ?? [];
+  const hasIssueTab = sessionIssues.length > 0;
+
+  const issueData = useSessionIssues(sessionIssues, panelShown && activeTabIsIssue);
+
+  const tabs = tabOrder({ pr: hasPrTab, issue: hasIssueTab });
 
   // One rule, read rather than written back: an explicit pick wins wherever it
   // still names a tab this session draws, and otherwise the derived default
@@ -354,7 +431,7 @@ function App() {
   // so a session with no PR tab cycles through two and never lands on one that
   // isn't drawn.
   const stepTab = (delta: number) => {
-    if (!panelOpen) return;
+    if (!panelShown) return;
     const from = tabs.indexOf(activeTab);
     setPanelTab(tabs[(from + delta + tabs.length) % tabs.length]);
   };
@@ -446,6 +523,11 @@ function App() {
   // pane *defaults* to is `activeTab`'s rule and needs no help here, and ⌘E
   // stays a plain toggle because it draws nothing and so promises nothing.
   const handleTogglePanel = () => {
+    // On the issues page the chord only ever *closes*. There is nothing for it
+    // to reopen — a row is what picks an issue — so a toggle that could open
+    // would have to guess which one, and the last pick is rarely the one wanted
+    // on the way back. Closing is the half that has an unambiguous meaning.
+    if (issuesOpen) return setPickedIssue(null);
     if (!panelOpen) {
       if (hasOpenPr && hasPrTab) setPanelTab("pr");
       else if (lastTurnChanged) setPanelTab("changes");
@@ -467,7 +549,7 @@ function App() {
     baseline,
     head,
     revision,
-    panelOpen && activeTab === "changes",
+    panelShown && activeTab === "changes",
   );
 
   // One button, so the tab decides what it re-reads. Subagents has nothing to
@@ -477,7 +559,9 @@ function App() {
       ? { onRefresh: changesData.refresh, loading: changesData.loading }
       : activeTab === "pr"
         ? { onRefresh: pullRequests.refresh, loading: pullRequests.loading }
-        : null;
+        : activeTab === "issue"
+          ? { onRefresh: issueData.refresh, loading: issueData.loading }
+          : null;
 
   // Same order the sidebar draws, so the walk matches the list even when the
   // sidebar is collapsed and there is nothing on screen to follow — project
@@ -527,7 +611,17 @@ function App() {
   useHotkey("ArrowUp", () => stepSession(-1), { shift: true });
   useHotkey("ArrowDown", () => stepSession(1), { shift: true });
   // ⌘E for the right pane against ⌘B for the left.
-  useHotkey("e", togglePanel);
+  //
+  // Bound to the raw toggle rather than to `handleTogglePanel`, deliberately:
+  // that one picks a tab on the way open, which is right for a button the
+  // reader aimed at and wrong for a chord that draws nothing and so promises
+  // nothing. Which means the issues-page guard has to be repeated here — it
+  // lived only in `handleTogglePanel` at first, so the button honoured it and
+  // the chord went straight past it to a pane that is not on screen.
+  useHotkey("e", () => {
+    if (issuesOpen) return setPickedIssue(null);
+    togglePanel();
+  });
   // ⌘⇧[ / ⌘⇧] — the browser and editor chord for stepping through tabs, so it
   // arrives already known. The shift layout reaches `key`, so the character is
   // `{` rather than `[`; the physical key rides along for the engines that
@@ -545,12 +639,20 @@ function App() {
   // every chord it matches — and the app has no Reload menu item, which on
   // macOS would swallow the key before the webview ever saw it.
   useHotkey("r", () => {
-    if (panelOpen) panelRefresh?.onRefresh();
+    // "Re-read what I am looking at", the same rule the session case follows:
+    // the pane wins where one is open, and the list has it otherwise.
+    if (issuesOpen) {
+      if (pickedIssue) return pickedIssueData.refresh();
+      return issuesRefreshRef.current?.();
+    }
+    if (panelShown) panelRefresh?.onRefresh();
   });
   // By position in the tab row, so a third view needs only a third line here.
-  // No-ops without a session, where there is no row to switch.
-  useHotkey("1", () => setViewTab("chat"));
-  useHotkey("2", () => setViewTab("changes"));
+  // No-ops without a session, where there is no row to switch — and on the
+  // issues page, where the row is not drawn: switching an invisible tab looks
+  // like nothing happening and then shows up as the wrong view on the way back.
+  useHotkey("1", () => !issuesOpen && setViewTab("chat"));
+  useHotkey("2", () => !issuesOpen && setViewTab("changes"));
   // ⌘, — every macOS app's preferences chord, and the only way into settings
   // while the sidebar is collapsed and its gear gone with it. Safe to take for
   // `useHotkey`'s usual pair of reasons: it claims the chord, and the app's
@@ -582,7 +684,9 @@ function App() {
     <TooltipProvider>
     <DiffWorkerPool pair={codeThemePair}>
     <AppShell
-      centered={!selectedSession}
+      // The issues page fills the column, so the centred empty-composer state
+      // is wrong there even with no session selected.
+      centered={!selectedSession && !issuesOpen}
       sidebar={
         <Sidebar
           items={searchedSessions}
@@ -594,12 +698,25 @@ function App() {
           statusBySession={statusBySession}
           askingSessions={askingSessions}
           prFor={prMarks.prFor}
-          selectedSessionId={selectedSessionId}
+          // Cleared while the page is up. The column is showing issues, so a
+          // lit row would name a session that is nowhere on screen — and the
+          // selection itself is kept, which is what makes coming back free.
+          selectedSessionId={issuesOpen ? null : selectedSessionId}
           collapsed={collapsed}
           onToggleCollapsed={toggleSidebar}
           onOpenSettings={() => setSettingsOpen(true)}
-          onSelect={handleSelectSessionIndexItem}
-          onNewSession={handleNewSession}
+          onSelect={async (sessionId) => {
+            // A session is what the column shows now. The page is left as it
+            // was — its filters and its scroll come back with it.
+            setIssuesOpen(false);
+            await handleSelectSessionIndexItem(sessionId);
+          }}
+          onNewSession={() => {
+            setIssuesOpen(false);
+            handleNewSession();
+          }}
+          onOpenIssues={() => setIssuesOpen(true)}
+          issuesOpen={issuesOpen}
           onDetach={detachSession}
           onSetFlags={async (sessionId, flags) => {
             await setSessionFlags(sessionId, flags);
@@ -669,34 +786,82 @@ function App() {
           <SessionHeader
             session={selectedSession}
             branch={prBranch}
+            standIn={issuesOpen ? "Issues" : null}
             className="flex-1"
           />
 
-          {selectedSession && <ViewTabs tab={viewTab} onChange={setViewTab} />}
+          {!issuesOpen && selectedSession && <ViewTabs tab={viewTab} onChange={setViewTab} />}
 
-          {selectedSession && (
-            <PanelToggle
-              onToggle={handleTogglePanel}
-              open={panelOpen}
-              changes={lastTurnChanged}
-              pr={hasOpenPr && hasPrTab}
-              draft={allDrafts}
-            />
-          )}
+          {issuesOpen
+            ? // Only once something is open to close. Nothing on this page can
+              // *open* the pane — a row does that — so a toggle drawn at rest
+              // would be a control with one dead state.
+              pickedIssue && (
+                <PanelToggle onToggle={() => setPickedIssue(null)} open changes={false} />
+              )
+            : selectedSession && (
+                <PanelToggle
+                  onToggle={handleTogglePanel}
+                  open={panelOpen}
+                  changes={lastTurnChanged}
+                  pr={hasOpenPr && hasPrTab}
+                  draft={allDrafts}
+                />
+              )}
         </header>
       }
       panel={
-        // Mounted whenever a session is, open or not — closing or switching
+        // The pane describes whatever the main column is showing. On the issues
+        // page that is an issue and never a session — which is the whole reason
+        // the session's pane is hidden there: left up, it went on describing
+        // changes and a pull request belonging to work the reader had left.
+        issuesOpen ? (
+          <RightPanel
+            open={!!pickedIssue}
+            // A word rather than a tab row: there is one thing in this pane
+            // and nothing to switch to. "Details" and not "Issue", which would
+            // name the tab this replaced and say the same thing as the pane's
+            // own contents.
+            heading="Details"
+            tab="issue"
+            onTabChange={() => {}}
+            refresh={{
+              onRefresh: pickedIssueData.refresh,
+              loading: pickedIssueData.loading,
+            }}
+          >
+            <TabBody active>
+              <IssuePanel
+                // No session, so no link to remove — the row draws its open-in-
+                // tracker button and nothing else.
+                sessionId={null}
+                issues={pickedIssueRefs}
+                onUnlink={() => {}}
+                details={pickedIssueData.details}
+                loading={pickedIssueData.loading}
+                unavailable={pickedIssueData.unavailable}
+              />
+            </TabBody>
+          </RightPanel>
+        ) : // Mounted whenever a session is, open or not — closing or switching
         // tabs only hides, so reopening shows what was already there instead of
         // refetching and re-highlighting it. `active` is what stops the hidden
         // changes tab from snapshotting the working tree in the background.
         selectedSession ? (
           <RightPanel
-            open={panelOpen}
+            open={panelShown}
             tab={activeTab}
             onTabChange={setPanelTab}
-            counts={{ subagents: subagents.length, pr: prBadgeCount(pullRequests.prs) }}
+            counts={{
+              subagents: subagents.length,
+              pr: prBadgeCount(pullRequests.prs),
+              // Only above one: a tab reading "Issue 1" says what the tab
+              // already says, and the count is news exactly when there is more
+              // than one thing behind it.
+              issue: sessionIssues.length > 1 ? sessionIssues.length : 0,
+            }}
             pr={hasPrTab}
+            issue={hasIssueTab}
             refresh={panelRefresh}
           >
             <TabBody active={activeTab === "changes"}>
@@ -715,6 +880,14 @@ function App() {
             <TabBody active={hasPrTab && activeTab === "pr"}>
               <PrPanel branch={prBranch} {...pullRequests} />
             </TabBody>
+            <TabBody active={hasIssueTab && activeTab === "issue"}>
+              <IssuePanel
+                sessionId={selectedSessionId}
+                issues={sessionIssues}
+                onUnlink={unlinkIssue}
+                {...issueData}
+              />
+            </TabBody>
           </RightPanel>
         ) : null
       }
@@ -724,7 +897,7 @@ function App() {
         // the reader can't see. Safe to unmount: the draft and the attachment
         // tray are module-level stores precisely because the composer already
         // unmounts crossing the empty state.
-        selectedSession && viewTab !== "chat" ? null : (
+        issuesOpen || (selectedSession && viewTab !== "chat") ? null : (
         <ChatInput
           onSend={handleSendMsg}
           commands={slashCommands}
@@ -735,6 +908,7 @@ function App() {
           busy={busy}
           sessionId={selectedSessionId}
           isNewTask={!selectedSession}
+          issuesConnected={issuesConnected}
           error={error}
           onDismissError={() => setError(null)}
           archived={selectedSession?.archived ?? false}
@@ -794,10 +968,26 @@ function App() {
         )
       }
     >
+      {/* Hidden rather than unmounted, like everything else in this column:
+          the list, its filters and its scroll survive a trip into a session and
+          back, which is the trip this page exists to make. */}
+      <TabBody active={issuesOpen}>
+        <IssuesView
+          active={issuesOpen}
+          picked={pickedIssue?.identifier ?? null}
+          onPick={setPickedIssue}
+          refreshRef={issuesRefreshRef}
+          connected={issuesConnected}
+          onConnect={integrations.connect}
+          connecting={integrations.busy}
+          connectError={integrations.error}
+        />
+      </TabBody>
+
       {/* Hidden rather than unmounted, the same bargain the right panel's tabs
           make: the transcript keeps its scroll position and its highlighted
           diffs, and the repo view keeps its selection and its reads. */}
-      <TabBody active={viewTab === "chat"}>
+      <TabBody active={!issuesOpen && viewTab === "chat"}>
       <Chat
         session={selectedSession}
         streamingBlock={
@@ -813,8 +1003,8 @@ function App() {
         compacting={compacting}
         queuedMessages={queuedMessages}
         working={working}
-        crowded={!collapsed && panelOpen}
-        active={viewTab === "chat"}
+        crowded={!collapsed && (panelShown || (issuesOpen && !!pickedIssue))}
+        active={!issuesOpen && viewTab === "chat"}
       />
       </TabBody>
 
@@ -822,7 +1012,7 @@ function App() {
         // Keyed by session so the selection, the sub-tab and the commit box
         // reset with it. Cheap to remount: the reads behind it are cached by
         // tree id at module level and survive the unmount.
-        <TabBody active={viewTab === "changes"}>
+        <TabBody active={!issuesOpen && viewTab === "changes"}>
           <ChangesView
             key={selectedSession.sessionId}
             cwd={selectedSession.cwd}
@@ -850,7 +1040,11 @@ function App() {
     <QuitDialog />
     {/* Mounted here rather than in the sidebar, which unmounts whole when it
         collapses and would take ⌘, with it. */}
-    <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+    <SettingsDialog
+      open={settingsOpen}
+      onOpenChange={setSettingsOpen}
+      integrations={integrations}
+    />
     <WorktreeDialog
       prompt={worktreePrompt}
       onConfirm={(sessionId) => removeWorktree(sessionId)}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -603,13 +603,24 @@ function App() {
     if (!selectedSessionId) setPanelOpen(false);
   }, [selectedSessionId]);
 
+  // Every way of arriving at a session, so none of them can forget to leave the
+  // issues page. The two sidebar buttons closed it and the chords beside them
+  // did not, which made ⌘N and ⌘⇧↑/↓ look inert: they moved the selection under
+  // a column still full of issues, and the change only showed up on the way
+  // back. The page itself is left as it was — its filters and its scroll come
+  // back with it — so this is a navigation, not a dismissal.
+  const goToSession = (go: () => void) => {
+    setIssuesOpen(false);
+    go();
+  };
+
   const toggleSidebar = () => setCollapsed((prev) => !prev);
   useHotkey("b", toggleSidebar);
-  useHotkey("n", handleNewSession);
+  useHotkey("n", () => goToSession(handleNewSession));
   // ⌘⇧ rather than plain ⌘: the composer is focused most of the time, where
   // ⌘↑/↓ is the webview's own jump-to-start/end of the input.
-  useHotkey("ArrowUp", () => stepSession(-1), { shift: true });
-  useHotkey("ArrowDown", () => stepSession(1), { shift: true });
+  useHotkey("ArrowUp", () => goToSession(() => stepSession(-1)), { shift: true });
+  useHotkey("ArrowDown", () => goToSession(() => stepSession(1)), { shift: true });
   // ⌘E for the right pane against ⌘B for the left.
   //
   // Bound to the raw toggle rather than to `handleTogglePanel`, deliberately:
@@ -705,16 +716,10 @@ function App() {
           collapsed={collapsed}
           onToggleCollapsed={toggleSidebar}
           onOpenSettings={() => setSettingsOpen(true)}
-          onSelect={async (sessionId) => {
-            // A session is what the column shows now. The page is left as it
-            // was — its filters and its scroll come back with it.
-            setIssuesOpen(false);
-            await handleSelectSessionIndexItem(sessionId);
-          }}
-          onNewSession={() => {
-            setIssuesOpen(false);
-            handleNewSession();
-          }}
+          onSelect={(sessionId) =>
+            goToSession(() => void handleSelectSessionIndexItem(sessionId))
+          }
+          onNewSession={() => goToSession(handleNewSession)}
           onOpenIssues={() => setIssuesOpen(true)}
           issuesOpen={issuesOpen}
           onDetach={detachSession}
@@ -735,13 +740,13 @@ function App() {
             // Settling the open session leaves nothing to look at but the
             // unsettle bar, so it goes back to the empty composer instead.
             if (flags.archived === true && sessionId === selectedSessionId) {
-              handleNewSession();
+              goToSession(handleNewSession);
             } else if (flags.archived === false) {
               // Unsettling only happens from the settled list, and the row
               // just left it — follow it back to where it landed, onto the
               // row itself.
               if (showArchived) setShowArchived(false);
-              void handleSelectSessionIndexItem(sessionId);
+              goToSession(() => void handleSelectSessionIndexItem(sessionId));
             }
           }}
           onFork={forkSession}
@@ -1025,7 +1030,7 @@ function App() {
     {/* Outside `AppShell` on purpose: it is fixed to the window rather than
         placed in the layout, and the shell has no slot that isn't a pane. */}
     <NoticeStack
-      onSelect={(id) => void handleSelectSessionIndexItem(id)}
+      onSelect={(id) => goToSession(() => void handleSelectSessionIndexItem(id))}
       // The session and the pane both, since the card is about something the
       // transcript does not show. The pick is written the same way
       // `usePullRequest`'s `onOpened` writes it — `activeTab` honours a

--- a/apps/desktop/src/components/ChatInput.tsx
+++ b/apps/desktop/src/components/ChatInput.tsx
@@ -4,6 +4,7 @@ import { ArrowUp, CornerDownLeft, Paperclip, Square, X } from "lucide-react";
 
 import AttachmentTray from "@/components/composer/AttachmentTray";
 import FileMentionMenu from "@/components/composer/FileMentionMenu";
+import IssueMentionMenu from "@/components/composer/IssueMentionMenu";
 import SlashCommandMenu from "@/components/composer/SlashCommandMenu";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,8 +17,10 @@ import {
 import { useDraft } from "@/hooks/useDraft";
 import { useFileSearch } from "@/hooks/useFileSearch";
 import { useHotkey } from "@/hooks/useHotkey";
+import { useIssueSearch } from "@/hooks/useIssueSearch";
 import { useRecentCommands } from "@/hooks/useRecentCommands";
 import { SEGMENT_COLOR, highlightSegments, splitMention } from "@/lib/highlight";
+import { applyIssue, issueSpan } from "@/lib/issue";
 import { applyMention, mentionSpan } from "@/lib/mention";
 import {
   applyCommand,
@@ -27,7 +30,7 @@ import {
   slashQuery,
 } from "@/lib/slash";
 import { cn } from "@/lib/utils";
-import type { FileMatch, QueuedMessage, SlashCommand } from "@/types/events";
+import type { FileMatch, Issue, QueuedMessage, SlashCommand } from "@/types/events";
 
 type ChatInputProps = {
   /// `attachmentPaths` is what the tray held, as absolute paths. The backend
@@ -42,6 +45,10 @@ type ChatInputProps = {
   /// worktree session mentions paths inside its tree — the CLI resolves `@path`
   /// against the directory it was spawned in, and those are the same one.
   cwd?: string | null;
+  /// An issue tracker is connected, so `#` opens a picker. Drawn in the
+  /// placeholder and nowhere else — the picker itself simply finds nothing
+  /// without one.
+  issuesConnected?: boolean;
   /// Interrupts the running turn. Reachable while `busy` and the box is empty —
   /// with something typed the same button sends, since a prompt written during a
   /// turn is queued onto it rather than refused.
@@ -137,6 +144,7 @@ export default function ChatInput({
   onSend,
   commands = [],
   cwd = null,
+  issuesConnected = false,
   onStop,
   onCancelQueued,
   queuedCount = 0,
@@ -204,6 +212,12 @@ export default function ChatInput({
   const mention = mentionSpan(message, caret);
   const files = useFileSearch(cwd, mention?.query ?? null);
 
+  // The third of the same shape, and mutually exclusive with the other two for
+  // the same reason: the caret sits in exactly one token, and a token opening
+  // with `#` is neither one opening with `@` nor a command at position zero.
+  const issue = issueSpan(message, caret);
+  const issues = useIssueSearch(issue?.query ?? null);
+
   // Flattened in render order, so arrowing through the list and drawing it
   // can't disagree about which row an index names.
   const commandMatches = useMemo(() => groups.flatMap((group) => group.items), [groups]);
@@ -211,8 +225,9 @@ export default function ChatInput({
   // Only the count is shared between the two pickers — the lists themselves stay
   // separate all the way to the pick, so nothing has to be narrowed back out of
   // a union that `mention` already decided.
-  const rowCount = mention ? files.length : commandMatches.length;
-  const menuOpen = !dismissed && rowCount > 0 && (query !== null || mention !== null);
+  const rowCount = mention ? files.length : issue ? issues.length : commandMatches.length;
+  const menuOpen =
+    !dismissed && rowCount > 0 && (query !== null || mention !== null || issue !== null);
   // Clamped rather than trusted: both lists arrive asynchronously, so a list
   // that shrinks under an already-moved selection would otherwise index past
   // its end — and an undefined row only shows up as a crash on the keystroke
@@ -222,10 +237,11 @@ export default function ChatInput({
   // Keyed on the query text rather than on the span, which is a fresh object
   // every keystroke and would reset the selection on a bare cursor move.
   const mentionQuery = mention?.query ?? null;
+  const issueQuery = issue?.query ?? null;
   useEffect(() => {
     setActiveIndex(0);
-    if (query === null && mentionQuery === null) setDismissed(false);
-  }, [query, mentionQuery]);
+    if (query === null && mentionQuery === null && issueQuery === null) setDismissed(false);
+  }, [query, mentionQuery, issueQuery]);
 
   const pickCommand = (command: SlashCommand) => {
     const next = applyCommand(message, command.name);
@@ -243,12 +259,27 @@ export default function ChatInput({
     textareaRef.current?.focus();
   };
 
+  const pickIssue = (picked: Issue) => {
+    if (!issue) return;
+
+    const next = applyIssue(message, issue, picked.identifier, picked.title);
+    pendingCaretRef.current = next.caret;
+    setMessage(next.text);
+    textareaRef.current?.focus();
+  };
+
   /// The keyboard's way into whichever list is drawn. A click calls the same
-  /// two functions directly, so the two routes cannot diverge.
+  /// functions directly, so the two routes cannot diverge.
   const pickRow = (index: number) => {
     if (mention) {
       const file = files[index];
       if (file) pickFile(file);
+      return;
+    }
+
+    if (issue) {
+      const picked = issues[index];
+      if (picked) pickIssue(picked);
       return;
     }
 
@@ -583,6 +614,15 @@ export default function ChatInput({
                 placement={isNewTask ? "below" : "above"}
                 bare={isNewTask}
               />
+            ) : issue ? (
+              <IssueMentionMenu
+                issues={issues}
+                activeIndex={active}
+                onPick={pickIssue}
+                onHover={setActiveIndex}
+                placement={isNewTask ? "below" : "above"}
+                bare={isNewTask}
+              />
             ) : (
               <SlashCommandMenu
                 groups={groups}
@@ -633,7 +673,16 @@ export default function ChatInput({
                   const mirror = mirrorRef.current;
                   if (mirror) mirror.scrollTop = e.currentTarget.scrollTop;
                 }}
-                placeholder={isNewTask ? "Describe a task. @files. /skills and commands." : "Send follow-up"}
+                // Names `#` only where it would do something. An unconnected
+                // reader offered a tag they cannot use learns the app is
+                // missing a feature rather than that they haven't set one up.
+                placeholder={
+                  isNewTask
+                    ? issuesConnected
+                      ? "Describe a task. #issues. @files. /skills and commands."
+                      : "Describe a task. @files. /skills and commands."
+                    : "Send follow-up"
+                }
                 onChange={(e) => {
                   setMessage(e.currentTarget.value);
                   setCaret(e.currentTarget.selectionStart);

--- a/apps/desktop/src/components/IssueAsset.tsx
+++ b/apps/desktop/src/components/IssueAsset.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 
 import { invoke } from "@tauri-apps/api/core";
 import { Download, File } from "lucide-react";
 
 import ImageLightbox from "@/components/chat/ImageLightbox";
 import { formatBytes } from "@/lib/format";
+import { issueGeneration, subscribeIssueGeneration } from "@/lib/issue";
 import { cn } from "@/lib/utils";
 import type { IssueAsset } from "@/types/events";
 
@@ -19,24 +20,46 @@ import type { IssueAsset } from "@/types/events";
 /// a `data:` URL, and only then is there something a `src` can point at.
 ///
 /// Cached per URL across mounts, `null` included. A description is re-rendered
-/// on every keystroke in the page's search box and on every panel refresh, and
-/// each of those would otherwise re-download every screenshot in it.
-const cache = new Map<string, IssueAsset | null>();
+/// on every keystroke in the page's search box, and each of those would
+/// otherwise re-download every screenshot in it.
+///
+/// **A failure is cached too, and only the generation gets it back.** Not
+/// caching one is worse than it looks — a fetch that failed would be retried on
+/// every render of the description holding it, which is a retry per keystroke.
+/// But a `null` kept forever is a screenshot that a reconnect and a Refresh can
+/// both fail to recover, and the reader is left pressing a button that provably
+/// does nothing. So every entry carries the connection generation it was read
+/// under, and one from an older generation is a miss: connecting a key, and
+/// pressing Refresh, each bump it.
+type Cached = { generation: number; asset: IssueAsset | null };
+
+const cache = new Map<string, Cached>();
 const inFlight = new Map<string, Promise<IssueAsset | null>>();
 
+/// The entry for `url` if one was read under the generation now current.
+function cached(url: string): Cached | undefined {
+  const entry = cache.get(url);
+  return entry && entry.generation === issueGeneration() ? entry : undefined;
+}
+
 function load(url: string): Promise<IssueAsset | null> {
-  const cached = cache.get(url);
-  if (cached !== undefined) return Promise.resolve(cached);
+  const entry = cached(url);
+  if (entry) return Promise.resolve(entry.asset);
 
   // Deduped, because one description can name the same image twice and React
   // may mount both halves in the same frame.
   const running = inFlight.get(url);
   if (running) return running;
 
+  // Captured before the request goes out. A read that started under the old key
+  // is written under the old key, so it is a miss for every later reader rather
+  // than an answer standing in for one nobody has asked for yet.
+  const generation = issueGeneration();
+
   const request = invoke<IssueAsset>("fetch_issue_asset", { url })
     .catch(() => null)
     .then((asset) => {
-      cache.set(url, asset);
+      cache.set(url, { generation, asset });
       inFlight.delete(url);
       return asset;
     });
@@ -46,12 +69,17 @@ function load(url: string): Promise<IssueAsset | null> {
 }
 
 function useAsset(url: string): { asset: IssueAsset | null; loading: boolean } {
-  const [asset, setAsset] = useState<IssueAsset | null>(() => cache.get(url) ?? null);
-  const [loading, setLoading] = useState(() => !cache.has(url));
+  const [asset, setAsset] = useState<IssueAsset | null>(() => cached(url)?.asset ?? null);
+  const [loading, setLoading] = useState(() => !cached(url));
+
+  // Subscribed, not read once: a reconnect or a Refresh has to reach a card
+  // already on screen, which is the one showing "Unavailable".
+  const generation = useSyncExternalStore(subscribeIssueGeneration, issueGeneration);
 
   useEffect(() => {
-    if (cache.has(url)) {
-      setAsset(cache.get(url) ?? null);
+    const entry = cached(url);
+    if (entry) {
+      setAsset(entry.asset);
       setLoading(false);
       return;
     }
@@ -67,7 +95,7 @@ function useAsset(url: string): { asset: IssueAsset | null; loading: boolean } {
     return () => {
       live = false;
     };
-  }, [url]);
+  }, [url, generation]);
 
   return { asset, loading };
 }

--- a/apps/desktop/src/components/IssueAsset.tsx
+++ b/apps/desktop/src/components/IssueAsset.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from "react";
+
+import { invoke } from "@tauri-apps/api/core";
+import { Download, File } from "lucide-react";
+
+import ImageLightbox from "@/components/chat/ImageLightbox";
+import { formatBytes } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { IssueAsset } from "@/types/events";
+
+/// A file uploaded to an issue, fetched through the backend rather than by the
+/// webview.
+///
+/// **Linear serves its uploads behind the same auth its API is behind**, so an
+/// `<img src="https://uploads.linear.app/…">` resolves to a 401 and the webview
+/// draws its own broken-image box — which reads as the app being unable to show
+/// the picture rather than as the picture needing a key. Everything here exists
+/// to put the key on that request: the backend fetches the bytes and hands back
+/// a `data:` URL, and only then is there something a `src` can point at.
+///
+/// Cached per URL across mounts, `null` included. A description is re-rendered
+/// on every keystroke in the page's search box and on every panel refresh, and
+/// each of those would otherwise re-download every screenshot in it.
+const cache = new Map<string, IssueAsset | null>();
+const inFlight = new Map<string, Promise<IssueAsset | null>>();
+
+function load(url: string): Promise<IssueAsset | null> {
+  const cached = cache.get(url);
+  if (cached !== undefined) return Promise.resolve(cached);
+
+  // Deduped, because one description can name the same image twice and React
+  // may mount both halves in the same frame.
+  const running = inFlight.get(url);
+  if (running) return running;
+
+  const request = invoke<IssueAsset>("fetch_issue_asset", { url })
+    .catch(() => null)
+    .then((asset) => {
+      cache.set(url, asset);
+      inFlight.delete(url);
+      return asset;
+    });
+
+  inFlight.set(url, request);
+  return request;
+}
+
+function useAsset(url: string): { asset: IssueAsset | null; loading: boolean } {
+  const [asset, setAsset] = useState<IssueAsset | null>(() => cache.get(url) ?? null);
+  const [loading, setLoading] = useState(() => !cache.has(url));
+
+  useEffect(() => {
+    if (cache.has(url)) {
+      setAsset(cache.get(url) ?? null);
+      setLoading(false);
+      return;
+    }
+
+    let live = true;
+    setLoading(true);
+    void load(url).then((next) => {
+      if (!live) return;
+      setAsset(next);
+      setLoading(false);
+    });
+
+    return () => {
+      live = false;
+    };
+  }, [url]);
+
+  return { asset, loading };
+}
+
+/// An image from an issue's description, drawn as an image and openable full
+/// size.
+///
+/// Falls back to the file card below rather than to a broken image: anything
+/// the webview will not render — an SVG it refuses, a format it does not know,
+/// a fetch that failed — is still a file somebody can download, and a card
+/// saying so beats a grey box saying nothing.
+///
+/// The lightbox is the transcript's own, and it earns its place here for the
+/// same reason it does there and more so: this pane is a third of the window,
+/// so a screenshot of a screen is unreadable at the only width it can be given.
+/// One image per lightbox rather than the description's whole set — these are
+/// spread through prose rather than gathered in a row, so there is no set the
+/// arrows would be stepping through.
+export function IssueImage({ src, alt }: { src: string; alt?: string }) {
+  const { asset, loading } = useAsset(src);
+  const [broken, setBroken] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  if (loading) {
+    return <span className="my-1 block h-24 w-full animate-pulse rounded-lg bg-muted/50" />;
+  }
+
+  if (!asset || broken || !asset.mime.startsWith("image/")) {
+    return <IssueFile href={src} name={alt || "Image"} />;
+  }
+
+  const name = alt || "Image";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="my-1 block max-w-full cursor-zoom-in"
+      >
+        <img
+          src={asset.dataUrl}
+          alt={alt ?? ""}
+          // `onError` is the second net under the mime check: a mime can say
+          // `image/svg+xml` and still not render, and the fallback is a real
+          // card rather than the browser's own broken glyph.
+          onError={() => setBroken(true)}
+          className="max-w-full rounded-lg border border-border"
+        />
+      </button>
+
+      <ImageLightbox
+        images={[{ src: asset.dataUrl, name }]}
+        index={open ? 0 : null}
+        onIndex={() => {}}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+/// A file from an issue's description — the shape Linear itself draws.
+///
+/// Name, size, and a download that appears under the cursor. The whole row is
+/// the control, so the glyph on the right is a hint about what a click does
+/// rather than a second target to aim at.
+export function IssueFile({ href, name }: { href: string; name: string }) {
+  const { asset, loading } = useAsset(href);
+
+  const download = () => {
+    if (!asset) return;
+    // Through an anchor rather than `openUrl`: the bytes are already here as a
+    // `data:` URL, and `download` is what gives the file its name back — the
+    // URL itself is an opaque key with no name in it.
+    const link = document.createElement("a");
+    link.href = asset.dataUrl;
+    link.download = name;
+    link.click();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={download}
+      disabled={!asset}
+      title={name}
+      className={cn(
+        "group/file my-1 flex w-full items-center gap-3 rounded-lg border border-border px-3 py-2.5 text-left transition-colors",
+        asset ? "hover:bg-sidebar-accent/50" : "cursor-default",
+      )}
+    >
+      <File className="size-5 shrink-0 text-muted-foreground" />
+
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-chat">{name}</span>
+        <span className="text-ui text-muted-foreground">
+          {loading ? "Loading…" : asset ? formatBytes(asset.bytes) : "Unavailable"}
+        </span>
+      </span>
+
+      {asset && (
+        <Download className="size-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/file:opacity-100" />
+      )}
+    </button>
+  );
+}

--- a/apps/desktop/src/components/IssuePanel.tsx
+++ b/apps/desktop/src/components/IssuePanel.tsx
@@ -1,0 +1,341 @@
+import { useState } from "react";
+
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { ChevronRight, ExternalLink, Unlink } from "lucide-react";
+
+import Avatar from "@/components/Avatar";
+import { IssueFile, IssueImage } from "@/components/IssueAsset";
+import IssueStateIcon, { IssuePriorityIcon } from "@/components/IssueStateIcon";
+import { Markdown } from "@/components/chat/Markdown";
+import { Button } from "@/components/ui/button";
+import { relativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { Components } from "streamdown";
+
+import type { IssueDetail, IssueRef, IssueUnavailable } from "@/types/events";
+
+/// What to say when the issue could not be read, in terms of what the reader
+/// would do about it. `not_connected` keeps its own sentence because it is not
+/// a failure — it is the app's resting state before anyone has connected a
+/// tracker. Both cures name the Issues page, which is the one place a key can
+/// be pasted; a sentence pointing at Settings would send the reader to a row
+/// that only ever disconnects.
+const UNAVAILABLE: Record<IssueUnavailable["kind"], string> = {
+  not_connected: "Connect Linear on the Issues page to see this issue.",
+  unauthorized:
+    "Linear rejected the saved key. Disconnect it in Settings, then paste a new one on the Issues page.",
+  offline: "Could not reach Linear.",
+  other: "",
+};
+
+function errorText(error: IssueUnavailable): string {
+  return UNAVAILABLE[error.kind] || (error.kind === "other" ? error.detail : "");
+}
+
+/// Uploads inside a description, drawn rather than linked.
+///
+/// Linear puts both in the description's markdown — an image as `![](…)`, a
+/// file as `[name](…)` — and both point at `uploads.linear.app`, which serves
+/// them behind the same auth the API is behind. So the webview cannot fetch
+/// either on its own: the image renders as broken and the link opens a browser
+/// tab that 401s. These two send the request through the backend, where the key
+/// is, which is the whole of the fix.
+///
+/// Anything *not* an upload is left exactly as it was — an ordinary link in an
+/// issue is an ordinary link, and rewriting it would take the app's own link
+/// dialog off it.
+const ASSETS: Components = {
+  img: ({ src, alt }) =>
+    typeof src === "string" && isUpload(src) ? (
+      <IssueImage src={src} alt={alt} />
+    ) : (
+      <img src={typeof src === "string" ? src : undefined} alt={alt ?? ""} />
+    ),
+  a: ({ href, children, ...rest }) =>
+    typeof href === "string" && isUpload(href) ? (
+      // The link text is the filename Linear wrote into the markdown, and it
+      // is the only place the name survives — the URL itself is an opaque key.
+      <IssueFile href={href} name={typeof children === "string" ? children : href} />
+    ) : (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    ),
+};
+
+/// Whether a URL is one of Linear's own uploads.
+///
+/// The frontend's copy of Rust's `is_upload`, and it has to agree with it: this
+/// decides what gets *drawn* as an asset, that one decides what the key is sent
+/// to. Host-exactly, not by prefix — `uploads.linear.app.evil.test` passes a
+/// prefix test and is not Linear.
+function isUpload(url: string): boolean {
+  try {
+    return new URL(url).host === "uploads.linear.app";
+  } catch {
+    return false;
+  }
+}
+
+/// The issues this session's work is against, one collapsible row each — the
+/// shape the changes and pull request panels already use, because the question
+/// is the same: a list of things, any one of which can be opened.
+///
+/// The rows are drawn from the session's **links**, not from the read: a link
+/// carries the identifier and the title, so the panel has something to show
+/// before the tracker answers and keeps it if the tracker never does. The read
+/// fills in the body, the status and the conversation.
+export default function IssuePanel({
+  sessionId,
+  issues,
+  details,
+  loading,
+  unavailable,
+  onUnlink,
+}: {
+  sessionId: string | null;
+  /// What the session is tagged with, newest last.
+  issues: IssueRef[];
+  /// Detail by identifier, as far as it has arrived.
+  details: Record<string, IssueDetail>;
+  loading: boolean;
+  unavailable: IssueUnavailable | null;
+  onUnlink: (sessionId: string, key: string) => void;
+}) {
+  if (!issues.length) {
+    return (
+      <Empty>
+        No issue on this session. Tag one with <code className="text-foreground">#</code> in the
+        composer.
+      </Empty>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {/* Under the rows it failed to update rather than over them: a refresh
+          that failed against issues already on screen must not hide them. */}
+      {unavailable && <p className="px-3 py-2 text-ui text-destructive">{errorText(unavailable)}</p>}
+
+      {issues.map((issue, i) => (
+        <IssueRow
+          key={issue.id}
+          issue={issue}
+          detail={details[issue.identifier] ?? null}
+          loading={loading}
+          // Newest tag last, and the first row open: a session tagged once has
+          // its issue open, and one tagged three times opens on the oldest —
+          // which is the one it was started against.
+          defaultOpen={i === 0}
+          collapsible={issues.length > 1}
+          onUnlink={sessionId ? () => onUnlink(sessionId, issue.id) : undefined}
+        />
+      ))}
+    </div>
+  );
+}
+
+function IssueRow({
+  issue,
+  detail,
+  loading,
+  defaultOpen,
+  collapsible,
+  onUnlink,
+}: {
+  issue: IssueRef;
+  detail: IssueDetail | null;
+  loading: boolean;
+  defaultOpen: boolean;
+  /// False when this is the session's only issue. It is then always open and
+  /// its header is a label rather than a control — a disclosure arrow that can
+  /// only point down is an affordance for nothing.
+  collapsible: boolean;
+  onUnlink?: () => void;
+}) {
+  const [collapsed, setCollapsed] = useState(!defaultOpen);
+  const open = !collapsible || !collapsed;
+  const toggle = () => setCollapsed((prev) => !prev);
+
+  return (
+    <div className="border-b border-border last:border-b-0">
+      {/* A div behaving as a button, because the buttons inside it are real
+          ones and a button cannot nest a button — the same shape `PrRow` and
+          `SessionRow` use. */}
+      <div
+        {...(collapsible
+          ? {
+              role: "button",
+              tabIndex: 0,
+              onClick: toggle,
+              onKeyDown: (e: React.KeyboardEvent) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  toggle();
+                }
+              },
+            }
+          : {})}
+        className={cn(
+          "group flex w-full items-center gap-2 px-3 py-2.5 text-left text-ui",
+          collapsible &&
+            "cursor-pointer transition-colors hover:bg-sidebar-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+        )}
+      >
+        {collapsible && (
+          <ChevronRight
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-90",
+            )}
+          />
+        )}
+
+        {/* Always drawn, "no priority" included — the slot is reserved so the
+            row does not reflow when the read lands. `none` until it does,
+            which is the honest resting value rather than a guess. */}
+        <IssuePriorityIcon priority={detail?.priority ?? "none"} />
+
+        <span className="shrink-0 font-medium tabular-nums">{issue.identifier}</span>
+
+        {/* From the read where it has landed, and a resting glyph until then —
+            so the row never jumps between two heights as detail arrives. */}
+        {detail ? (
+          <IssueStateIcon
+            kind={detail.state.kind}
+            color={detail.state.color}
+            label={detail.state.name}
+          />
+        ) : (
+          <IssueStateIcon kind="other" label={loading ? "Loading" : "Unknown"} />
+        )}
+
+        {/* The link's own title until the read lands, then the tracker's — a
+            link is a copy and can be stale, and this is where that shows. */}
+        <span className="min-w-0 flex-1 truncate text-muted-foreground">
+          {detail?.title ?? issue.title}
+        </span>
+
+        <div className="flex shrink-0 items-center gap-0.5">
+          {onUnlink && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`Remove ${issue.identifier}`}
+              title={`Remove ${issue.identifier} from this session`}
+              // Shown on hover and on focus, like every other row-level control
+              // here: untagging is rare, and a button on every row at rest is
+              // one more thing between the reader and what the row says.
+              className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+              onClick={(e) => {
+                e.stopPropagation();
+                onUnlink();
+              }}
+            >
+              <Unlink className="size-3.5" />
+            </Button>
+          )}
+
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Open ${issue.identifier} in the browser`}
+            className="text-muted-foreground"
+            onClick={(e) => {
+              e.stopPropagation();
+              void openUrl(issue.url);
+            }}
+          >
+            <ExternalLink className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {open && <IssueBody detail={detail} loading={loading} />}
+    </div>
+  );
+}
+
+/// What is inside an opened issue: its status and people, then its description,
+/// then what has been said on it.
+///
+/// The description is drawn here where the pull request panel deliberately
+/// leaves the PR body out, and the difference is who wrote it. A PR body is the
+/// reader's own text, restating what they can see in the diff beside it; an
+/// issue's description is somebody else's, and it is the whole reason the tab
+/// exists.
+function IssueBody({ detail, loading }: { detail: IssueDetail | null; loading: boolean }) {
+  if (!detail) {
+    return (
+      <p className="px-3 pb-3 text-ui text-muted-foreground">
+        {loading ? "Reading the issue…" : "Could not read this issue."}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-3 pb-3">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-ui text-muted-foreground">
+        {detail.assignee && (
+          <span className="flex items-center gap-1.5">
+            <Avatar src={detail.assignee.avatar} name={detail.assignee.name} />
+            {detail.assignee.name}
+          </span>
+        )}
+
+        {detail.project && <span>{detail.project}</span>}
+
+        {/* Last, because it is the least of the four and the one that keeps
+            changing — a row that reflows as the clock moves is worse at the
+            left edge than at the right. */}
+        {detail.updatedAt && <span>Updated {relativeTime(detail.updatedAt)}</span>}
+      </div>
+
+      {detail.labels.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {detail.labels.map((label) => (
+            // The tracker's own colour, and the one place this panel uses it:
+            // a label has no meaning apart from the colour somebody chose for
+            // it, unlike a status, which folds onto a fixed vocabulary.
+            <span
+              key={label.name}
+              className="rounded-full border px-1.5 py-px text-ui"
+              style={{ borderColor: label.color || undefined, color: label.color || undefined }}
+            >
+              {label.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {detail.description ? (
+        <div className="text-chat">
+          <Markdown components={ASSETS}>{detail.description}</Markdown>
+        </div>
+      ) : (
+        <p className="text-ui text-muted-foreground">No description.</p>
+      )}
+
+      {detail.comments.length > 0 && (
+        <div className="flex flex-col gap-2 border-t border-border pt-3">
+          {detail.comments.map((comment, i) => (
+            <div key={i} className="flex flex-col gap-1">
+              <div className="flex items-center gap-1.5 text-ui text-muted-foreground">
+                <Avatar src={comment.author.avatar} name={comment.author.name} />
+                <span className="text-foreground">{comment.author.name}</span>
+                <span>{relativeTime(comment.createdAt)}</span>
+              </div>
+              <div className="text-chat">
+                <Markdown>{comment.body}</Markdown>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <p className="px-3 py-4 text-ui text-muted-foreground">{children}</p>;
+}

--- a/apps/desktop/src/components/IssueStateIcon.tsx
+++ b/apps/desktop/src/components/IssueStateIcon.tsx
@@ -1,0 +1,203 @@
+import { cn } from "@/lib/utils";
+import type { IssuePriority, IssueStateKind } from "@/types/events";
+
+/// Linear's own status and priority marks, redrawn rather than approximated.
+///
+/// These are the two glyph sets a reader arriving from the tracker already
+/// knows by shape — a part-filled ring is progress, three rising bars are
+/// priority — and a lucide stand-in for either was a second vocabulary to
+/// learn for no gain. Paths taken from Linear's own SVGs.
+///
+/// Shape comes from the *kind*, which is a fixed six-way vocabulary; the colour
+/// is the tracker's where it gave one. A workspace that paints "In Review"
+/// green should read green here too, and the kind is what keeps the shape
+/// stable while it does.
+
+/// Fallback colours, matching Linear's defaults, for where no state colour is
+/// to hand — the issues page's group headers name a *kind*, and the several
+/// states folded into one may each carry a different colour of their own.
+const KIND_COLOR: Record<IssueStateKind, string> = {
+  triage: "#e2a336",
+  backlog: "#bec2c8",
+  unstarted: "#e2e2e2",
+  started: "#f2c94c",
+  completed: "#5e6ad2",
+  canceled: "#95a2b3",
+  other: "#bec2c8",
+};
+
+/// How far round the ring is filled. Linear draws progress as a pie wedge
+/// inside an outlined circle, and the fraction is the whole of what separates
+/// Todo from In Progress from In Review.
+const WEDGE: Partial<Record<IssueStateKind, number>> = {
+  unstarted: 0,
+  triage: 0.25,
+  started: 0.5,
+  other: 0,
+};
+
+/// The wedge path for a fraction of the ring, drawn from the centre.
+///
+/// Hand-rolled rather than a stroke-dasharray ring, because Linear's mark is a
+/// filled pie and a dashed stroke reads as a dotted outline at 14px.
+function wedgePath(fraction: number): string {
+  if (fraction <= 0) return "";
+  if (fraction >= 1) return "M 3.5,3.5 m -3.5,0 a 3.5,3.5 0 1,0 7,0 a 3.5,3.5 0 1,0 -7,0";
+
+  const angle = fraction * 2 * Math.PI;
+  const x = 3.5 * Math.sin(angle);
+  const y = -3.5 * Math.cos(angle);
+  const sweep = fraction > 0.5 ? 1 : 0;
+
+  return `M 3.5,3.5 L 3.5,0 A 3.5,3.5 0 ${sweep},1 ${(3.5 + x).toFixed(3)},${(3.5 + y).toFixed(3)} z`;
+}
+
+export default function IssueStateIcon({
+  kind,
+  color,
+  label,
+  className,
+}: {
+  kind: IssueStateKind;
+  /// The tracker's own colour for this exact state. Absent where the caller
+  /// only knows the kind.
+  color?: string | null;
+  /// The state's own name — "In Review" is what the reader's workspace calls it
+  /// and what they will look for, where `started` is what this app folds it
+  /// into. Falls back to nothing rather than reading the kind out loud.
+  label?: string;
+  className?: string;
+}) {
+  const fill = color || KIND_COLOR[kind];
+  const shared = {
+    width: 14,
+    height: 14,
+    viewBox: "0 0 14 14",
+    className: cn("size-3.5 shrink-0", className),
+    role: "img" as const,
+    "aria-label": label,
+    "aria-hidden": label ? undefined : true,
+  };
+
+  if (kind === "completed") {
+    return (
+      <svg {...shared} fill={fill}>
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M7 0C3.13401 0 0 3.13401 0 7C0 10.866 3.13401 14 7 14C10.866 14 14 10.866 14 7C14 3.13401 10.866 0 7 0ZM11.101 5.10104C11.433 4.76909 11.433 4.23091 11.101 3.89896C10.7691 3.56701 10.2309 3.56701 9.89896 3.89896L5.5 8.29792L4.10104 6.89896C3.7691 6.56701 3.2309 6.56701 2.89896 6.89896C2.56701 7.2309 2.56701 7.7691 2.89896 8.10104L4.89896 10.101C5.2309 10.433 5.7691 10.433 6.10104 10.101L11.101 5.10104Z"
+        />
+      </svg>
+    );
+  }
+
+  if (kind === "canceled") {
+    return (
+      <svg {...shared} fill={fill}>
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M7 14C10.866 14 14 10.866 14 7C14 3.13401 10.866 0 7 0C3.13401 0 0 3.13401 0 7C0 10.866 3.13401 14 7 14ZM5.03033 3.96967C4.73744 3.67678 4.26256 3.67678 3.96967 3.96967C3.67678 4.26256 3.67678 4.73744 3.96967 5.03033L5.93934 7L3.96967 8.96967C3.67678 9.26256 3.67678 9.73744 3.96967 10.0303C4.26256 10.3232 4.73744 10.3232 5.03033 10.0303L7 8.06066L8.96967 10.0303C9.26256 10.3232 9.73744 10.3232 10.0303 10.0303C10.3232 9.73744 10.3232 9.26256 10.0303 8.96967L8.06066 7L10.0303 5.03033C10.3232 4.73744 10.3232 4.26256 10.0303 3.96967C9.73744 3.67678 9.26256 3.67678 8.96967 3.96967L7 5.93934L5.03033 3.96967Z"
+        />
+      </svg>
+    );
+  }
+
+  // Backlog is the one that isn't a ring at all — a dashed circle, which is
+  // Linear's way of saying this is not yet on anybody's list.
+  if (kind === "backlog") {
+    return (
+      <svg {...shared} fill={fill}>
+        <path d="M13.9408 7.91426L11.9576 7.65557C11.9855 7.4419 12 7.22314 12 7C12 6.77686 11.9855 6.5581 11.9576 6.34443L13.9408 6.08573C13.9799 6.38496 14 6.69013 14 7C14 7.30987 13.9799 7.61504 13.9408 7.91426ZM13.4688 4.32049C13.2328 3.7514 12.9239 3.22019 12.5538 2.73851L10.968 3.95716C11.2328 4.30185 11.4533 4.68119 11.6214 5.08659L13.4688 4.32049ZM11.2615 1.4462L10.0428 3.03204C9.69815 2.76716 9.31881 2.54673 8.91341 2.37862L9.67951 0.531163C10.2486 0.767153 10.7798 1.07605 11.2615 1.4462ZM7.91426 0.0591659L7.65557 2.04237C7.4419 2.01449 7.22314 2 7 2C6.77686 2 6.5581 2.01449 6.34443 2.04237L6.08574 0.059166C6.38496 0.0201343 6.69013 0 7 0C7.30987 0 7.61504 0.0201343 7.91426 0.0591659ZM4.32049 0.531164L5.08659 2.37862C4.68119 2.54673 4.30185 2.76716 3.95716 3.03204L2.73851 1.4462C3.22019 1.07605 3.7514 0.767153 4.32049 0.531164ZM1.4462 2.73851L3.03204 3.95716C2.76716 4.30185 2.54673 4.68119 2.37862 5.08659L0.531164 4.32049C0.767153 3.7514 1.07605 3.22019 1.4462 2.73851ZM0.0591659 6.08574C0.0201343 6.38496 0 6.69013 0 7C0 7.30987 0.0201343 7.61504 0.059166 7.91426L2.04237 7.65557C2.01449 7.4419 2 7.22314 2 7C2 6.77686 2.01449 6.5581 2.04237 6.34443L0.0591659 6.08574ZM0.531164 9.67951L2.37862 8.91341C2.54673 9.31881 2.76716 9.69815 3.03204 10.0428L1.4462 11.2615C1.07605 10.7798 0.767153 10.2486 0.531164 9.67951ZM2.73851 12.5538L3.95716 10.968C4.30185 11.2328 4.68119 11.4533 5.08659 11.6214L4.32049 13.4688C3.7514 13.2328 3.22019 12.9239 2.73851 12.5538ZM6.08574 13.9408L6.34443 11.9576C6.5581 11.9855 6.77686 12 7 12C7.22314 12 7.4419 11.9855 7.65557 11.9576L7.91427 13.9408C7.61504 13.9799 7.30987 14 7 14C6.69013 14 6.38496 13.9799 6.08574 13.9408ZM9.67951 13.4688L8.91341 11.6214C9.31881 11.4533 9.69815 11.2328 10.0428 10.968L11.2615 12.5538C10.7798 12.9239 10.2486 13.2328 9.67951 13.4688ZM12.5538 11.2615L10.968 10.0428C11.2328 9.69815 11.4533 9.31881 11.6214 8.91341L13.4688 9.67951C13.2328 10.2486 12.924 10.7798 12.5538 11.2615Z" />
+      </svg>
+    );
+  }
+
+  const wedge = wedgePath(WEDGE[kind] ?? 0);
+
+  return (
+    <svg {...shared}>
+      <rect x="1" y="1" width="12" height="12" rx="6" stroke={fill} strokeWidth="1.5" fill="none" />
+      {wedge && <path d={wedge} fill={fill} transform="translate(3.5,3.5)" />}
+    </svg>
+  );
+}
+
+/// The five priority marks, always drawn — including "none".
+///
+/// Reserving the slot matters more than what fills it: a glyph that appears
+/// only on some rows shifts every title beside it, and the eye reads the
+/// resulting ragged column as disorder rather than as information. Linear draws
+/// "no priority" as three flat dashes for exactly this reason, so the column is
+/// the same width on every row and the *height* of the bars is the signal.
+const BARS: Record<Exclude<IssuePriority, "urgent" | "none">, number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+const PRIORITY_LABEL: Record<IssuePriority, string> = {
+  none: "No priority",
+  low: "Low priority",
+  medium: "Medium priority",
+  high: "High priority",
+  urgent: "Urgent",
+};
+
+export function IssuePriorityIcon({
+  priority,
+  className,
+}: {
+  priority: IssuePriority;
+  className?: string;
+}) {
+  const shared = {
+    width: 16,
+    height: 16,
+    viewBox: "0 0 16 16",
+    role: "img" as const,
+    "aria-label": PRIORITY_LABEL[priority],
+  };
+
+  if (priority === "urgent") {
+    return (
+      // The one that is not bars at all. Urgent is a filled square with a bang
+      // in it, so it reads as an alarm rather than as "one bar more than high".
+      <svg {...shared} className={cn("size-4 shrink-0 text-destructive", className)} fill="currentColor">
+        <path d="M3 1C1.91067 1 1 1.91067 1 3V13C1 14.0893 1.91067 15 3 15H13C14.0893 15 15 14.0893 15 13V3C15 1.91067 14.0893 1 13 1H3ZM7 4L9 4L8.75391 8.99836H7.25L7 4ZM9 11C9 11.5523 8.55228 12 8 12C7.44772 12 7 11.5523 7 11C7 10.4477 7.44772 10 8 10C8.55228 10 9 10.4477 9 11Z" />
+      </svg>
+    );
+  }
+
+  if (priority === "none") {
+    return (
+      <svg
+        {...shared}
+        className={cn("size-4 shrink-0 text-muted-foreground/50", className)}
+        fill="currentColor"
+      >
+        <rect x="1.5" y="7.25" width="3" height="1.5" rx="0.5" />
+        <rect x="6.5" y="7.25" width="3" height="1.5" rx="0.5" />
+        <rect x="11.5" y="7.25" width="3" height="1.5" rx="0.5" />
+      </svg>
+    );
+  }
+
+  // Bars past the level are drawn faint rather than dropped, which is what
+  // makes low and medium readable as *positions on a scale* instead of as two
+  // unrelated marks.
+  const lit = BARS[priority];
+  const dim = (index: number) => (index <= lit ? 1 : 0.25);
+
+  return (
+    <svg
+      {...shared}
+      className={cn("size-4 shrink-0 text-muted-foreground", className)}
+      fill="currentColor"
+    >
+      <rect x="1.5" y="8" width="3" height="6" rx="1" fillOpacity={dim(1)} />
+      <rect x="6.5" y="5" width="3" height="9" rx="1" fillOpacity={dim(2)} />
+      <rect x="11.5" y="2" width="3" height="12" rx="1" fillOpacity={dim(3)} />
+    </svg>
+  );
+}

--- a/apps/desktop/src/components/IssuesView.tsx
+++ b/apps/desktop/src/components/IssuesView.tsx
@@ -1,0 +1,583 @@
+import { useEffect, useMemo, useState, type MutableRefObject } from "react";
+
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { ChevronRight, RefreshCw, Search, SlidersHorizontal } from "lucide-react";
+
+import Avatar from "@/components/Avatar";
+import IssueStateIcon, { IssuePriorityIcon } from "@/components/IssueStateIcon";
+import LinearIcon from "@/components/LinearIcon";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { IS_MAC } from "@/lib/platform";
+import { useIssues } from "@/hooks/useIssues";
+import { groupIssues } from "@/lib/issue";
+import { calendarDay } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type {
+  Issue,
+  IssueGroup,
+  IssueQuery,
+  IssueScope,
+  IssueStateKind,
+  IssueUnavailable,
+} from "@/types/events";
+
+/// Where a personal API key is made. Linked rather than described, because the
+/// path through Linear's own settings is theirs to change and a stale sentence
+/// here is worse than none.
+const LINEAR_KEYS_URL = "https://linear.app/settings/account/security";
+
+/// Linear's own MCP documentation. The setup is theirs and it changes, so this
+/// points at it rather than reproducing it.
+const LINEAR_MCP_URL = "https://linear.app/docs/mcp";
+
+/// What a failed read says, in one line.
+///
+/// The cure is named where there is one — a key Linear has stopped accepting is
+/// fixed by disconnecting in Settings and pasting a new one here, and saying so
+/// is the difference between a sentence to act on and one to stare at. Anything
+/// unrecognised falls back to the tracker's own words rather than a shrug of
+/// our own.
+function unavailableText(unavailable: IssueUnavailable): string {
+  switch (unavailable.kind) {
+    case "unauthorized":
+      return "Linear rejected the saved key. Disconnect it in Settings, then paste a new one.";
+    case "offline":
+      return "Could not reach Linear.";
+    case "not_connected":
+      return "No issue tracker connected.";
+    default:
+      return unavailable.detail;
+  }
+}
+
+const SCOPES: { value: IssueScope; label: string }[] = [
+  { value: "assigned", label: "Assigned to me" },
+  { value: "created", label: "Created" },
+];
+
+/// The two buckets that are read on demand. Drawn in the same order [groupIssues]
+/// would put them in, so opening one does not reshuffle the page.
+const SETTLED_KINDS: { key: IssueStateKind; label: string }[] = [
+  { key: "completed", label: "Done" },
+  { key: "canceled", label: "Cancelled" },
+];
+
+/// Every issue the reader could pick up.
+///
+/// A page rather than a panel: the right-hand panel answers "what is *this*
+/// session about", and this answers "what is there to work on" — which has no
+/// session to hang off and is the thing you look at before there is one.
+///
+/// It reads. Clicking a row opens the issue in the tracker, which is where its
+/// text, its status and its people can actually be changed — a second place to
+/// edit them is a second place to be wrong about them.
+export default function IssuesView({
+  active,
+  connected,
+  onConnect,
+  connecting,
+  connectError,
+  picked,
+  onPick,
+  refreshRef,
+}: {
+  /// The page is the thing on screen. Hidden pages do not read, for the reason
+  /// the right panel's own `active` exists.
+  active: boolean;
+  connected: boolean;
+  /// Answers whether the key was accepted, so the field can clear itself only
+  /// on success.
+  onConnect: (key: string) => Promise<boolean>;
+  connecting: boolean;
+  connectError: string | null;
+  /// The issue whose detail the pane beside this is showing, so the row can
+  /// say which one it is. Owned by `App`, because the pane is.
+  picked: string | null;
+  onPick: (issue: Issue) => void;
+  /// Where this page hands its refresh up, so ⌘R can reach it. `App` owns the
+  /// chord — it has to pick between this page and the right panel, and only it
+  /// knows which one the reader is looking at.
+  refreshRef?: MutableRefObject<(() => void) | null>;
+}) {
+  const { issues, settled, filters, query, setQuery, loading, unavailable, refresh } = useIssues(
+    active && connected,
+  );
+
+  // Kept current rather than set once: `refresh` is re-made whenever the hook
+  // re-runs, and a handle captured at mount would close over a stale one.
+  useEffect(() => {
+    if (!refreshRef) return;
+    refreshRef.current = refresh;
+    return () => {
+      refreshRef.current = null;
+    };
+  }, [refreshRef, refresh]);
+
+  const set = (patch: Partial<IssueQuery>) => setQuery({ ...query, ...patch });
+  const groups = useMemo(() => groupIssues(issues), [issues]);
+  const settledGroups = useMemo(() => groupIssues(settled.issues), [settled.issues]);
+
+  if (!connected) {
+    return <Connect onConnect={onConnect} busy={connecting} error={connectError} />;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-1.5 px-3 pt-3">
+        {SCOPES.map((scope) => (
+          // Chips rather than a menu, because these are the two questions worth
+          // one press: what is mine to do, and what did I ask for. Everything
+          // that narrows *within* an answer is behind the control beside them.
+          <button
+            key={scope.value}
+            type="button"
+            onClick={() => set({ scope: scope.value })}
+            className={cn(
+              "rounded-full px-2.5 py-1 text-ui transition-colors",
+              query.scope === scope.value
+                ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {scope.label}
+          </button>
+        ))}
+
+        <FilterMenu query={query} filters={filters} onChange={set} />
+
+        {/* Far right, away from the chips. It acts on the whole page rather
+            than narrowing it, so sitting in the row of things that narrow read
+            as a third chip. Same corner and same chord as the right panel's,
+            which is the point: the chord means "re-read what I am looking at",
+            and never a specific thing. */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Refresh"
+              className="ml-auto text-muted-foreground/60 hover:text-muted-foreground"
+              onClick={refresh}
+            >
+              <RefreshCw className={cn("size-3.5", loading && "animate-spin")} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            Refresh
+            <KbdGroup>
+              <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+              <Kbd>R</Kbd>
+            </KbdGroup>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      {/* No fill and no border. A search box is the one control here that is
+          always in the same place, so it needs no edge to be found — and a
+          filled field above a borderless list draws a box round the least
+          interesting third of the page. The glyph does the work the border
+          was doing: it says "type here" without enclosing anything. */}
+      <div className="flex h-11 shrink-0 items-center gap-2 px-3">
+        <Search className="size-4 shrink-0 text-muted-foreground" />
+        <Input
+          value={query.text ?? ""}
+          placeholder="Search issues"
+          spellCheck={false}
+          // `dark:bg-transparent` as well as `bg-transparent`: the base input
+          // carries `dark:bg-input/30`, which is the more specific rule and
+          // wins — so the plain override read as removed here while leaving a
+          // fill on screen.
+          className="h-full rounded-none border-0 bg-transparent p-0 shadow-none focus-visible:ring-0 dark:bg-transparent"
+          onChange={(e) => set({ text: e.currentTarget.value || null })}
+        />
+      </div>
+
+      {/* Under the header rather than over the rows: a failed refresh leaves
+          what was already read on screen, and this says the answer is stale. */}
+      {unavailable && (
+        <p className="border-b border-border px-3 py-2 text-ui text-destructive">
+          {unavailableText(unavailable)}
+        </p>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {issues.length === 0 && !loading && (
+          <p className="px-3 py-4 text-ui text-muted-foreground">
+            {query.text
+              ? "No issue matches that."
+              : query.scope === "created"
+                ? "Nothing you filed is open."
+                : "Nothing assigned to you."}
+          </p>
+        )}
+
+        {groups.map((group) => (
+          <Group key={group.key} kind={group.key} label={group.label} count={group.issues.length}>
+            {group.issues.map((issue) => (
+              <IssueRow
+                key={issue.id}
+                issue={issue}
+                picked={issue.identifier === picked}
+                onPick={onPick}
+              />
+            ))}
+          </Group>
+        ))}
+
+        {/* Done and Cancelled are always here and always start closed. Finished
+            work is most of a workspace and almost never what the page was
+            opened for — but it is what the reader wants when they want it, and
+            a filter they have to find first is worse than a heading they can
+            see. Nothing is fetched until one is opened: the headings cost a
+            round trip only when somebody asks a question of them. */}
+        {SETTLED_KINDS.map(({ key, label }) => {
+          const group = settledGroups.find((g) => g.key === key);
+
+          return (
+            <Group
+              key={key}
+              kind={key}
+              label={label}
+              count={settled.loaded ? (group?.issues.length ?? 0) : null}
+              collapsedByDefault
+              onFirstOpen={settled.request}
+            >
+              {settled.loading && !settled.loaded ? (
+                <p className="px-3 py-2 text-ui text-muted-foreground">Reading…</p>
+              ) : group ? (
+                group.issues.map((issue) => (
+                  <IssueRow
+                    key={issue.id}
+                    issue={issue}
+                    picked={issue.identifier === picked}
+                    onPick={onPick}
+                  />
+                ))
+              ) : (
+                <p className="px-3 py-2 text-ui text-muted-foreground">Nothing here.</p>
+              )}
+            </Group>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/// The page with nothing connected, and the key field is *here* rather than a
+/// trip to settings — this is the surface that has nothing to show without one,
+/// so this is where the thing that fixes it belongs.
+function Connect({
+  onConnect,
+  busy,
+  error,
+}: {
+  onConnect: (key: string) => Promise<boolean>;
+  busy: boolean;
+  error: string | null;
+}) {
+  const [key, setKey] = useState("");
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-6">
+      <div className="flex w-full max-w-sm flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          {/* The mark, because it is what makes this recognisable before the
+              sentence under it is read — and this is one of the two places in
+              the app where naming the tracker is the point rather than a leak
+              of the implementation. */}
+          <p className="flex items-center gap-2 text-ui font-medium">
+            <LinearIcon />
+            Connect Linear
+          </p>
+          {/* Read access is the whole ask, and saying so is what makes pasting
+              a key into a desktop app a smaller decision than it looks. */}
+          <p className="text-ui text-muted-foreground">
+            Paste a personal API key with read access. Dray only reads — it never changes an issue.
+          </p>
+        </div>
+
+        <form
+          className="flex gap-2"
+          onSubmit={async (e) => {
+            e.preventDefault();
+            if (await onConnect(key)) setKey("");
+          }}
+        >
+          <Input
+            value={key}
+            // A personal API key is a credential, and this page is open in
+            // front of other people often enough.
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="lin_api_…"
+            onChange={(e) => setKey(e.currentTarget.value)}
+          />
+          {/* Height matched to the field beside it rather than left at the
+              small default — two controls on one line that disagree about how
+              tall they are read as a mistake before they read as a form. */}
+          <Button type="submit" className="h-9 shrink-0" disabled={busy || !key.trim()}>
+            {busy ? "Connecting…" : "Connect"}
+          </Button>
+        </form>
+
+        {error && <p className="text-ui text-destructive">{error}</p>}
+
+        <button
+          type="button"
+          className="self-start text-ui text-muted-foreground hover:text-foreground"
+          onClick={() => void openUrl(LINEAR_KEYS_URL)}
+        >
+          Create a key in Linear
+        </button>
+
+        {/* The other half of the setup, and this is the place to say it.
+            This key is what fills *these* screens; it gives the agent nothing.
+            An agent that is to read an issue in full, or move one, needs
+            Linear's MCP server — and someone finding that out later, from a
+            model working off a one-line title, finds it out the expensive way.
+            Said here, while they are already setting this up, and said once. */}
+        <p className="border-t border-border pt-3 text-ui text-muted-foreground">
+          This key is read-only, and it is for Dray. To let the agent read and manage issues in
+          chat, add{" "}
+          <button
+            type="button"
+            className="text-foreground underline underline-offset-2 hover:text-foreground/80"
+            onClick={() => void openUrl(LINEAR_MCP_URL)}
+          >
+            Linear's MCP server
+          </button>{" "}
+          to your CLI.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/// One status bucket, collapsible, with the kind's own glyph beside the name.
+///
+/// Grouped because a flat list of forty issues has no shape: what is in
+/// progress and what is still a wish are different questions, and the tracker
+/// the reader already has open groups them exactly this way.
+///
+/// No fill behind the header, and space between groups instead. A tinted band
+/// across the page draws a box round the quietest line on it; a gap says the
+/// same thing with nothing at all, and leaves the rows as the only marked
+/// surface. The glyph is what the row above gave up — one copy, on the heading
+/// that names the state, rather than one per row repeating it.
+function Group({
+  kind,
+  label,
+  count,
+  collapsedByDefault = false,
+  onFirstOpen,
+  children,
+}: {
+  kind: IssueStateKind;
+  label: string;
+  /// `null` for a group whose rows have not been read yet — the settled ones
+  /// before anybody opens them. A zero there would be a claim, not a blank.
+  count: number | null;
+  collapsedByDefault?: boolean;
+  onFirstOpen?: () => void;
+  children: React.ReactNode;
+}) {
+  const [collapsed, setCollapsed] = useState(collapsedByDefault);
+
+  return (
+    <div className="mb-1.5 last:mb-0">
+      <button
+        type="button"
+        onClick={() => {
+          if (collapsed) onFirstOpen?.();
+          setCollapsed((prev) => !prev);
+        }}
+        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-ui text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronRight className={cn("size-3.5 transition-transform", !collapsed && "rotate-90")} />
+        <IssueStateIcon kind={kind} />
+        <span className="font-medium text-foreground">{label}</span>
+        {count !== null && <span className="tabular-nums">{count}</span>}
+      </button>
+
+      {!collapsed && children}
+    </div>
+  );
+}
+
+/// The filters, behind one control.
+///
+/// A menu rather than more chips: these narrow *within* whichever chip is on,
+/// and four more controls across the header would be four things to read past
+/// on every visit to change none of them.
+///
+/// A team or project list with one entry is not offered at all — a filter whose
+/// only option is "the one you already have" is a control that cannot do
+/// anything, and this is a solo tool often pointed at a single team.
+function FilterMenu({
+  query,
+  filters,
+  onChange,
+}: {
+  query: IssueQuery;
+  filters: { teams: IssueGroup[]; projects: IssueGroup[] } | null;
+  onChange: (patch: Partial<IssueQuery>) => void;
+}) {
+  const teams = filters && filters.teams.length > 1 ? filters.teams : [];
+  const projects = filters && filters.projects.length > 1 ? filters.projects : [];
+  const narrowed = !!query.teamId || !!query.projectId;
+
+  // Nothing left to narrow by. A trigger that opens an empty menu is worse than
+  // no trigger, and a single-team workspace is the ordinary case here.
+  if (!teams.length && !projects.length) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Filters"
+          // Lit while something is on, so a list narrowed by a filter set on a
+          // previous visit says so rather than reading as an empty workspace.
+          className={cn(
+            narrowed ? "text-foreground" : "text-muted-foreground/60 hover:text-muted-foreground",
+          )}
+        >
+          <SlidersHorizontal className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" className="w-56">
+        {teams.length > 0 && (
+          <>
+            <DropdownMenuLabel>Team</DropdownMenuLabel>
+            <DropdownMenuCheckboxItem
+              checked={!query.teamId}
+              onCheckedChange={() => onChange({ teamId: null })}
+            >
+              All teams
+            </DropdownMenuCheckboxItem>
+            {teams.map((team) => (
+              <DropdownMenuCheckboxItem
+                key={team.id}
+                checked={query.teamId === team.id}
+                // Picking one clears the other, so the menu is a radio group
+                // spelled with checkmarks — the shape the rest of the app's
+                // menus use, and one filter per axis is what the backend takes.
+                onCheckedChange={(on) => onChange({ teamId: on ? team.id : null })}
+              >
+                {team.name}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </>
+        )}
+
+        {projects.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Project</DropdownMenuLabel>
+            <DropdownMenuCheckboxItem
+              checked={!query.projectId}
+              onCheckedChange={() => onChange({ projectId: null })}
+            >
+              All projects
+            </DropdownMenuCheckboxItem>
+            {projects.map((project) => (
+              <DropdownMenuCheckboxItem
+                key={project.id}
+                checked={query.projectId === project.id}
+                onCheckedChange={(on) => onChange({ projectId: on ? project.id : null })}
+              >
+                {project.name}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/// One issue. The whole row opens it in the pane beside this one.
+///
+/// It used to open the tracker in a browser, and that was a trip taken for
+/// something the app already had: the pane draws the description, the people,
+/// the attachments and the conversation from the same key this list was read
+/// with. Linear is still one click away — the pane's own row carries the
+/// button — but it is the second thing offered rather than the first.
+///
+/// No start button. It would have to name a project, and this page is
+/// workspace-wide — so the button either guesses which repo the work belongs in
+/// or grows a picker of its own beside every row. Tagging a session with `#` in
+/// the composer already starts work against an issue, from a place that knows
+/// which project it is in.
+function IssueRow({
+  issue,
+  picked,
+  onPick,
+}: {
+  issue: Issue;
+  picked: boolean;
+  onPick: (issue: Issue) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onPick(issue)}
+      className={cn(
+        "group flex w-full items-center gap-2 px-3 py-2 text-left text-ui transition-colors",
+        picked ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/50",
+      )}
+    >
+      {/* Always drawn, "no priority" included. A glyph that appears on only
+          some rows shifts every title beside it, and a ragged left edge reads
+          as disorder rather than as information. */}
+      <IssuePriorityIcon priority={issue.priority} />
+
+      <span className="w-16 shrink-0 truncate text-muted-foreground tabular-nums">
+        {issue.identifier}
+      </span>
+
+      {/* No status glyph here. The rows are already gathered under a heading
+          that carries one, so a second copy on every row says what the row's
+          own position has just said. */}
+      <span className="min-w-0 flex-1 truncate">{issue.title}</span>
+
+      {issue.project && (
+        <span className="hidden shrink-0 rounded-full border border-border px-1.5 py-px text-muted-foreground lg:inline">
+          {issue.project}
+        </span>
+      )}
+
+      {/* Who has it. Unassigned draws nothing rather than a placeholder head:
+          the question is "whose is this", and a row with no answer should read
+          as quiet, not as somebody with no face. */}
+      {issue.assignee && (
+        <Avatar
+          src={issue.assignee.avatar}
+          name={issue.assignee.name}
+          className="hidden sm:flex"
+        />
+      )}
+
+      {/* The least of what the row says and the first thing to go when it is
+          narrow — the identifier and the title are what it is read for. */}
+      <span className="hidden w-16 shrink-0 text-right text-muted-foreground sm:inline">
+        {calendarDay(issue.updatedAt)}
+      </span>
+    </button>
+  );
+}

--- a/apps/desktop/src/components/LinearIcon.tsx
+++ b/apps/desktop/src/components/LinearIcon.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+/// Linear's mark.
+///
+/// Drawn wherever the reader is being asked about Linear *specifically* — the
+/// connect form and the settings row — and nowhere else. Everywhere else the
+/// surface says "issue", because a second tracker should cost a module and not
+/// a rename of every panel; the logo is the one place naming it is the point,
+/// since it is what makes "paste a key" recognisable before the sentence
+/// under it is read.
+///
+/// `currentColor`, not brand purple: this sits in a row of muted chrome, and
+/// a single saturated logo would be the loudest thing on a surface whose job
+/// is to be quiet.
+export default function LinearIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className={cn("size-4 shrink-0", className)}
+      fill="currentColor"
+      role="img"
+      aria-label="Linear"
+    >
+      <path d="M1.22541 61.5228c-.2225-.9485.90748-1.5459 1.59638-.857L38.3326 96.1793c.6889.6889.0915 1.8189-.857 1.5964C19.1583 93.4468 4.5532 78.8417 1.22541 61.5228ZM.00189135 46.8891c-.01764375.2833.08887215.5599.28957165.7606L52.3503 99.7085c.2007.2007.4773.3075.7606.2896 2.3692-.1476 4.6938-.46 6.9624-.9259.7645-.157 1.0301-1.0963.4782-1.6481L2.57595 39.4485c-.55186-.5519-1.49117-.2863-1.648174.4782-.465915 2.2686-.77832 4.5932-.92588465 6.9624ZM4.21093 29.7054c-.16649.3738-.08169.8106.20765 1.1l64.77602 64.776c.2894.2894.7262.3742 1.1.2077 1.7861-.7956 3.5171-1.6927 5.1855-2.684.5521-.328.6373-1.0867.1832-1.5407L8.43566 24.3367c-.45409-.4541-1.21271-.3689-1.54074.1832-.99132 1.6684-1.88843 3.3994-2.68399 5.1855ZM12.6587 18.074c-.3701-.3701-.393-.9637-.0443-1.3541C21.7795 6.45931 35.1114 0 49.9997 0 77.6142 0 100 22.3858 100 50c0 14.8883-6.4593 28.2202-16.7199 37.3856-.3903.3487-.984.3258-1.354-.0443L12.6587 18.074Z" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -115,13 +115,16 @@ export function PanelToggle({
 
 /// Which body the right panel is showing. This is the set, not the order —
 /// see `tabOrder`.
-export const PANEL_TABS = ["changes", "subagents", "pr"] as const;
+export const PANEL_TABS = ["changes", "subagents", "pr", "issue"] as const;
 
 export type PanelTab = (typeof PANEL_TABS)[number];
 
 const LABELS: Record<PanelTab, string> = {
   changes: "Changes",
   subagents: "Subagents",
+  // Singular, and not "Linear": the panel is about the work's issue whoever
+  // tracks it, and a session usually carries one.
+  issue: "Issue",
   // Not "Pull Request": the short form is what anyone working on one calls it,
   // and the long one is the widest label in a row of three.
   pr: "PR",
@@ -143,9 +146,14 @@ const LABELS: Record<PanelTab, string> = {
 /// The PR tab is absent entirely for a session that has no PR to show — see
 /// `prTabVisible`. A tab whose only content is "there is nothing here" is one
 /// the eye has to skip past on every session that will never have one.
-export function tabOrder({ pr }: { pr: boolean }): readonly PanelTab[] {
-  if (!pr) return ["changes", "subagents"];
-  return ["pr", "changes", "subagents"] as const;
+export function tabOrder({ pr, issue }: { pr: boolean; issue: boolean }): readonly PanelTab[] {
+  const tabs: PanelTab[] = pr ? ["pr", "changes"] : ["changes"];
+  // Immediately before Subagents wherever it is drawn, so the row's order is
+  // the same one ⌘⇧[ steps whether or not a session has an issue on it.
+  if (issue) tabs.push("issue");
+  tabs.push("subagents");
+
+  return tabs;
 }
 
 type RightPanelProps = {
@@ -160,11 +168,27 @@ type RightPanelProps = {
   counts?: Partial<Record<PanelTab, number>>;
   /// There is a pull request tab to draw at all — see `prTabVisible`.
   pr?: boolean;
+  /// This session is tagged with at least one issue. Absent otherwise, for the
+  /// PR tab's reason: a tab whose only content is "there is nothing here" is one
+  /// the eye skips past on every session that will never have one.
+  issue?: boolean;
   /// Re-reads whatever the active tab is showing, drawn at the far end of the
   /// tab row. One button rather than one per panel: it means the same thing
   /// everywhere, so it belongs to the frame and always sits in the same place.
   /// Absent for a tab with nothing to re-read.
   refresh?: { onRefresh: () => void; loading: boolean } | null;
+  /// A word in the top strip in place of the tab row.
+  ///
+  /// For a pane with one thing in it and no second thing to switch to. A row of
+  /// one tab is a control that cannot do anything, and the keycaps beside it
+  /// name a chord that would step between one place and itself — but an empty
+  /// strip is worse than either, since it reads as chrome that failed to load.
+  /// So the row keeps its height, loses its controls, and says what the pane is.
+  ///
+  /// It also loses its bottom rule. That line separates a row of *controls* from
+  /// what they act on; over a heading belonging to the thing underneath it, it
+  /// cuts a title off its own body.
+  heading?: string;
   children: React.ReactNode;
 };
 
@@ -198,7 +222,9 @@ export default function RightPanel({
   onTabChange,
   counts,
   pr = false,
+  issue = false,
   refresh,
+  heading,
   children,
 }: RightPanelProps) {
   return (
@@ -211,41 +237,54 @@ export default function RightPanel({
       )}
     >
       <div
-        className="flex h-(--titlebar-h) shrink-0 items-center gap-0.5 border-b border-border px-2"
+        className={cn(
+          "flex h-(--titlebar-h) shrink-0 items-center gap-0.5 px-2",
+          !heading && "border-b border-border",
+        )}
         data-tauri-drag-region="deep"
       >
-        {tabOrder({ pr }).map((value) => (
-          <button
-            key={value}
-            type="button"
-            onClick={() => onTabChange(value)}
-            className={cn(
-              "rounded-md px-2 py-1 text-ui transition-colors",
-              tab === value
-                ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            {LABELS[value]}
-            {!!counts?.[value] && (
-              <span className="ml-1 text-muted-foreground">{counts[value]}</span>
-            )}
-          </button>
-        ))}
+        {heading ? (
+          // Padded to sit where a tab's label would, so the pane's first line
+          // lands on the same baseline whichever frame it is wearing.
+          <span className="px-2 py-1 text-ui font-medium">{heading}</span>
+        ) : (
+          <>
+            {tabOrder({ pr, issue }).map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => onTabChange(value)}
+                className={cn(
+                  "rounded-md px-2 py-1 text-ui transition-colors",
+                  tab === value
+                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {LABELS[value]}
+                {!!counts?.[value] && (
+                  <span className="ml-1 text-muted-foreground">{counts[value]}</span>
+                )}
+              </button>
+            ))}
 
-        {/* Beside the tabs rather than at the far end, and with no label: next
-            to the thing it acts on, the caps read as belonging to the row
-            without a word saying so. Drawn at all — rather than hidden in a
-            tooltip the way the rest of the app's shortcuts are — because a
-            chord for a row of two or three tabs is one nobody goes looking for.
+            {/* Beside the tabs rather than at the far end, and with no label:
+                next to the thing it acts on, the caps read as belonging to the
+                row without a word saying so. Drawn at all — rather than hidden
+                in a tooltip the way the rest of the app's shortcuts are —
+                because a chord for a row of two or three tabs is one nobody
+                goes looking for.
 
-            Three caps, not four: `[ ]` is one key with two ends rather than two
-            alternatives, so splitting it reads as a chord wanting both. */}
-        <KbdGroup className="ml-1.5 shrink-0 opacity-50">
-          <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
-          <Kbd>⇧</Kbd>
-          <Kbd>[ ]</Kbd>
-        </KbdGroup>
+                Three caps, not four: `[ ]` is one key with two ends rather than
+                two alternatives, so splitting it reads as a chord wanting
+                both. */}
+            <KbdGroup className="ml-1.5 shrink-0 opacity-50">
+              <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+              <Kbd>⇧</Kbd>
+              <Kbd>[ ]</Kbd>
+            </KbdGroup>
+          </>
+        )}
 
         {/* Gone entirely on Subagents, which has nothing to re-read. It reserved
             its width back when the keycaps sat to its right and would have slid

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useId, type ReactNode } from "react";
+import { useId, useState, type ReactNode } from "react";
 
 import {
   Dialog,
@@ -6,8 +6,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import LinearIcon from "@/components/LinearIcon";
+import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { useAppSettings } from "@/hooks/useAppSettings";
+import type { useIntegrations } from "@/hooks/useIntegrations";
 import type { SettingsView } from "@/types/events";
 
 /// The app's preferences, such as they are.
@@ -19,9 +22,12 @@ import type { SettingsView } from "@/types/events";
 export default function SettingsDialog({
   open,
   onOpenChange,
+  integrations,
 }: {
   open: boolean;
   onOpenChange: (next: boolean) => void;
+  /// Owned by `App`, because the issues page and the composer read it too.
+  integrations: ReturnType<typeof useIntegrations>;
 }) {
   const { settings, setAnalyticsEnabled } = useAppSettings(open);
 
@@ -35,6 +41,8 @@ export default function SettingsDialog({
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
         </DialogHeader>
+
+        <IssueTrackerRow {...integrations} />
 
         <AnalyticsRow view={settings} onChange={setAnalyticsEnabled} />
       </DialogContent>
@@ -83,6 +91,80 @@ function AnalyticsRow({
   );
 }
 
+/// The connected issue tracker — and **only** when there is one.
+///
+/// Connecting happens on the issues page, not here. That page is the surface
+/// with nothing to show without a key, so it is where the field that fixes it
+/// belongs; a second copy in this dialog would be a second form for one slot,
+/// and a settings row offering to connect something the reader has never seen
+/// is a row they cannot judge. What is left here is what settings are actually
+/// for: seeing what is connected, and taking it back.
+function IssueTrackerRow({
+  integrations,
+  busy,
+  error,
+  disconnect,
+}: ReturnType<typeof useIntegrations>) {
+  const id = useId();
+  /// The button arms a confirm that replaces it — the same shape the sidebar's
+  /// delete and the PR panel's merge use. Asked for because the key is not
+  /// recoverable from here: taking it back means finding the tracker's own
+  /// settings page and minting a new one, which is a long way to be sent by a
+  /// button pressed on the way to somewhere else.
+  const [confirming, setConfirming] = useState(false);
+
+  const account = integrations?.linear ?? null;
+
+  // Nothing connected is nothing to say. The reader is not missing a control:
+  // the Issues page in the sidebar is where this starts.
+  if (!account) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <SettingRow
+        id={id}
+        label="Issue tracker"
+        description={
+          confirming
+            ? "Dray will forget the key. Sessions keep the issues they are tagged with."
+            : // The mark rather than the word, since the word is already the row's
+              // subject — and it is what makes this row findable at a glance in a
+              // dialog of sentences.
+              <span className="flex items-center gap-1.5">
+                <LinearIcon className="size-3.5" />
+                {account.orgName}, as {account.userName}
+              </span>
+        }
+      >
+        {confirming ? (
+          <div className="flex items-center gap-1.5">
+            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={busy}
+              onClick={async () => {
+                await disconnect();
+                setConfirming(false);
+              }}
+            >
+              Disconnect
+            </Button>
+          </div>
+        ) : (
+          <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
+            Disconnect
+          </Button>
+        )}
+      </SettingRow>
+
+      {error && <p className="text-ui text-destructive">{error}</p>}
+    </div>
+  );
+}
+
 /// Label and reason on the left, control on the right — the shape every
 /// settings row here should take, so the second one costs no layout decisions.
 function SettingRow({
@@ -93,20 +175,27 @@ function SettingRow({
 }: {
   id: string;
   label: string;
-  description: string;
+  /// A node, not a string: a row whose reason is best said with a mark beside
+  /// it should not have to reach past this for the privilege.
+  description: ReactNode;
   children: ReactNode;
 }) {
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div className="flex flex-col gap-1">
+    // The label and the control share the top line; the description gets the
+    // width of the row to itself underneath. Side by side was the first shape
+    // and it broke on the widest control here: two buttons pushed the sentence
+    // into a third of the dialog, where four words took three lines and the
+    // row's height jumped every time the control changed. The description is
+    // prose and wants a measure; the control is a fixed thing and wants an
+    // edge to sit against.
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between gap-4">
         <label htmlFor={id} className="text-ui font-medium">
           {label}
         </label>
-        <p className="text-ui text-muted-foreground">{description}</p>
+        <div className="shrink-0">{children}</div>
       </div>
-      {/* Nudged to sit on the label's own line rather than the row's top edge,
-          which the description below makes taller than the control. */}
-      <div className="mt-0.5">{children}</div>
+      <p className="text-ui text-muted-foreground">{description}</p>
     </div>
   );
 }

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -83,7 +83,7 @@ type SidebarProps = {
   collapsed: boolean;
   onToggleCollapsed: () => void;
   onOpenSettings: () => void;
-  onSelect: (sessionId: string) => Promise<void>;
+  onSelect: (sessionId: string) => void;
   onNewSession: () => void;
   /// Opens the issues page in the main column. It is not a session, so it does
   /// not move the selection — coming back from it lands on the session that was
@@ -1328,7 +1328,7 @@ function SessionRow({
   /// Something is still refreshing this row's mark. False in the archived view,
   /// which asks for no repos — see the call site.
   marksLive?: boolean;
-  onSelect: (sessionId: string) => Promise<void>;
+  onSelect: (sessionId: string) => void;
   /// This row has a parent in the same list, so 'Detach from parent' is a real
   /// offer. Kept apart from `depth` only because a cyclic index draws a row at
   /// the top level that still has a link worth cutting.

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   CheckCheck,
   ChevronDown,
   CircleDashed,
+  CircleDot,
   GitBranchPlus,
   Unlink,
   Inbox,
@@ -84,6 +85,14 @@ type SidebarProps = {
   onOpenSettings: () => void;
   onSelect: (sessionId: string) => Promise<void>;
   onNewSession: () => void;
+  /// Opens the issues page in the main column. It is not a session, so it does
+  /// not move the selection — coming back from it lands on the session that was
+  /// open before.
+  onOpenIssues: () => void;
+  /// The issues page is the thing on screen, so the row draws as the current
+  /// one. Read here rather than derived from the selection, which the page
+  /// deliberately leaves alone.
+  issuesOpen: boolean;
   onSetFlags: (
     sessionId: string,
     flags: { archived?: boolean; pinned?: boolean },
@@ -491,6 +500,8 @@ export default function Sidebar({
   onToggleCollapsed,
   onSelect,
   onNewSession,
+  onOpenIssues,
+  issuesOpen,
   onSetFlags,
   onFork,
   onDelete,
@@ -603,11 +614,27 @@ export default function Sidebar({
           </KbdGroup>
         </Button>
 
+        {/* Under New Task, because it is the other way a task starts — an
+            issue is a task somebody already wrote down. Drawn whether or not a
+            tracker is connected: the page's own empty state is where connecting
+            is offered, and a row that only appears once you have found the
+            settings dialog can only be found by people who did not need it. */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onOpenIssues}
+          data-active={issuesOpen || undefined}
+          className="w-full justify-start px-1.5 text-ui data-[active]:bg-sidebar-accent data-[active]:text-sidebar-accent-foreground"
+        >
+          <CircleDot />
+          Issues
+        </Button>
+
         {/* The button *becomes* the field, on the same row at the same height:
             the icon holds its place, the caret lands where the label was, and
             nothing below it moves. Bare on purpose — a fill, a border or a
             focus ring here would draw a second kind of control into a strip
-            that is otherwise two buttons. The transparent border is what holds
+            that is otherwise plain buttons. The transparent border is what holds
             that promise to the pixel: every button carries one, so the icon
             would sit a pixel further out without it. */}
         {searching ? (

--- a/apps/desktop/src/components/chat/EventRow.tsx
+++ b/apps/desktop/src/components/chat/EventRow.tsx
@@ -71,6 +71,7 @@ export default function EventRow({
         <UserMessage
           text={payload.text}
           images={payload.images}
+          issues={payload.issues}
           from={payload.from}
           onOpenSession={onOpenSession}
         />

--- a/apps/desktop/src/components/chat/Markdown.tsx
+++ b/apps/desktop/src/components/chat/Markdown.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from "react";
-import { Streamdown, type LinkSafetyConfig, type ThemeInput } from "streamdown";
+import { Streamdown, type Components, type LinkSafetyConfig, type ThemeInput } from "streamdown";
 
 import LinkDialog from "@/components/chat/LinkDialog";
 import { useCodeTheme } from "@/hooks/useCodeTheme";
@@ -13,6 +13,10 @@ type MarkdownProps = {
   /// True while deltas are still arriving, so incomplete blocks render as
   /// prose instead of flickering through half-parsed markdown.
   streaming?: boolean;
+  /// Element overrides, for a caller whose markdown holds something this
+  /// renderer cannot resolve on its own — an issue description, whose images
+  /// and files sit behind the tracker's auth and have to be fetched with a key.
+  components?: Components;
   className?: string;
 };
 
@@ -46,7 +50,7 @@ const LINK_SAFETY: LinkSafetyConfig = {
 
 /// Streamdown is built on the same shadcn tokens as the rest of the app, so it
 /// inherits the palette; only typography scale is ours to set.
-function MarkdownImpl({ children, streaming = false, className }: MarkdownProps) {
+function MarkdownImpl({ children, streaming = false, components, className }: MarkdownProps) {
   // Shiki takes a [light, dark] pair and picks by the `.dark` class our theme
   // already sets, so this needs no mode of its own — only the user's pick.
   const { pair } = useCodeTheme();
@@ -61,6 +65,7 @@ function MarkdownImpl({ children, streaming = false, className }: MarkdownProps)
       mode={streaming ? "streaming" : "static"}
       isAnimating={streaming}
       plugins={plugins}
+      components={components}
       controls={CONTROLS}
       rehypePlugins={REHYPE_PLUGINS}
       linkSafety={LINK_SAFETY}

--- a/apps/desktop/src/components/chat/TurnBlock.tsx
+++ b/apps/desktop/src/components/chat/TurnBlock.tsx
@@ -193,6 +193,11 @@ function renderItem(
 function userProps(turn: Turn) {
   const payload = turn.prompt?.payload;
   return payload?.type === "user_message"
-    ? { text: payload.text, images: payload.images, from: payload.from }
+    ? {
+        text: payload.text,
+        images: payload.images,
+        issues: payload.issues,
+        from: payload.from,
+      }
     : { text: "" };
 }

--- a/apps/desktop/src/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/components/chat/UserMessage.tsx
@@ -1,11 +1,14 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { Image } from "lucide-react";
 
 import SessionAvatar from "@/components/SessionAvatar";
 import ImageRow from "@/components/chat/ImageRow";
 import { SEGMENT_COLOR, highlightSegments, splitMention } from "@/lib/highlight";
+import { issueUrl, parseIdentifier } from "@/lib/issue";
 import { stripSenderPrefix } from "@/lib/relay";
 import { shortenPath } from "@/lib/tools";
-import type { ImageRef, MessageSender } from "@/types/events";
+import { cn } from "@/lib/utils";
+import type { ImageRef, IssueRef, MessageSender } from "@/types/events";
 
 /// The user's own text, echoed from the event log rather than local state — the
 /// backend synthesizes and persists it, so this renders the same live or replayed.
@@ -29,14 +32,25 @@ import type { ImageRef, MessageSender } from "@/types/events";
 /// The line the backend writes into the prompt for the receiving agent is taken
 /// back off here, since the row above already says who is talking — safe to
 /// mute precisely because the field, not the prose, is what draws it.
+///
+/// An issue tag is the one coloured run that is also a *link*: it opens the
+/// issue in the tracker, where the reader can act on it rather than only read
+/// it. The URL comes off the event's own `issues` and never out of the text, so
+/// a tag naming an issue that never resolved stays coloured and inert instead
+/// of becoming a link to nowhere.
 export default function UserMessage({
   text,
   images = [],
+  issues = [],
   from = null,
   onOpenSession,
 }: {
   text: string;
   images?: ImageRef[];
+  /// What this prompt was tagged with. Not drawn — the tags are already in the
+  /// sentence — but it is where a tag's link comes from, since a URL recovered
+  /// from prose would be a guess.
+  issues?: IssueRef[];
   /// The session that relayed this, or `null` for a prompt the user typed.
   from?: MessageSender | null;
   /// Opens the sending session. Absent where nothing can navigate, which draws
@@ -99,6 +113,37 @@ export default function UserMessage({
                   <span key={i} className={SEGMENT_COLOR.mention} title={segment.text.slice(1)}>
                     @{name}
                   </span>
+                );
+              }
+
+              if (segment.kind === "issue") {
+                const identifier = parseIdentifier(segment.text.slice(1));
+                const url = identifier ? issueUrl(issues, identifier) : null;
+
+                // Inert without a link, which is the resting state of a tag
+                // whose issue never resolved — a button that opens nothing is
+                // worse than a word that was never one.
+                if (!url) {
+                  return (
+                    <span key={i} className={SEGMENT_COLOR.issue}>
+                      {segment.text}
+                    </span>
+                  );
+                }
+
+                return (
+                  <button
+                    key={i}
+                    type="button"
+                    title={`Open ${identifier} in ${new URL(url).hostname}`}
+                    // Underlined on hover rather than at rest: the colour
+                    // already sets it apart from the sentence, and a permanent
+                    // underline through a prompt reads as a correction.
+                    className={cn(SEGMENT_COLOR.issue, "cursor-pointer hover:underline")}
+                    onClick={() => void openUrl(url)}
+                  >
+                    {segment.text}
+                  </button>
                 );
               }
 

--- a/apps/desktop/src/components/composer/IssueMentionMenu.tsx
+++ b/apps/desktop/src/components/composer/IssueMentionMenu.tsx
@@ -1,0 +1,57 @@
+import IssueStateIcon, { IssuePriorityIcon } from "@/components/IssueStateIcon";
+import PickerMenu from "@/components/composer/PickerMenu";
+import type { Issue } from "@/types/events";
+
+/// The `#` picker's rows.
+///
+/// A flat list always, like the file picker and unlike the command one: the
+/// ranking *is* the answer here — assigned to you, unfinished, most urgent
+/// first — so a bare `#` already opens on the useful list and there is nothing
+/// a heading would separate.
+///
+/// The identifier leads because it is what gets typed and what lands in the
+/// text; the title follows because it is what the row is recognised by. Reverse
+/// them and every row starts with a different-length word, which is what makes
+/// a list unscannable.
+export default function IssueMentionMenu({
+  issues,
+  activeIndex,
+  onPick,
+  onHover,
+  placement = "above",
+  bare = false,
+}: {
+  issues: Issue[];
+  activeIndex: number;
+  onPick: (issue: Issue) => void;
+  onHover: (index: number) => void;
+  placement?: "above" | "below";
+  bare?: boolean;
+}) {
+  return (
+    <PickerMenu
+      groups={[{ label: null, items: issues }]}
+      label="Issues"
+      keyOf={(issue) => issue.id}
+      activeIndex={activeIndex}
+      onPick={onPick}
+      onHover={onHover}
+      placement={placement}
+      bare={bare}
+      renderItem={(issue) => (
+        <>
+          <IssueStateIcon kind={issue.state.kind} color={issue.state.color} label={issue.state.name} />
+
+          <span className="shrink-0 font-medium tabular-nums">{issue.identifier}</span>
+
+          <span className="min-w-0 truncate text-muted-foreground">{issue.title}</span>
+
+          {/* Trailing, so it can't push the title off its own left edge — and
+              absent on most rows, which is what makes it worth reading on the
+              few that carry it. */}
+          <IssuePriorityIcon priority={issue.priority} className="ml-auto" />
+        </>
+      )}
+    />
+  );
+}

--- a/apps/desktop/src/components/layout/SessionHeader.tsx
+++ b/apps/desktop/src/components/layout/SessionHeader.tsx
@@ -5,6 +5,11 @@ import type { SessionSnapshot } from "@/types/events";
 
 type SessionHeaderProps = {
   session: SessionSnapshot | null;
+  /// What the main column is showing, when it is not a session. The issues page
+  /// fills that column but is not a session and never becomes one, so the
+  /// header would otherwise sit at "New session" while a list of issues is on
+  /// screen — naming a thing the reader is not looking at.
+  standIn?: string | null;
   /// What `sessionBranch` made of this session, handed in rather than worked
   /// out again here: `App` has git's own reading of HEAD to give it, and a
   /// header naming one branch while the PR tab looks up another is the whole
@@ -20,11 +25,16 @@ type SessionHeaderProps = {
 /// No tooltip on it. It fired on every hover of a title that was not clipped,
 /// which is most of them, and repeated back text already on screen — the one
 /// thing the app's tooltip rule says a tooltip must not do.
-export default function SessionHeader({ session, branch, className }: SessionHeaderProps) {
-  if (!session) {
+export default function SessionHeader({
+  session,
+  branch,
+  standIn,
+  className,
+}: SessionHeaderProps) {
+  if (standIn || !session) {
     return (
       <div className={cn("min-w-0", className)}>
-        <span className="text-ui text-muted-foreground">New session</span>
+        <span className="text-ui text-muted-foreground">{standIn ?? "New session"}</span>
       </div>
     );
   }

--- a/apps/desktop/src/hooks/useIntegrations.ts
+++ b/apps/desktop/src/hooks/useIntegrations.ts
@@ -1,0 +1,72 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useState } from "react";
+
+import { forgetIssues } from "@/hooks/useIssues";
+import type { IntegrationsView } from "@/types/events";
+
+/// The connected issue tracker, and the two writes that change it.
+///
+/// Lives in `App` rather than in the dialog that used to own it: three surfaces
+/// read it now — the settings row, the issues page's own connect form, and the
+/// composer's placeholder — and a second copy per surface is a second answer to
+/// "are we connected" free to disagree with the first.
+export function useIntegrations(enabled: boolean) {
+  const [integrations, setIntegrations] = useState<IntegrationsView | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let live = true;
+    invoke<IntegrationsView>("get_integrations")
+      .then((next) => live && setIntegrations(next))
+      .catch((e) => console.error("[integrations]", e));
+
+    return () => {
+      live = false;
+    };
+  }, [enabled]);
+
+  /// Saves a key, or reports why it was refused.
+  ///
+  /// The error is *returned into state* rather than thrown: the row draws it
+  /// under the field, where a pasted key that was truncated or revoked is one
+  /// sentence away from being fixed. Answers whether it worked, so the caller
+  /// can clear the field only on success.
+  const connect = useCallback(async (key: string): Promise<boolean> => {
+    setBusy(true);
+    setError(null);
+    try {
+      setIntegrations(await invoke<IntegrationsView>("connect_linear", { key }));
+      // Every cached answer was taken with no key, including the
+      // `not_connected` failure the page's empty state was drawn from — so
+      // without this, connecting leaves the reader looking at the form they
+      // just filled in.
+      forgetIssues();
+      return true;
+    } catch (e) {
+      setError(String(e));
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      setIntegrations(await invoke<IntegrationsView>("disconnect_linear"));
+      // The other direction, and the same reason: a list read with the old key
+      // must not outlive it.
+      forgetIssues();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  return { integrations, busy, error, connect, disconnect };
+}

--- a/apps/desktop/src/hooks/useIssueSearch.ts
+++ b/apps/desktop/src/hooks/useIssueSearch.ts
@@ -1,0 +1,83 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useRef, useState } from "react";
+
+import type { Issue, IssueQuery } from "@/types/events";
+
+/// How deep the picker's list goes. The backend ranks by priority, so this is
+/// the depth somebody might scroll before typing another character rather than
+/// an attempt to show everything that matched.
+const LIMIT = 25;
+
+/// Longer than the file picker's 60ms, and for a different reason: that one is
+/// spacing out an IPC hop over an in-memory index, and this is a round trip to
+/// Linear. Every keystroke that reaches the network is one the reader waits on.
+const DEBOUNCE_MS = 200;
+
+/// Issues matching `query`, best first, or an empty list while the picker is
+/// closed.
+///
+/// `query` is `null` when the caret isn't in a tag, which is what closes the
+/// picker — passed rather than the hook being called conditionally, since hooks
+/// cannot be.
+///
+/// Shaped like [useFileSearch](./useFileSearch.ts) deliberately: the composer
+/// reads both the same way, and a second shape would be a second set of
+/// race-and-debounce rules to get right.
+export function useIssueSearch(query: string | null): Issue[] {
+  const [issues, setIssues] = useState<Issue[]>([]);
+  /// Whether anything is on screen to protect. A first read has nothing to wait
+  /// for, so it skips the debounce and the picker never opens blank.
+  const showing = useRef(false);
+
+  useEffect(() => {
+    if (query === null) {
+      setIssues([]);
+      showing.current = false;
+      return;
+    }
+
+    // Guards out-of-order replies as well as unmounting: two reads in flight
+    // can land either way round, and the older one landing last would leave the
+    // list describing a query already typed past.
+    let cancelled = false;
+
+    const run = () => {
+      const filters: IssueQuery = {
+        text: query || null,
+        // The picker is "what am I working on", which is the assigned and
+        // unfinished list. Widening lives on the issues page, where there is
+        // room for a filter row to say what it is doing.
+        scope: "assigned",
+        teamId: null,
+        projectId: null,
+        settled: false,
+      };
+
+      invoke<Issue[]>("list_issues", { query: filters, limit: LIMIT })
+        .then((matches) => {
+          if (cancelled) return;
+          setIssues(matches);
+          showing.current = true;
+        })
+        // The list is left as it was rather than cleared: a failed refresh must
+        // not empty a list somebody is reading, and there is nothing to say
+        // here anyway — a picker is not where "Linear is down" belongs.
+        .catch((e) => console.error("[issue search]", e));
+    };
+
+    if (!showing.current) {
+      run();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const timer = setTimeout(run, DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query]);
+
+  return issues;
+}

--- a/apps/desktop/src/hooks/useIssues.ts
+++ b/apps/desktop/src/hooks/useIssues.ts
@@ -1,0 +1,401 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type {
+  Issue,
+  IssueDetail,
+  IssueFilters,
+  IssueQuery,
+  IssueRef,
+  IssueUnavailable,
+} from "@/types/events";
+
+/// How many rows the page asks for. Well past a screenful, and short of a
+/// workspace: the useful list is what the reader is assigned and has not
+/// finished, which is rarely near this.
+const PAGE_LIMIT = 100;
+
+/// Typing in the page's search box reaches the network, so it is spaced out.
+/// Longer than the composer picker's 200ms: that one filters a menu somebody is
+/// mid-word in and wants to feel immediate, where this is a search box where a
+/// whole phrase gets typed before the answer is wanted.
+const DEBOUNCE_MS = 300;
+
+/// How long an answer counts as fresh. Leaving the page and coming back inside
+/// this window paints from the cache without a round trip, which is the trip
+/// this page exists to make — pick an issue, go work, come back.
+const FRESH_MS = 60_000;
+
+/// Answers per query, kept across mounts.
+///
+/// Keyed by the query itself, so flipping a chip and flipping back is free and
+/// nothing has to be invalidated: a different question is a different key. The
+/// list is capped rather than expired, because the stamp beside it is what
+/// decides staleness and this only bounds memory.
+const cache = new Map<string, Issue[]>();
+const fetchedAt = new Map<string, number>();
+
+/// Small: a reader works through two or three filter combinations, not twenty.
+const MAX_CACHED = 12;
+
+const keyOf = (query: IssueQuery) =>
+  JSON.stringify([
+    query.text ?? "",
+    query.scope,
+    query.teamId ?? "",
+    query.projectId ?? "",
+    query.settled,
+  ]);
+
+function remember(key: string, issues: Issue[]) {
+  cache.set(key, issues);
+  fetchedAt.set(key, Date.now());
+
+  // Oldest key first — `Map` keeps insertion order, and a re-read overwrites in
+  // place rather than moving, so this evicts by age of first sighting. Good
+  // enough for a cap whose only job is to stop unbounded growth.
+  while (cache.size > MAX_CACHED) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+    fetchedAt.delete(oldest);
+  }
+}
+
+/// Opened issues, keyed by identifier.
+///
+/// Its own cache rather than a second use of the list's: the two hold different
+/// shapes for the same issue — a row against a whole body — and they are read on
+/// different rhythms. This one is what stops the panel re-downloading a
+/// description every time a tab is switched, a session is reselected, or a row
+/// is picked on the issues page and picked again.
+const detailCache = new Map<string, IssueDetail>();
+const detailFetchedAt = new Map<string, number>();
+
+/// Larger than the list's cap: these are keyed one issue at a time rather than
+/// one whole query at a time, so a reader working through a handful of issues
+/// fills it much faster.
+const MAX_DETAILS = 24;
+
+function rememberDetail(identifier: string, detail: IssueDetail) {
+  detailCache.set(identifier, detail);
+  detailFetchedAt.set(identifier, Date.now());
+
+  while (detailCache.size > MAX_DETAILS) {
+    const oldest = detailCache.keys().next().value;
+    if (oldest === undefined) break;
+    detailCache.delete(oldest);
+    detailFetchedAt.delete(oldest);
+  }
+}
+
+type Read = { key: string; details: Record<string, IssueDetail> };
+
+function split(key: string): string[] {
+  return key ? key.split(",") : [];
+}
+
+function cachedDetails(identifiers: string[]): Record<string, IssueDetail> {
+  const found: Record<string, IssueDetail> = {};
+  for (const identifier of identifiers) {
+    const detail = detailCache.get(identifier);
+    if (detail) found[identifier] = detail;
+  }
+  return found;
+}
+
+/// Drops every cached answer, lists and bodies alike.
+///
+/// Called when the connection changes: a key that was just connected, or
+/// disconnected, makes every previous answer meaningless — including the
+/// `not_connected` failure that the page's empty state was drawn from.
+export function forgetIssues() {
+  cache.clear();
+  fetchedAt.clear();
+  detailCache.clear();
+  detailFetchedAt.clear();
+}
+
+/// What `invoke` rejected with, as the backend meant it.
+///
+/// Tauri hands the serialized `Err` back, so this is already the right shape —
+/// except when the bridge itself failed, which arrives as a string with no kind
+/// of its own. Same reading [usePullRequest](./usePullRequest.ts) takes.
+export function asUnavailable(e: unknown): IssueUnavailable {
+  if (e && typeof e === "object" && "kind" in e) return e as IssueUnavailable;
+  return { kind: "other", detail: String(e) };
+}
+
+const DEFAULT_QUERY: IssueQuery = {
+  text: null,
+  // The default is the useful one: what this person is meant to be working on.
+  scope: "assigned",
+  teamId: null,
+  projectId: null,
+  settled: false,
+};
+
+/// One list read, cached and debounced. The page runs two of these.
+///
+/// `enabled` is what makes the settled half free: a read that is never asked
+/// for costs nothing, so the done and cancelled groups can be drawn collapsed
+/// with no round trip behind them until somebody opens one.
+function useIssueList(query: IssueQuery, enabled: boolean, generation: number) {
+  const key = keyOf(query);
+
+  const [issues, setIssues] = useState<Issue[]>(() => cache.get(key) ?? []);
+  const [loading, setLoading] = useState(false);
+  const [unavailable, setUnavailable] = useState<IssueUnavailable | null>(null);
+  /// Whether this list has ever answered. Distinct from `issues.length`, which
+  /// cannot tell "nothing here" from "not asked yet" — and the two draw
+  /// differently on a group header that has no count to show until it has.
+  const [answered, setAnswered] = useState(() => cache.has(key));
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const cached = cache.get(key);
+    const fresh = Date.now() - (fetchedAt.get(key) ?? 0) < FRESH_MS;
+
+    // Painted first whatever happens: a cached answer is what the reader was
+    // looking at, and blanking it to re-fetch the same rows is the flicker this
+    // cache exists to remove.
+    if (cached) {
+      setIssues(cached);
+      setUnavailable(null);
+      setAnswered(true);
+    }
+    if (cached && fresh) {
+      // Cleared here as well as in `finally`, and this is the *only* path that
+      // clears it without a request having finished. A cancelled read never
+      // reaches its own `finally`, so backspacing to a query that is already
+      // cached — cancelling the in-flight read for the longer one and then
+      // short-circuiting — used to leave the spinner turning with nothing
+      // behind it, until some later read happened to end.
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    const run = () => {
+      invoke<Issue[]>("list_issues", { query, limit: PAGE_LIMIT })
+        .then((next) => {
+          if (cancelled) return;
+          remember(key, next);
+          setIssues(next);
+          setUnavailable(null);
+        })
+        .catch((e) => {
+          if (cancelled) return;
+          // The list is *not* cleared: a failed refresh should leave what the
+          // reader was reading, and a failed first read has nothing to clear.
+          // The banner is what says the answer is stale.
+          setUnavailable(asUnavailable(e));
+        })
+        .finally(() => {
+          if (cancelled) return;
+          setLoading(false);
+          setAnswered(true);
+        });
+    };
+
+    // Typing is debounced; a chip or a refresh is not. A click is a single act
+    // and waiting 200ms to honour one reads as lag, where every keystroke is
+    // one more of a run and the reader has not finished the word yet.
+    //
+    // Gated on there being text at all, and deliberately *not* on there being
+    // something cached to protect. That was the first version and it debounced
+    // nothing that mattered: each keystroke makes a key nothing is cached
+    // under, so every one of them took the un-debounced path and fired its own
+    // request — which is exactly the run this exists to collapse.
+    const timer = setTimeout(run, query.text ? DEBOUNCE_MS : 0);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [enabled, key, query, generation]);
+
+  return { issues, loading, unavailable, loaded: answered };
+}
+
+/// The issues page's lists, its filter row's options, and the state of the read.
+///
+/// Filters live here rather than in the view so the read and the controls that
+/// change it cannot disagree about what is on screen — the page draws what this
+/// answers and owns none of it.
+export function useIssues(active: boolean) {
+  const [query, setQuery] = useState<IssueQuery>(DEFAULT_QUERY);
+  const [filters, setFilters] = useState<IssueFilters | null>(null);
+  /// Bumped to force a read the query alone would not trigger — the refresh
+  /// button, and a connection that just changed under the page. It is what
+  /// re-arms the effect; `forgetIssues()` beside it is what makes the read
+  /// happen, since the effect's own rule is "fetch what is not fresh". The
+  /// counter must not also be read as "never use the cache again" — it only
+  /// ever goes up, so gating the cache on it left every later chip flip and
+  /// every later visit refetching for the life of the page.
+  const [generation, setGeneration] = useState(0);
+
+  /// Whether anybody has opened a settled group yet. Sticky for the life of the
+  /// page rather than per group: once the reader has asked to see finished work
+  /// they are unlikely to want it taken away, and both groups come back in one
+  /// read anyway.
+  const [wantSettled, setWantSettled] = useState(false);
+
+  const openQuery = useMemo(() => ({ ...query, settled: false }), [query]);
+  const settledQuery = useMemo(() => ({ ...query, settled: true }), [query]);
+
+  const open = useIssueList(openQuery, active, generation);
+  const settled = useIssueList(settledQuery, active && wantSettled, generation);
+
+  // Read once per visit rather than with every list: teams and projects change
+  // on the timescale of somebody reorganising a workspace, and this is a second
+  // round trip behind the rows the reader is waiting for.
+  useEffect(() => {
+    if (!active || filters) return;
+
+    let live = true;
+    invoke<IssueFilters>("list_issue_filters")
+      .then((next) => live && setFilters(next))
+      // Silent: with no filters the row simply offers less, and the list above
+      // has already said whatever went wrong.
+      .catch(() => {});
+
+    return () => {
+      live = false;
+    };
+  }, [active, filters, generation]);
+
+  return {
+    issues: open.issues,
+    filters,
+    query,
+    setQuery,
+    loading: open.loading || settled.loading,
+    // The open half's failure is the one worth a banner: it is the list the
+    // page is *for*, and a settled group that could not be read says so by
+    // staying empty under a header the reader opened.
+    unavailable: open.unavailable,
+    settled: {
+      issues: settled.issues,
+      loading: settled.loading,
+      loaded: settled.loaded,
+      /// Called the first time a settled group is opened. Idempotent, so a
+      /// second group opening costs nothing.
+      request: useCallback(() => setWantSettled(true), []),
+    },
+    /// Forces a read past the cache, and re-reads the filter options too — a
+    /// connection that just changed has neither.
+    refresh: useCallback(() => {
+      forgetIssues();
+      setFilters(null);
+      setGeneration((n) => n + 1);
+    }, []),
+  };
+}
+
+/// Detail for every issue a session is tagged with, keyed by identifier.
+///
+/// Read from the tracker rather than drawn from the links themselves: a link
+/// carries the identifier and the title, which is all a *prompt* needs, and the
+/// panel wants the description, the status and the comments. The links are what
+/// the tab is drawn from meanwhile, so the panel has rows before this lands and
+/// keeps them if it never does.
+export function useSessionIssues(issues: IssueRef[], active: boolean) {
+  // Joined into a string so the effect's dependency is the *set* of
+  // identifiers, not the array's identity — which is fresh on every render of
+  // a session that is streaming.
+  const key = issues.map((issue) => issue.identifier).join(",");
+
+  // Carries the key it was built for, and anything read under another key is
+  // dropped *during render* rather than in the effect. The effect runs after
+  // paint, so state alone left one frame of the previous issue's description
+  // under the new issue's title — most visible on the issues page, where
+  // picking a row is a key change and nothing else.
+  const [read, setRead] = useState<Read>(() => ({ key, details: cachedDetails(split(key)) }));
+  const current = read.key === key ? read : { key, details: cachedDetails(split(key)) };
+
+  const [loading, setLoading] = useState(false);
+  const [unavailable, setUnavailable] = useState<IssueUnavailable | null>(null);
+  const [generation, setGeneration] = useState(0);
+
+  useEffect(() => {
+    if (!active || !key) return;
+
+    const identifiers = split(key);
+
+    // Whatever is already in hand goes up first, before anything is asked for.
+    // Without this the panel blanked and read the whole description back on
+    // every tab switch, every reselect, and every second visit to a row —
+    // which is what watching it say "reading the issue…" over and over was.
+    const cached = cachedDetails(identifiers);
+    setRead({ key, details: cached });
+    if (Object.keys(cached).length > 0) setUnavailable(null);
+
+    // Only the ones nothing fresh is held for. A session tagged with three
+    // issues, two of them read a moment ago, costs one request rather than
+    // three.
+    const wanted = identifiers.filter(
+      (identifier) => Date.now() - (detailFetchedAt.get(identifier) ?? 0) >= FRESH_MS,
+    );
+
+    if (wanted.length === 0) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    Promise.all(
+      wanted.map((identifier) =>
+        invoke<IssueDetail>("get_issue", { identifier })
+          .then((detail) => {
+            rememberDetail(identifier, detail);
+            return detail;
+          })
+          .catch((e) => {
+            // One issue that cannot be read costs its own body, not the panel:
+            // a session tagged with two issues, one of them since deleted,
+            // still draws the other.
+            if (!cancelled) setUnavailable(asUnavailable(e));
+            return null;
+          }),
+      ),
+    )
+      .then((answers) => {
+        if (cancelled) return;
+        // Rebuilt from the cache rather than merged into what is on screen, so
+        // an identifier that has left the set leaves the record with it.
+        setRead({ key, details: cachedDetails(identifiers) });
+        if (answers.some(Boolean)) setUnavailable(null);
+      })
+      .finally(() => !cancelled && setLoading(false));
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key, active, generation]);
+
+  return {
+    details: current.details,
+    // Left as "a read is out", not masked by what is already cached: every
+    // reader of it is per-issue, and each already draws its own body when it
+    // has one — so a session holding one cached issue and one still arriving
+    // needs this true or the second row reads as unreadable rather than
+    // pending.
+    loading,
+    unavailable,
+    /// Forces a re-read past the cache. Forgetting first rather than passing a
+    /// flag down: the effect's own rule is "fetch what is not fresh", and
+    /// dropping the stamps is what makes that rule answer yes.
+    refresh: useCallback(() => {
+      for (const identifier of split(key)) {
+        detailCache.delete(identifier);
+        detailFetchedAt.delete(identifier);
+      }
+      setGeneration((n) => n + 1);
+    }, [key]),
+  };
+}

--- a/apps/desktop/src/hooks/useIssues.ts
+++ b/apps/desktop/src/hooks/useIssues.ts
@@ -1,5 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+
+import {
+  issueGeneration,
+  newIssueGeneration,
+  subscribeIssueGeneration,
+} from "@/lib/issue";
 
 import type {
   Issue,
@@ -47,7 +53,12 @@ const keyOf = (query: IssueQuery) =>
     query.settled,
   ]);
 
-function remember(key: string, issues: Issue[]) {
+function remember(key: string, issues: Issue[], generation: number) {
+  // A read issued before the connection changed must not put its answer back
+  // after `forgetIssues` took it out — and above all must not re-stamp it fresh,
+  // which would tell every later reader the old key's answer is current.
+  if (generation !== issueGeneration()) return;
+
   cache.set(key, issues);
   fetchedAt.set(key, Date.now());
 
@@ -77,7 +88,9 @@ const detailFetchedAt = new Map<string, number>();
 /// fills it much faster.
 const MAX_DETAILS = 24;
 
-function rememberDetail(identifier: string, detail: IssueDetail) {
+function rememberDetail(identifier: string, detail: IssueDetail, generation: number) {
+  if (generation !== issueGeneration()) return;
+
   detailCache.set(identifier, detail);
   detailFetchedAt.set(identifier, Date.now());
 
@@ -114,6 +127,11 @@ export function forgetIssues() {
   fetchedAt.clear();
   detailCache.clear();
   detailFetchedAt.clear();
+  // Last, and it is what makes the clearing stick: a read already in flight is
+  // holding the generation it started under, so from here its write is refused.
+  // It also wakes every mounted hook, which would otherwise keep drawing a body
+  // read with a key that has since been revoked.
+  newIssueGeneration();
 }
 
 /// What `invoke` rejected with, as the backend meant it.
@@ -179,11 +197,15 @@ function useIssueList(query: IssueQuery, enabled: boolean, generation: number) {
     let cancelled = false;
     setLoading(true);
 
+    // Captured before the request goes out, not read when it lands: that is the
+    // whole of the guard.
+    const reading = issueGeneration();
+
     const run = () => {
       invoke<Issue[]>("list_issues", { query, limit: PAGE_LIMIT })
         .then((next) => {
           if (cancelled) return;
-          remember(key, next);
+          remember(key, next, reading);
           setIssues(next);
           setUnavailable(null);
         })
@@ -308,6 +330,26 @@ export function useSessionIssues(issues: IssueRef[], active: boolean) {
   // a session that is streaming.
   const key = issues.map((issue) => issue.identifier).join(",");
 
+  // The tracker's own id for each link, where it has one. Rebuilt on the same
+  // key rather than held in state: it is a lookup table for the read below, and
+  // nothing on screen is drawn from it.
+  const idFor = useMemo(() => {
+    const byIdentifier = new Map<string, string>();
+    for (const issue of issues) {
+      // A blind link writes the identifier into both fields, and an id that is
+      // not the tracker's own names nothing on its side — passing it would cost
+      // a lookup that can only 404 before the fallback runs.
+      if (issue.id && issue.id !== issue.identifier) byIdentifier.set(issue.identifier, issue.id);
+    }
+    return byIdentifier;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  // Subscribed rather than only read, so a connection changing under a mounted
+  // panel re-runs the read below. Without it the tab kept drawing a body that
+  // was fetched with a key since revoked.
+  const connection = useSyncExternalStore(subscribeIssueGeneration, issueGeneration);
+
   // Carries the key it was built for, and anything read under another key is
   // dropped *during render* rather than in the effect. The effect runs after
   // paint, so state alone left one frame of the previous issue's description
@@ -348,11 +390,17 @@ export function useSessionIssues(issues: IssueRef[], active: boolean) {
     let cancelled = false;
     setLoading(true);
 
+    const reading = issueGeneration();
+
     Promise.all(
       wanted.map((identifier) =>
-        invoke<IssueDetail>("get_issue", { identifier })
+        // The tracker's own id travels with the identifier where the link has
+        // one. It is the stable half: an issue moved to another team renumbers,
+        // and a lookup by the recorded spelling then answers "no such issue" for
+        // work that is very much still there.
+        invoke<IssueDetail>("get_issue", { identifier, id: idFor.get(identifier) ?? null })
           .then((detail) => {
-            rememberDetail(identifier, detail);
+            rememberDetail(identifier, detail, reading);
             return detail;
           })
           .catch((e) => {
@@ -376,7 +424,7 @@ export function useSessionIssues(issues: IssueRef[], active: boolean) {
     return () => {
       cancelled = true;
     };
-  }, [key, active, generation]);
+  }, [key, active, generation, connection, idFor]);
 
   return {
     details: current.details,
@@ -395,6 +443,12 @@ export function useSessionIssues(issues: IssueRef[], active: boolean) {
         detailCache.delete(identifier);
         detailFetchedAt.delete(identifier);
       }
+      // The whole generation, not just these identifiers: an upload that failed
+      // to fetch is cached under its own URL in another module, and Refresh is
+      // the reader asking for exactly that again. It also refuses the write of
+      // any read still in flight, which would otherwise re-stamp what was just
+      // dropped.
+      newIssueGeneration();
       setGeneration((n) => n + 1);
     }, [key]),
   };

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -297,12 +297,27 @@ const handleSendMsg = async (
     // an ordinary `user_message` and retires it below. The status is already
     // `in_progress` and stays that way — the turn it was queued onto is the one
     // still running.
+    // Applied on every path below, queued included. A `#DRA-53` is expanded
+    // and recorded whether the prompt is sent or held, so the panel's Issue tab
+    // must not wait on a boundary — or on a reselect — to show what the session
+    // is now about. The backend answers with the list *as written*, because
+    // re-tagging replaces an entry rather than appending one.
+    const applySentIssues = () => {
+      setSessionIndexItems((prev) =>
+        prev.map((i) => (i.sessionId === sessionId ? { ...i, issues: outcome.issues } : i)),
+      );
+      setSessions((prev) =>
+        prev.map((s) => (s.sessionId === sessionId ? { ...s, issues: outcome.issues } : s)),
+      );
+    };
+
     if (outcome.queued) {
       const queued = outcome.queued;
       setQueuedBySession((prev) => ({
         ...prev,
         [sessionId]: [...(prev[sessionId] ?? []), queued],
       }));
+      applySentIssues();
       return;
     }
 
@@ -329,6 +344,7 @@ const handleSendMsg = async (
           : i,
       ),
     );
+    applySentIssues();
   } catch (e) {
     // A rejected invoke means the turn never started, so nothing will arrive to
     // clear the status — release it here rather than leaving the composer stuck.

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -13,7 +13,7 @@ import {
 import { isWindowFocused, onFocusChange } from "@/lib/focus";
 import { notifyOS } from "@/lib/notify";
 import { playNotification } from "@/lib/sound";
-import { AgentEvent, ApprovalPolicy, BackgroundTask, BranchList, Effort, Model, ModelId, Project, QueuedMessage, SendOutcome, SessionIndexItem, SessionSnapshot, SessionStatus, SessionStatusEvent, SessionTitleEvent } from "../types/events";
+import { AgentEvent, ApprovalPolicy, BackgroundTask, BranchList, Effort, IssueRef, Model, ModelId, Project, QueuedMessage, SendOutcome, SessionIndexItem, SessionSnapshot, SessionStatus, SessionStatusEvent, SessionTitleEvent } from "../types/events";
 
 // Only for a session indexed before the model was recorded, which reads back as
 // "unknown". Everything else seeds from the user's stored prefs.
@@ -608,6 +608,31 @@ const setSessionFlags = async (
           : s,
       ),
     );
+  } catch (e) {
+    setError(String(e));
+  }
+};
+
+// Applies whatever a link write answered with to both copies of the session.
+//
+// Two copies, for `setSessionFlags`' reason: the sidebar reads the index items
+// and the open transcript holds its own flattened copy, which is what the panel
+// and its tab are drawn from. Leaving either behind shows an issue that is no
+// longer linked, or hides one that is.
+const applyIssues = (sessionId: string, issues: IssueRef[]) => {
+  setSessionIndexItems((prev) =>
+    prev.map((i) => (i.sessionId === sessionId ? { ...i, issues } : i)),
+  );
+  setSessions((prev) =>
+    prev.map((s) => (s.sessionId === sessionId ? { ...s, issues } : s)),
+  );
+};
+
+// Removes one. `key` is the tracker's own id from the row that was clicked; the
+// backend also accepts the human identifier, which is what the CLI passes.
+const unlinkIssue = async (sessionId: string, key: string) => {
+  try {
+    applyIssues(sessionId, await invoke<IssueRef[]>("unlink_issue", { sessionId, key }));
   } catch (e) {
     setError(String(e));
   }
@@ -1324,6 +1349,6 @@ const contextUsage: { used: number; max: number } | null = (() => {
   return used !== null && max !== null ? { used, max } : null;
 })();
 
-return {sessions, selectedSessionId, selectedSession, streamingContentBlock, sessionIndexItems, statusBySession, askingSessions, showArchived, setShowArchived, models, modelId, effort, permissionMode, projects, projectPath, branches, branch, useWorktree, busy, working, backgroundTasks, compacting, contextUsage, error, setError, handleModelChange, setPermissionMode, handleAttachProject, handleSelectProject, handleSelectBranch, pendingBranch, setPendingBranch, runCheckout, setUseWorktree, handleSendMsg, handleInterrupt, handleStopTask, queuedMessages, handleCancelQueued, handleRespondPermission, handleAnswerQuestions, handleSelectSessionIndexItem, handleNewSession, setSessionFlags, forkSession, detachSession, deleteSession, removeWorktree};
+return {sessions, selectedSessionId, selectedSession, streamingContentBlock, sessionIndexItems, statusBySession, askingSessions, showArchived, setShowArchived, models, modelId, effort, permissionMode, projects, projectPath, branches, branch, useWorktree, busy, working, backgroundTasks, compacting, contextUsage, error, setError, handleModelChange, setPermissionMode, handleAttachProject, handleSelectProject, handleSelectBranch, pendingBranch, setPendingBranch, runCheckout, setUseWorktree, handleSendMsg, handleInterrupt, handleStopTask, queuedMessages, handleCancelQueued, handleRespondPermission, handleAnswerQuestions, handleSelectSessionIndexItem, handleNewSession, setSessionFlags, forkSession, unlinkIssue, detachSession, deleteSession, removeWorktree};
 
 }

--- a/apps/desktop/src/lib/changes.test.ts
+++ b/apps/desktop/src/lib/changes.test.ts
@@ -18,7 +18,15 @@ function prompt(baseline: string | null): AgentEvent {
     ts: "2026-08-11T00:00:00Z",
     turnId: null,
     subagent: null,
-    payload: { type: "user_message", text: "hi", images: [], baseline, queued: false, from: null },
+    payload: {
+      type: "user_message",
+      text: "hi",
+      images: [],
+      issues: [],
+      baseline,
+      queued: false,
+      from: null,
+    },
     raw: null,
   } as AgentEvent;
 }

--- a/apps/desktop/src/lib/format.test.ts
+++ b/apps/desktop/src/lib/format.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { calendarDay } from "@/lib/format";
+
+/// Fixed so "today" is a known afternoon rather than whenever the suite runs —
+/// every case here is about which side of a midnight a timestamp falls on, and
+/// a real clock would make half of them flip depending on the hour.
+const NOW = new Date(2026, 7, 27, 14, 0, 0); // 27 Aug 2026, local
+
+describe("calendarDay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it("names the two days that have names", () => {
+    expect(calendarDay(new Date(2026, 7, 27, 9, 0).toISOString())).toBe("Today");
+    expect(calendarDay(new Date(2026, 7, 26, 23, 30).toISOString())).toBe("Yesterday");
+  });
+
+  /// Calendar days, not a 24-hour window. Something touched at 11pm last night
+  /// is yesterday's work by 1am, and an elapsed-hours reading would call it
+  /// today for another two hours.
+  it("counts midnights, not hours", () => {
+    vi.setSystemTime(new Date(2026, 7, 27, 1, 0));
+
+    expect(calendarDay(new Date(2026, 7, 26, 23, 0).toISOString())).toBe("Yesterday");
+    // Two hours earlier and one hour apart, but the same day.
+    expect(calendarDay(new Date(2026, 7, 27, 0, 30).toISOString())).toBe("Today");
+  });
+
+  it("falls back to a date past yesterday", () => {
+    expect(calendarDay(new Date(2026, 7, 23, 12, 0).toISOString())).toBe("Aug 23");
+  });
+
+  /// The year is noise on every row within this year and the only thing telling
+  /// two rows apart across one.
+  it("adds the year only once it stops being obvious", () => {
+    expect(calendarDay(new Date(2025, 7, 23, 12, 0).toISOString())).toBe("Aug 23, 2025");
+  });
+
+  /// A row still has to draw. An unparseable stamp costs its own cell, never the
+  /// list around it.
+  it("is empty for something that is not a date", () => {
+    expect(calendarDay("not a date")).toBe("");
+  });
+
+  /// A stamp from the future — clock skew between this machine and the tracker's
+  /// — reads as today rather than as a negative day count.
+  it("reads a future stamp as today", () => {
+    expect(calendarDay(new Date(2026, 7, 28, 9, 0).toISOString())).toBe("Today");
+  });
+});

--- a/apps/desktop/src/lib/format.ts
+++ b/apps/desktop/src/lib/format.ts
@@ -46,6 +46,34 @@ export function resetTime(iso: string): string {
   return `${time} on ${date}`;
 }
 
+/// Calendar days for a list you read down rather than watch — "Today",
+/// "Yesterday", then "Aug 23".
+///
+/// Deliberately not [relativeTime]. That one counts elapsed time, which is the
+/// right reading for a session that moved four minutes ago and the wrong one
+/// for an issue: "20m" and "1d" invite arithmetic, and nobody looking at a
+/// backlog wants to work out which afternoon "2d" was. A calendar day is the
+/// unit the tracker itself uses and the unit the reader thinks in.
+export function calendarDay(iso: string): string {
+  const at = Date.parse(iso);
+  if (Number.isNaN(at)) return "";
+
+  const days = daysApart(new Date(at), new Date());
+  if (days <= 0) return "Today";
+  if (days === 1) return "Yesterday";
+
+  const date = new Date(at);
+  // The year only once it stops being obvious. Within this year it is noise on
+  // every row; across one it is the only thing that tells them apart.
+  const sameYear = date.getFullYear() === new Date().getFullYear();
+
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+}
+
 function daysApart(from: Date, to: Date): number {
   const midnight = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
   return Math.round((midnight(to) - midnight(from)) / 86_400_000);

--- a/apps/desktop/src/lib/highlight.ts
+++ b/apps/desktop/src/lib/highlight.ts
@@ -6,10 +6,11 @@
 /// textarea, and the same text echoed back into the transcript. Colouring a word
 /// while typing that goes plain once sent — or the reverse — reads as a bug in
 /// whichever surface the reader noticed second.
+import { OPENERS, parseIdentifier } from "@/lib/issue";
 import { parseSlashCommand } from "@/lib/slash";
 
 export type Segment = {
-  kind: "text" | "command" | "mention";
+  kind: "text" | "command" | "mention" | "issue";
   text: string;
 };
 
@@ -21,6 +22,7 @@ export const SEGMENT_COLOR: Record<Segment["kind"], string> = {
   text: "",
   command: "text-accent-command",
   mention: "text-accent-mention",
+  issue: "text-accent-issue",
 };
 
 /// A mention split into the part worth reading and the part that is only there
@@ -63,11 +65,22 @@ export function highlightSegments(text: string): Segment[] {
   }
 
   for (; i < text.length; i += 1) {
-    if (text[i] !== "@") continue;
-    // Must open a word, which is what keeps an email address plain. Note this
-    // also holds at `i === plainFrom` right after a command, where the previous
-    // character is the last of the command name rather than a space.
-    if (i > 0 && !SPACE.test(text[i - 1])) continue;
+    const opener = text[i];
+    if (opener !== "@" && opener !== "#") continue;
+    // Must open a word, which is what keeps an email address and a `#fff`
+    // colour plain. Note this also holds at `i === plainFrom` right after a
+    // command, where the previous character is the last of the command name
+    // rather than a space.
+    //
+    // Bracketing punctuation counts as opening one — `(#DRA-53)` is a tag in a
+    // sentence — and only for a tag, because that is the rule the backend
+    // links by. A mention is left as strict as it was: the CLI parses `@path`
+    // out of the prompt itself, so widening it here would paint mentions the
+    // harness will not read.
+    const previous = i > 0 ? text[i - 1] : " ";
+    const opensWord =
+      SPACE.test(previous) || (opener === "#" && OPENERS.includes(previous));
+    if (!opensWord) continue;
 
     let end = i + 1;
     while (end < text.length && !SPACE.test(text[end])) end += 1;
@@ -76,11 +89,29 @@ export function highlightSegments(text: string): Segment[] {
     // colour arrives with the path rather than flashing on the `@` itself.
     if (end === i + 1) continue;
 
-    if (i > plainFrom) segments.push({ kind: "text", text: text.slice(plainFrom, i) });
-    segments.push({ kind: "mention", text: text.slice(i, end) });
+    let kind: Segment["kind"];
+    let stop = end;
 
-    plainFrom = end;
-    i = end - 1;
+    if (opener === "@") {
+      kind = "mention";
+    } else {
+      // A tag is coloured only where it is a real identifier, because that is
+      // exactly what will be linked — `#fff` at the start of a line, or a
+      // markdown heading's word, must read as the prose they are. The scan
+      // stops at the number's end rather than the token's, so the comma in
+      // `#DRA-53,` stays plain like the sentence it belongs to.
+      const identifier = parseIdentifier(text.slice(i + 1, end));
+      if (!identifier) continue;
+
+      kind = "issue";
+      stop = i + 1 + identifier.length;
+    }
+
+    if (i > plainFrom) segments.push({ kind: "text", text: text.slice(plainFrom, i) });
+    segments.push({ kind, text: text.slice(i, stop) });
+
+    plainFrom = stop;
+    i = stop - 1;
   }
 
   if (plainFrom < text.length) {

--- a/apps/desktop/src/lib/issue.test.ts
+++ b/apps/desktop/src/lib/issue.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyIssue,
+  groupIssues,
+  issueSpan,
+  issueTag,
+  issueUrl,
+  parseIdentifier,
+} from "@/lib/issue";
+import type { Issue, IssueRef, IssueStateKind } from "@/types/events";
+
+const ref = (identifier: string, title: string): IssueRef => ({
+  tracker: "linear",
+  id: `uuid-${identifier}`,
+  identifier,
+  title,
+  url: `https://linear.app/x/issue/${identifier}`,
+});
+
+describe("issueSpan", () => {
+  it("opens on a tag the caret is inside", () => {
+    const text = "fix #DRA-53 now";
+    // Caret just after the `3`.
+    expect(issueSpan(text, 11)).toEqual({ start: 4, end: 11, query: "DRA-53" });
+  });
+
+  it("opens on a bare hash, which is the whole assigned list", () => {
+    expect(issueSpan("#", 1)).toEqual({ start: 0, end: 1, query: "" });
+  });
+
+  it("stays shut on a hash that does not open a word", () => {
+    // The colour case: a `#` mid-token is not a tag, and painting one would
+    // open the picker on every hex value anybody types.
+    expect(issueSpan("border #fff", 11)).not.toBeNull();
+    expect(issueSpan("color:#fff", 10)).toBeNull();
+  });
+
+  it("reads the whole token, not the half before the caret", () => {
+    // Backing up to fix a typo filters on the corrected whole — the same rule
+    // the file picker follows, and what makes the correction visible.
+    const span = issueSpan("#DRA-53", 4);
+    expect(span?.query).toBe("DRA-53");
+  });
+
+  it("is null when the caret is not in a token at all", () => {
+    expect(issueSpan("plain words", 5)).toBeNull();
+    expect(issueSpan("#DRA-53 after", 13)).toBeNull();
+  });
+});
+
+describe("applyIssue", () => {
+  it("writes the identifier and the title, and leaves the caret past a space", () => {
+    const span = issueSpan("fix #DRA", 8)!;
+    const next = applyIssue("fix #DRA", span, "DRA-53", "Issue tracker integration");
+
+    expect(next.text).toBe("fix #DRA-53 Issue tracker integration ");
+    expect(next.caret).toBe(next.text.length);
+  });
+
+  it("keeps the rest of the line and does not double its space", () => {
+    const span = issueSpan("fix #DR now", 7)!;
+    const next = applyIssue("fix #DR now", span, "DRA-53", "Fix it");
+
+    expect(next.text).toBe("fix #DRA-53 Fix it now");
+    // Caret sits after the space, ready for the next word.
+    expect(next.text.slice(next.caret)).toBe("now");
+  });
+
+  /// The string Rust's `tag_text` writes for `--issue`, so a tag picked from the
+  /// menu and one appended by the CLI are the same thing.
+  it("matches the shape the backend writes", () => {
+    expect(issueTag("DRA-53", "One")).toBe("#DRA-53 One");
+    // A title we never resolved leaves the identifier standing alone rather
+    // than a trailing space nobody typed.
+    expect(issueTag("DRA-53", "")).toBe("#DRA-53");
+  });
+});
+
+describe("parseIdentifier", () => {
+  it("takes a key and a number, and uppercases the key", () => {
+    expect(parseIdentifier("DRA-53")).toBe("DRA-53");
+    expect(parseIdentifier("dra-53")).toBe("DRA-53");
+    // Trailing punctuation stops the scan rather than failing it.
+    expect(parseIdentifier("DRA-53),")).toBe("DRA-53");
+  });
+
+  it("refuses everything that is not one", () => {
+    expect(parseIdentifier("fff")).toBeNull();
+    expect(parseIdentifier("53")).toBeNull();
+    expect(parseIdentifier("1-2")).toBeNull();
+    expect(parseIdentifier("DRA-")).toBeNull();
+  });
+});
+
+describe("issueUrl", () => {
+  it("finds where a tag points", () => {
+    const issues = [ref("DRA-53", "One"), ref("DRA-9", "Two")];
+
+    expect(issueUrl(issues, "DRA-9")).toBe("https://linear.app/x/issue/DRA-9");
+  });
+
+  /// A tag whose issue never resolved — the tracker was unreachable when the
+  /// prompt was sent — stays plain text rather than becoming a dead link.
+  it("is null for a tag nothing was linked for", () => {
+    expect(issueUrl([], "DRA-53")).toBeNull();
+    expect(issueUrl([ref("DRA-53", "One")], "DRA-9")).toBeNull();
+  });
+});
+
+const issue = (identifier: string, kind: IssueStateKind): Issue => ({
+  tracker: "linear",
+  id: `uuid-${identifier}`,
+  identifier,
+  title: identifier,
+  url: `https://linear.app/x/issue/${identifier}`,
+  state: { name: "Whatever this team calls it", kind, color: "#000" },
+  priority: "none",
+  assignee: null,
+  labels: [],
+  team: "DRA",
+  project: null,
+  updatedAt: "2026-08-27T00:00:00Z",
+});
+
+describe("groupIssues", () => {
+  /// Started first and settled last, whatever order the list arrived in — the
+  /// order work moves through, which is the order attention should reach it in.
+  it("buckets by state kind, in the page's own order", () => {
+    const groups = groupIssues([
+      issue("DRA-1", "completed"),
+      issue("DRA-2", "started"),
+      issue("DRA-3", "backlog"),
+      issue("DRA-4", "started"),
+    ]);
+
+    expect(groups.map((g) => g.label)).toEqual(["In Progress", "Backlog", "Done"]);
+    expect(groups[0].issues.map((i) => i.identifier)).toEqual(["DRA-2", "DRA-4"]);
+  });
+
+  /// Grouping on the *kind*, not the name: a name is per-team prose, so a list
+  /// spanning three teams would otherwise draw a dozen headings for what are
+  /// really the same few states.
+  it("gathers teams that name one state differently", () => {
+    const a = issue("DRA-1", "started");
+    const b = { ...issue("OPS-1", "started"), state: { name: "Shipping", kind: "started" as const, color: "#000" } };
+
+    expect(groupIssues([a, b])).toHaveLength(1);
+  });
+
+  it("drops empty buckets", () => {
+    expect(groupIssues([])).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/issue.ts
+++ b/apps/desktop/src/lib/issue.ts
@@ -1,0 +1,165 @@
+/// Where the composer's `#` issue picker opens, what a pick writes into the
+/// text, and how the issues page groups what it lists.
+///
+/// The third sibling of [slash.ts] and [mention.ts], and it is shaped like the
+/// second: an issue tag is a word inside a sentence, can appear any number of
+/// times, and has to be told apart from a colour (`#fff`) and from a markdown
+/// heading. So the caret finds its own token here, exactly as a mention does.
+///
+/// The identifier's shape is what separates a tag from either — a team key and
+/// a number. That rule lives twice, here and in Rust's `issue_tags`, because
+/// the picker needs it before a prompt is sent and the backend needs it after;
+/// the two are pinned by tests on both sides rather than by one calling the
+/// other, which neither can.
+///
+/// [slash.ts]: ./slash.ts
+/// [mention.ts]: ./mention.ts
+import type { Issue, IssueRef, IssueStateKind } from "@/types/events";
+
+/// The tag token the caret is sitting in.
+export type IssueSpan = {
+  start: number;
+  end: number;
+  /// Everything after the `#`, to the end of the token — not to the caret, so
+  /// backing up to fix a typo filters on the corrected whole.
+  query: string;
+};
+
+const SPACE = /\s/;
+
+/// Punctuation a tag can open behind, so `(#DRA-53)` is a tag inside a
+/// sentence rather than prose. Skipped rather than treated as part of the
+/// token, and the *same* set Rust's `issue_tags` trims — the two decide
+/// respectively what gets painted and what gets linked, and a word painted as a
+/// tag that links nothing is the drift worth guarding against.
+export const OPENERS = "([\"'";
+
+/// The tag being typed, or `null` when the caret isn't in one.
+///
+/// A bare `#` counts: it opens the picker on the reader's own assigned issues,
+/// which is the list they most often want and the reason the empty query is not
+/// treated as "nothing typed yet".
+export function issueSpan(text: string, caret: number): IssueSpan | null {
+  if (caret < 1 || caret > text.length) return null;
+
+  let start = caret;
+  while (start > 0 && !SPACE.test(text[start - 1])) start -= 1;
+
+  // The walk stops at whitespace or the line's start, so landing on a `#` here
+  // proves it opens a word — which is the whole of the `#fff`-mid-sentence
+  // guard, exactly as the mention walk guards an email address. Bracketing
+  // punctuation is stepped over first, since it opens the word too.
+  while (start < text.length && OPENERS.includes(text[start])) start += 1;
+  if (text[start] !== "#") return null;
+
+  // A markdown heading is `#` followed by a space, so the token is the `#`
+  // alone and the caret is behind it. That case is *allowed* to open the picker
+  // — someone typing `# ` to make a heading has a picker flash open on one
+  // keystroke, where refusing it would take the bare `#` list away entirely.
+
+  let end = caret;
+  while (end < text.length && !SPACE.test(text[end])) end += 1;
+
+  return { start, end, query: text.slice(start + 1, end) };
+}
+
+/// The text of a tag: the identifier, then the title.
+///
+/// The same string Rust's `tag_text` writes when `--issue` names one, and both
+/// are pinned — a tag picked from the menu and a tag appended by the CLI have
+/// to be one shape, or the transcript draws two things for one idea.
+///
+/// The title is *in the text* rather than drawn beside it, and that is what
+/// makes the whole feature cheap: the model reads it, the transcript reads it,
+/// and the composer's overlay stays in register with the textarea underneath
+/// because there is nothing painted that isn't really there.
+export function issueTag(identifier: string, title: string): string {
+  return title ? `#${identifier} ${title}` : `#${identifier}`;
+}
+
+/// The text with the tag at `span` replaced, and where the caret goes after.
+///
+/// A trailing space, because a tag is almost never the last thing typed and the
+/// alternative is every reader pressing space themselves. Not added when one is
+/// already there, or picking twice leaves a gap.
+export function applyIssue(
+  text: string,
+  span: IssueSpan,
+  identifier: string,
+  title: string,
+): { text: string; caret: number } {
+  const tag = issueTag(identifier, title);
+  const after = text.slice(span.end);
+  const spaced = after.startsWith(" ") ? after : ` ${after}`;
+
+  return {
+    text: `${text.slice(0, span.start)}${tag}${spaced}`,
+    caret: span.start + tag.length + 1,
+  };
+}
+
+/// `DRA-53` out of a token, or `null` when it isn't an identifier.
+///
+/// The frontend's copy of Rust's `parse_identifier`, and it has to agree with
+/// it: this decides what the transcript paints as a tag, and that one decides
+/// what actually gets linked. A word painted as a tag that links nothing is the
+/// drift worth watching for.
+export function parseIdentifier(text: string): string | null {
+  const match = /^([A-Za-z][A-Za-z0-9]*)-(\d+)/.exec(text);
+  if (!match) return null;
+
+  return `${match[1].toUpperCase()}-${match[2]}`;
+}
+
+/// Where an identifier points, from the links a message carries.
+///
+/// `null` for a tag whose issue was never resolved — an unreachable tracker at
+/// send time, or a tag naming an issue that does not exist. Those stay drawn as
+/// plain coloured text rather than becoming a link to nowhere.
+export function issueUrl(issues: IssueRef[], identifier: string): string | null {
+  // An empty URL is as good as none, and reaches here whenever a link was made
+  // by `dray issue link` with no `--url`: the app writes down what the caller
+  // gave it and asks the tracker nothing, so the field can simply be blank.
+  // Left unchecked, the tag becomes a button that opens nowhere.
+  return issues.find((issue) => issue.identifier === identifier)?.url || null;
+}
+
+/// The status buckets the issues page draws, in the order it draws them.
+///
+/// Keyed on the state's *kind* rather than its name: a name is per-team prose
+/// ("Shipping", "In Review", "Icebox"), so grouping by it turns a list spanning
+/// three teams into a dozen headings for what are really the same few states.
+/// The kind is a fixed six-way vocabulary, which is what makes the grouping
+/// stable across a whole workspace.
+///
+/// Started first and settled last — the order work moves through, which is also
+/// the order attention should reach it in.
+const GROUPS: { key: IssueStateKind; label: string }[] = [
+  { key: "started", label: "In Progress" },
+  { key: "triage", label: "Triage" },
+  { key: "unstarted", label: "Todo" },
+  { key: "backlog", label: "Backlog" },
+  { key: "completed", label: "Done" },
+  { key: "canceled", label: "Cancelled" },
+  // Last, because it only ever holds a state Linear added and we don't model —
+  // rare, and never the thing the reader came for.
+  { key: "other", label: "Other" },
+];
+
+export type IssueGrouping = {
+  key: IssueStateKind;
+  label: string;
+  issues: Issue[];
+};
+
+/// `issues` bucketed by state, with empty buckets dropped.
+///
+/// Order *within* a bucket is left exactly as it arrived — the backend has
+/// already sorted by priority, and re-sorting here would be a second opinion
+/// about the same question.
+export function groupIssues(issues: Issue[]): IssueGrouping[] {
+  return GROUPS.map((group) => ({
+    ...group,
+    issues: issues.filter((issue) => issue.state.kind === group.key),
+  })).filter((group) => group.issues.length > 0);
+}

--- a/apps/desktop/src/lib/issue.ts
+++ b/apps/desktop/src/lib/issue.ts
@@ -163,3 +163,43 @@ export function groupIssues(issues: Issue[]): IssueGrouping[] {
     issues: issues.filter((issue) => issue.state.kind === group.key),
   })).filter((group) => group.issues.length > 0);
 }
+
+/// Which connection every cached issue read belongs to.
+///
+/// Bumped whenever the answer to "who are we, and what may we read" changes: a
+/// key connected, a key disconnected, a reader pressing Refresh. Every issue
+/// cache in the app — lists, opened bodies, fetched uploads — is stamped with
+/// the generation it was read under, and a read that started under an older one
+/// is refused rather than written.
+///
+/// It is the counter `usePrMarks` already keeps, for the same reason and against
+/// the same failure. Clearing a cache is not enough on its own: a read issued
+/// *before* the clear lands after it and puts the entry straight back, and the
+/// damaging half is not the stale row but the stamp beside it, which tells every
+/// later reader the answer is current and suppresses the read that would correct
+/// it.
+let reads = 0;
+
+const listeners = new Set<() => void>();
+
+/// The generation a read starting now belongs to. Captured before the request
+/// goes out and checked again before anything is written.
+export function issueGeneration(): number {
+  return reads;
+}
+
+/// Invalidates every issue read in the app, and answers with the generation that
+/// replaces them.
+export function newIssueGeneration(): number {
+  reads += 1;
+  for (const listener of listeners) listener();
+  return reads;
+}
+
+/// For `useSyncExternalStore`, so a hook holding an answer read under the old
+/// generation re-reads rather than sitting on it until something else happens to
+/// remount it.
+export function subscribeIssueGeneration(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/apps/desktop/src/lib/mention.test.ts
+++ b/apps/desktop/src/lib/mention.test.ts
@@ -131,12 +131,68 @@ describe("highlightSegments", () => {
     expect(highlightSegments("look at @")).toEqual([{ kind: "text", text: "look at @" }]);
   });
 
+  it("marks an issue tag", () => {
+    expect(highlightSegments("start on #DRA-53 today")).toEqual([
+      { kind: "text", text: "start on " },
+      { kind: "issue", text: "#DRA-53" },
+      { kind: "text", text: " today" },
+    ]);
+  });
+
+  /// All three can share one sentence, which is why the three colours are
+  /// chosen far apart in hue — and why this case is pinned.
+  it("marks a command, a mention and a tag together", () => {
+    expect(highlightSegments("/review #DRA-53 @src/lib/issue.ts")).toEqual([
+      { kind: "command", text: "/review" },
+      { kind: "text", text: " " },
+      { kind: "issue", text: "#DRA-53" },
+      { kind: "text", text: " " },
+      { kind: "mention", text: "@src/lib/issue.ts" },
+    ]);
+  });
+
+  /// The tag stops at the number, so the punctuation after it stays part of the
+  /// sentence rather than being painted as an address.
+  it("stops a tag at the end of its number", () => {
+    expect(highlightSegments("see #DRA-53, then stop")).toEqual([
+      { kind: "text", text: "see " },
+      { kind: "issue", text: "#DRA-53" },
+      { kind: "text", text: ", then stop" },
+    ]);
+  });
+
+  /// Bracketed is still a tag, because the backend links it — the overlay and
+  /// the link have to agree about what a tag is, or a word is painted as an
+  /// address that nothing resolves, or the reverse.
+  it("marks a bracketed tag", () => {
+    expect(highlightSegments("see (#DRA-53) first")).toEqual([
+      { kind: "text", text: "see (" },
+      { kind: "issue", text: "#DRA-53" },
+      { kind: "text", text: ") first" },
+    ]);
+  });
+
+  /// A colour and a heading are prose. Painting either would promise a link
+  /// that nothing is going to make.
+  it("leaves a hash that is not an identifier plain", () => {
+    expect(highlightSegments("border #fff please")).toEqual([
+      { kind: "text", text: "border #fff please" },
+    ]);
+    expect(highlightSegments("# Heading")).toEqual([{ kind: "text", text: "# Heading" }]);
+    expect(highlightSegments("channel#DRA-1")).toEqual([
+      { kind: "text", text: "channel#DRA-1" },
+    ]);
+  });
+
   it("concatenates back to the original", () => {
     roundTrips("/review @src/lib/slash.ts and @src/lib/mention.ts please");
     roundTrips("ping me@example.com");
     roundTrips("@a @b @c");
     roundTrips("");
     roundTrips("/compact");
+    roundTrips("/review #DRA-53 @src/lib/issue.ts");
+    roundTrips("see (#DRA-53), and #fff, and #DRA-9.");
+    roundTrips("#");
   });
 });
 

--- a/apps/desktop/src/lib/transcript.test.ts
+++ b/apps/desktop/src/lib/transcript.test.ts
@@ -20,7 +20,15 @@ function event(seq: number, payload: AgentEventPayload): AgentEvent {
 }
 
 function prompt(seq: number, text: string, queued: boolean): AgentEvent {
-  return event(seq, { type: "user_message", text, images: [], baseline: null, queued, from: null });
+  return event(seq, {
+    type: "user_message",
+    text,
+    images: [],
+    issues: [],
+    baseline: null,
+    queued,
+    from: null,
+  });
 }
 
 function callStarted(seq: number, callId: string): AgentEvent {

--- a/apps/desktop/src/types/events.ts
+++ b/apps/desktop/src/types/events.ts
@@ -46,6 +46,17 @@ export type AgentEventPayload = { "type": "turn_started" } & SessionInfo | { "ty
  */
 head: string | null, } | { "type": "settings_changed" } & Settings | { "type": "user_message", text: string, images: Array<ImageRef>, 
 /**
+ * The issues this prompt was tagged with, resolved against the tracker
+ * as it was sent.
+ *
+ * A field rather than something to be parsed back out of `text`, for
+ * the reason `from` below gives: the block appended to the prompt is
+ * prose, and a transcript that recovered it with a pattern would fail
+ * silently the first time the wording moved. The bubble rebuilds the
+ * exact string from *these* and drops it only if the text ends with it.
+ */
+issues: Array<IssueRef>, 
+/**
  * The working tree as it stood when this prompt was sent, as a git
  * tree id — the "before" side the changes panel diffs against.
  *
@@ -209,7 +220,17 @@ export type AppSettings = {
  * as. A file that exists and cannot be parsed reads the other way — see
  * [`read`].
  */
-analyticsEnabled: boolean, };
+analyticsEnabled: boolean, 
+/**
+ * Who the stored issue-tracker key belongs to.
+ *
+ * The account, never the key — that lives in `credentials.json` beside
+ * this, and never rides the struct handed to the frontend. This is only
+ * what saves a round trip to draw a name in the settings row. It is
+ * therefore not the connection: an account here with no key behind it
+ * reads as disconnected. See [`crate::issues::get_integrations`].
+ */
+linearAccount: TrackerAccount | null, };
 
 /**
  * Permission stance a session *runs under*, in roughly increasing order of
@@ -422,6 +443,175 @@ export type Harness = "claude_code" | "codex";
 export type HookPhase = "started" | "finished";
 
 export type ImageRef = { path: string | null, url: string | null, mimeType: string | null, };
+
+/**
+ * What the settings dialog draws. `None` is a tracker nobody has connected.
+ */
+export type IntegrationsView = { linear: TrackerAccount | null, };
+
+/**
+ * One row in a list, and everything a row draws.
+ *
+ * Distinct from [`IssueDetail`] rather than one type with empty fields: a list
+ * read does not ask for descriptions or comments, and a struct that carries
+ * them anyway hands the panel an issue whose body is silently missing.
+ */
+export type Issue = { tracker: IssueTracker, id: string, identifier: string, title: string, url: string, state: IssueState, priority: IssuePriority, assignee: IssuePerson | null, labels: Array<IssueLabel>, 
+/**
+ * Team key (`DRA`) — what the identifier is built from, so a row filtered
+ * across teams still says which one it belongs to.
+ */
+team: string | null, project: string | null, updatedAt: string, };
+
+/**
+ * A file uploaded to an issue, fetched with the stored key.
+ *
+ * **The whole reason this command exists.** Linear's uploads live behind the
+ * same auth the API does, so the `<img src>` in a description resolves to a
+ * 401 and the webview draws its broken-image box — which reads as "Dray cannot
+ * show this" rather than "this needs a key". Fetching here and handing back a
+ * `data:` URL is what makes an image in an issue an image on screen.
+ *
+ * Bytes rather than a signed URL because Linear issues none, and `data:`
+ * rather than a local file because these are read once and thrown away.
+ */
+export type IssueAsset = { 
+/**
+ * `image/png`, `text/plain`… as the server reported it.
+ */
+mime: string, 
+/**
+ * `data:<mime>;base64,…`, ready to put in a `src` or an `href`.
+ */
+dataUrl: string, bytes: number, };
+
+export type IssueComment = { author: IssuePerson, body: string, createdAt: string, url: string | null, };
+
+/**
+ * One issue, opened. The panel's read.
+ */
+export type IssueDetail = { 
+/**
+ * Markdown, as the tracker holds it. `None` for an issue nobody wrote one
+ * for, which the panel says plainly rather than drawing an empty box.
+ */
+description: string | null, comments: Array<IssueComment>, tracker: IssueTracker, id: string, identifier: string, title: string, url: string, state: IssueState, priority: IssuePriority, assignee: IssuePerson | null, labels: Array<IssueLabel>, 
+/**
+ * Team key (`DRA`) — what the identifier is built from, so a row filtered
+ * across teams still says which one it belongs to.
+ */
+team: string | null, project: string | null, updatedAt: string, };
+
+/**
+ * The filter row's options, read once per connection rather than per keystroke.
+ */
+export type IssueFilters = { teams: Array<IssueGroup>, projects: Array<IssueGroup>, };
+
+export type IssueGroup = { id: string, name: string, };
+
+export type IssueLabel = { name: string, color: string, };
+
+export type IssuePerson = { name: string, 
+/**
+ * `None` for an account with no picture, which the panel draws as an
+ * initial rather than as a gap — same bargain the PR panel makes.
+ */
+avatar: string | null, };
+
+/**
+ * Linear's five levels, by name rather than by its `0..4` integer — where `0`
+ * is *no* priority and therefore sorts nothing like a number.
+ */
+export type IssuePriority = "urgent" | "high" | "medium" | "low" | "none";
+
+/**
+ * What the issues page can narrow to, and what the picker asks with.
+ */
+export type IssueQuery = { 
+/**
+ * Free text. Matched against title and identifier; an empty query is the
+ * resting state and lists rather than searches.
+ */
+text: string | null, scope: IssueScope, 
+/**
+ * Linear team id.
+ */
+teamId: string | null, projectId: string | null, 
+/**
+ * Which half of the workspace to read: the unfinished issues, or the done
+ * and cancelled ones.
+ *
+ * Two reads rather than one flag that widens a single read, because the
+ * settled half is most of a workspace and is nearly always dead weight —
+ * so the page draws its groups collapsed and asks for them only when one
+ * is opened. Splitting it here rather than filtering client-side is what
+ * makes that possible: a read that never happens costs nothing, and the
+ * two answers cache under separate keys.
+ */
+settled: boolean, };
+
+/**
+ * What a session records about an issue it is working on.
+ *
+ * Deliberately a *copy*, not a pointer: the title and the URL are what the
+ * sidebar and the prompt block need, and re-reading the tracker to draw a row
+ * would put a network call behind a session opening. It goes stale — a
+ * retitled issue keeps the old words here until the panel reads it back — and
+ * that is the right way round, since the alternative is a row that cannot be
+ * drawn while the workspace is unreachable.
+ */
+export type IssueRef = { tracker: IssueTracker, 
+/**
+ * The tracker's own stable id, which survives a move between teams where
+ * `identifier` does not.
+ */
+id: string, 
+/**
+ * What a person calls it: `DRA-53`.
+ */
+identifier: string, title: string, url: string, };
+
+/**
+ * Whose issues to list.
+ *
+ * The tracker's own two answers to "my issues", and a third for looking past
+ * them. Deliberately not a pair of booleans: assigned *and* created is a
+ * question nobody asks, and two flags can express it.
+ */
+export type IssueScope = "assigned" | "created" | "all";
+
+export type IssueState = { name: string, kind: IssueStateKind, 
+/**
+ * The tracker's own colour, so a status reads the same here as it does in
+ * the app the reader also has open.
+ */
+color: string, };
+
+/**
+ * Where an issue has got to, folded from the tracker's own vocabulary.
+ *
+ * Linear reports a workflow state's `type`, which is this set exactly — the
+ * state's *name* is per-team prose ("In Review", "Shipping") and belongs on
+ * screen, not in a match arm.
+ */
+export type IssueStateKind = "triage" | "backlog" | "unstarted" | "started" | "completed" | "canceled" | "other";
+
+/**
+ * Who tracks the issue. One variant today; it is on the wire and on disk so a
+ * session linked to a Linear issue stays readable once there are two.
+ */
+export type IssueTracker = "linear";
+
+/**
+ * Why there is nothing to show.
+ *
+ * Typed for [`PrUnavailable`](crate::github::PrUnavailable)'s reason: the
+ * frontend acts differently on each. `NotConnected` is the resting state of an
+ * app nobody has connected — an empty state pointing at settings, never an
+ * error — where `Unauthorized` means a key that has been revoked or rotated
+ * and is the one the reader has to do something about.
+ */
+export type IssueUnavailable = { "kind": "not_connected" } | { "kind": "unauthorized" } | { "kind": "offline", "detail": string } | { "kind": "other", "detail": string };
 
 /**
  * Shared with the harness parsers rather than duplicated — the wire shape
@@ -750,7 +940,14 @@ text: string, attachmentPaths: Array<string>,
  * can wait out a long turn, and the sending session may be renamed or
  * deleted before the boundary that delivers it.
  */
-from: MessageSender | null, };
+from: MessageSender | null, 
+/**
+ * Resolved when the prompt was typed, not at flush, for `from`'s reason:
+ * a held prompt can wait out a long turn, and re-reading the tracker at
+ * the boundary would put a network call — and its failure — inside the
+ * flush.
+ */
+issues: Array<IssueRef>, };
 
 export type RateLimit = { usedPercent: number | null, windowMinutes: number | null, 
 /**
@@ -827,6 +1024,16 @@ status: SessionStatus,
  */
 forkFrom: string | null, 
 /**
+ * The issues this session's work is against, newest link last.
+ *
+ * A list because one session really does carry several — three tags in one
+ * prompt is the case this was built for — and a copy rather than an id,
+ * so the panel's tab and the sidebar's row can be drawn with the tracker
+ * unreachable. `serde(default)` so entries written before the field read
+ * as untagged rather than failing the whole index.
+ */
+issues: Array<IssueRef>, 
+/**
  * The session whose agent created this one, for a session created over the
  * orchestration socket rather than by a person in the composer. `Some` is
  * also what the depth guard reads: a session that was itself spawned may
@@ -896,6 +1103,16 @@ status: SessionStatus,
  * this one is cleared the moment the CLI carries the fork out.
  */
 forkFrom: string | null, 
+/**
+ * The issues this session's work is against, newest link last.
+ *
+ * A list because one session really does carry several — three tags in one
+ * prompt is the case this was built for — and a copy rather than an id,
+ * so the panel's tab and the sidebar's row can be drawn with the tracker
+ * unreachable. `serde(default)` so entries written before the field read
+ * as untagged rather than failing the whole index.
+ */
+issues: Array<IssueRef>, 
 /**
  * The session whose agent created this one, for a session created over the
  * orchestration socket rather than by a person in the composer. `Some` is
@@ -1037,6 +1254,11 @@ images: Array<ImageRef>, };
  * for correctness, and [`ToolType::Other`] must always render acceptably.
  */
 export type ToolType = "shell" | "file_read" | "file_edit" | "search" | "web" | "mcp" | "subagent_spawn" | "other";
+
+/**
+ * The connected account, as the settings row draws it.
+ */
+export type TrackerAccount = { tracker: IssueTracker, userId: string, userName: string, orgName: string, };
 
 /**
  * How a turn ended. Claude Code reports this as `is_error` on its result

--- a/apps/desktop/src/types/events.ts
+++ b/apps/desktop/src/types/events.ts
@@ -969,7 +969,22 @@ snapshot: SessionSnapshot | null,
  * `Some` when a turn was already running, so the prompt is held rather
  * than sent. The frontend draws it as pending and can still take it back.
  */
-queued: QueuedMessage | null, };
+queued: QueuedMessage | null, 
+/**
+ * Every issue the session is linked to now, as written.
+ *
+ * Answered on **every** path — created, live, queued and resumed — because
+ * a `#DRA-53` is expanded and recorded on every one of them, and the
+ * frontend has no other way to learn what a prompt just linked. Without it
+ * a tag typed into an existing session persisted in Rust and reached the
+ * panel only on a reselect or a restart: the Issue tab went on drawing the
+ * session's old links while the index on disk held the new ones.
+ *
+ * The whole list rather than what this send added, for [`store::
+ * link_session_issue`]'s reason — re-tagging *replaces* an entry, so what
+ * changed is not a set the caller can apply on its own.
+ */
+issues: Array<IssueRef>, };
 
 export type SessionIndexItem = { sessionId: string, harness: Harness, 
 /**

--- a/crates/dray-proto/src/lib.rs
+++ b/crates/dray-proto/src/lib.rs
@@ -33,8 +33,21 @@ use std::path::PathBuf;
 /// half is behind so the reader — usually an agent, reading it as tool output —
 /// runs the cure that applies rather than the one that doesn't.
 ///
-/// v2 added `CreateSession::from`.
-pub const PROTOCOL_VERSION: u32 = 2;
+/// v2 added `CreateSession::from`. v3 added `CreateSession::issues` and
+/// [`Request::LinkIssues`], for the same test: an app that ignored `issues`
+/// would start the session with no issue linked and no line in its prompt
+/// saying what the work is against, and answer identically to a success — so
+/// the session runs, works on the wrong thing or on nothing, and reports back
+/// that it is done.
+///
+/// v4 reshaped [`LinkIssues`]: `identifiers: Vec<String>` became
+/// [`IssueInput`], carrying the title and URL the caller already has. The old
+/// shape made the *app* resolve each identifier against the tracker, so a link
+/// — a local record, on a session, about work — needed the network to be up and
+/// a key to be stored. The field is renamed rather than extended so the two
+/// shapes cannot be confused on the wire: an old app handed the new one finds
+/// no `identifiers` and refuses, which is the loud failure wanted here.
+pub const PROTOCOL_VERSION: u32 = 4;
 
 /// Where the app listens, unless [`endpoint`] is overridden.
 pub const SOCKET_NAME: &str = "dray.sock";
@@ -79,6 +92,7 @@ pub enum Request {
     CreateSession(CreateSession),
     ListSessions(ListSessions),
     SendMessage(SendMessage),
+    LinkIssues(LinkIssues),
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -119,6 +133,52 @@ pub struct CreateSession {
     /// business learning how a session's branch is named.
     #[serde(default)]
     pub from: Option<String>,
+    /// Issue identifiers (`DRA-53`) the new session's work is against.
+    ///
+    /// Resolved by the app, not here: the CLI holds no key and has no business
+    /// learning what a tracker is. Each one becomes a link on the session and a
+    /// line in the prompt — identifier and title, nothing more, since the agent
+    /// has the tracker's own MCP server for the rest.
+    #[serde(default)]
+    pub issues: Vec<String>,
+}
+
+/// Tagging a session that already exists — or untagging it.
+///
+/// One request with a flag rather than two, because the halves differ by a
+/// single word and every field is otherwise the same.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkIssues {
+    pub session_id: String,
+    pub issues: Vec<IssueInput>,
+    /// Remove these links instead of adding them. Only `identifier` is read.
+    #[serde(default)]
+    pub unlink: bool,
+}
+
+/// One issue to tag a session with, as the caller already knows it.
+///
+/// **The app writes this down and asks the tracker nothing.** A link is a local
+/// record — this session is about that work — and making it depend on a
+/// reachable tracker meant a link could fail for reasons that have nothing to
+/// do with what it records. The caller is an agent that has just read the issue
+/// through the tracker's own MCP server, so it has the title and the URL in
+/// hand; asking a second system for what the caller already holds is a round
+/// trip that can only introduce a way to fail.
+///
+/// `title` and `url` are optional because a bare identifier is still a usable
+/// link: the tag reads `#DRA-53` with no title after it, and stays plain text
+/// rather than becoming a link to nowhere.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueInput {
+    /// As a person writes it; case is the app's to normalize.
+    pub identifier: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
 }
 
 /// A prompt sent into a session that already exists.
@@ -173,6 +233,9 @@ pub enum Response {
         base_ref: Option<String>,
     },
     Listed { sessions: Vec<SessionSummary> },
+    /// Every issue the session carries *after* the change, so the caller sees
+    /// the result rather than a diff it has to apply to what it believed.
+    Linked { issues: Vec<IssueLink> },
     /// `queued` when the target had a turn in flight, so the prompt is held
     /// until it reaches a boundary rather than being dropped or interrupting.
     Sent { queued: bool },
@@ -210,6 +273,19 @@ pub struct SessionSummary {
     /// from the composer or from a terminal, and for one since detached.
     #[serde(default)]
     pub parent_session_id: Option<String>,
+}
+
+/// One issue a session is tagged with, as the CLI prints it.
+///
+/// A deliberate subset of the app's own `IssueRef`, for [`SessionSummary`]'s
+/// reason: that type carries ts-rs derives and a tracker enum, neither of which
+/// this side has any use for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueLink {
+    pub identifier: String,
+    pub title: String,
+    pub url: String,
 }
 
 /// Where to reach the app: `DRAY_ENDPOINT` if set, else the socket under the
@@ -325,7 +401,7 @@ mod tests {
         })))
         .unwrap();
 
-        assert_eq!(line["v"], 2);
+        assert_eq!(line["v"], PROTOCOL_VERSION);
         assert!(PROTOCOL_VERSION >= 2, "from must not travel under v1");
     }
 
@@ -345,6 +421,54 @@ mod tests {
             panic!("wrong variant");
         };
         assert_eq!(base_ref, None);
+    }
+
+    /// Same test `from` earned its bump on: an app that ignored these would
+    /// start a session against no issue at all and answer like a success.
+    #[test]
+    fn issues_travel_on_the_create_at_the_version_that_added_them() {
+        let line = serde_json::to_value(Envelope::new(Request::CreateSession(CreateSession {
+            prompt: "do it".into(),
+            issues: vec!["DRA-53".into()],
+            ..Default::default()
+        })))
+        .unwrap();
+
+        assert_eq!(line["issues"][0], "DRA-53");
+        assert!(PROTOCOL_VERSION >= 3, "issues must not travel under v2");
+    }
+
+    #[test]
+    fn linking_round_trips_and_says_which_way_it_goes() {
+        let line = serde_json::to_string(&Envelope::new(Request::LinkIssues(LinkIssues {
+            session_id: "abc".into(),
+            identifiers: vec!["DRA-1".into(), "DRA-2".into()],
+            unlink: true,
+        })))
+        .unwrap();
+        assert!(line.contains(r#""cmd":"link_issues""#));
+
+        let back: Envelope = serde_json::from_str(&line).unwrap();
+        let Request::LinkIssues(link) = back.request else {
+            panic!("wrong variant");
+        };
+        assert_eq!(link.identifiers.len(), 2);
+        assert!(link.unlink);
+    }
+
+    /// Absent reads as *adding*, which is the direction that cannot be
+    /// destructive — the one worth having as a default.
+    #[test]
+    fn a_link_with_no_direction_adds() {
+        let request: Request = serde_json::from_str(
+            r#"{"cmd":"link_issues","sessionId":"a","identifiers":["DRA-1"]}"#,
+        )
+        .unwrap();
+
+        let Request::LinkIssues(link) = request else {
+            panic!("wrong variant");
+        };
+        assert!(!link.unlink);
     }
 
     #[test]


### PR DESCRIPTION
## TLDR for human

- **Issues page** in the main column — scope chips, search, grouped by state kind, Done/Cancelled fetched only on expand
- **Issue tab** in the right panel — description with its uploads rendered, people, status, comments
- **`#DRA-53` tags in the composer**, resolved on send; the tag carries the title itself, so no block underneath
- **Key in `~/.dray/credentials.json` at 0600**, not the keychain
- **`dray issue link`** writes down what it is given and asks the tracker nothing; protocol at v4
- Docs: `apps/desktop/COPY-ISSUES.md` collects every user-facing string with its reason; CLAUDE.md gains an Issues section

---

Read-only. The surface says "issue" and the implementation says Linear — a second tracker is a module plus a variant on `IssueTracker`, not a rename of every panel. The word "Linear" reaches the reader in exactly two places: the connect form, and a failure Linear itself caused.

### Why the key is not in the keychain

macOS ties a keychain grant to the exact binary that asked, so every rebuild is a new application to the ACL and the grant never sticks — an authorization dialog several times an hour on any machine where the app is being built. Signing with a stable Developer ID settles it for a shipped build and does nothing for anyone working on the app.

The cost is worth stating: the key is readable by anything running as the user. What makes it tolerable is the company it keeps — `~/.dray` is already `0700` and holds every transcript, which is every file an agent read or wrote on this machine. `gh`, `npm` and `aws` make the same trade.

The mode is set on the **temp file before the rename**: `fs::write` creates at the process umask, so setting it afterwards leaves a window where the key sits world-readable. Pinned by a test — the failure is silent otherwise.

### Uploads

Linear puts images and files in the description's own markdown, so there is no attachment list to build — `img` and `a` are overridden on that one `Markdown` and everything else is left alone.

Uploads sit behind the same auth the API does, so a webview `<img src>` resolves to 401 and the browser draws its own broken box. `fetch_issue_asset` puts the key on that request and hands back a `data:` URL.

The host is checked **exactly, on the parsed host, never by prefix**. The description is text somebody else wrote and it names the URL this fetch is handed, so without the check an issue could name any host and have the app post a credential to it. `uploads.linear.app.evil.test` passes `starts_with` and is not Linear.

### The CLI writes blind

`dray issue link` records what it is given and asks the tracker nothing — the caller is an agent that just read the issue through the tracker's own MCP, so it holds the title and url already. Making the link need a reachable Linear and a stored key meant it could fail for reasons nothing to do with what it records.

`PROTOCOL_VERSION` 3 → 4 because `LinkIssues.identifiers` was **renamed** to `issues`, not extended: an old app handed the new shape finds no `identifiers` and refuses, which is the loud failure wanted here.

### Caching

Two module-level caches. The list is keyed on the whole query and capped at 12; opened issues are keyed by identifier and capped at 24, since one is a row and the other a whole body read on a different rhythm. Both fresh for 60s, both cleared by `forgetIssues()` on either integration write. Cached bodies are picked **during render**, not in an effect — `useEffect` runs after paint, which left one frame of the previous issue's description under the new issue's title.

### Tests

337 Rust, 269 frontend, 22 CLI. `tsc --noEmit` and `vite build` clean. Rebased onto `main` (5 commits); conflicts in `apps/cli/src/main.rs` and `Sidebar.tsx` resolved in favour of main's `dray update` signature and its real search field, with the Issues row added above it.

Refs DRA-53