### PR TITLE
fix(panel): start a new task with the pane closed

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -507,6 +507,18 @@ function App() {
     }
   };
 
+  // The pane is one piece of app-wide state, so a new task would otherwise
+  // inherit whichever pane the last session left open — invisibly, since the
+  // empty composer draws none, and then mounted open the moment the first
+  // prompt creates the session. That is the one moment its reads have nothing
+  // to answer from: the repo isn't resolved yet, so the tab draws an error for
+  // a second or three before the first read lands. Keyed on the selection
+  // rather than on `handleNewSession`, so every route to the empty composer is
+  // covered — ⌘N, the sidebar's +, settling the open session, deleting it.
+  useEffect(() => {
+    if (!selectedSessionId) setPanelOpen(false);
+  }, [selectedSessionId]);
+
   const toggleSidebar = () => setCollapsed((prev) => !prev);
   useHotkey("b", toggleSidebar);
   useHotkey("n", handleNewSession);


### PR DESCRIPTION
`panelOpen` is one piece of app-wide state, so a new task inherited whichever pane the last session left open. Nothing showed it — the empty composer draws no pane — until the first prompt created the session and the pane mounted open onto a repo the app has not resolved yet, drawing an error for a second or three before the read landed. Worst on the PR tab, where `gh` takes the better part of a second.

Keyed on the selection going to nothing rather than on `handleNewSession`, so every route to the empty composer is covered: ⌘N, the sidebar's +, settling the open session, deleting it.

Fixes DRA-63

🤖 Generated with [Claude Code](https://claude.com/claude-code)