### PR TITLE
PR panel: offer Delete branch on merged and closed PRs

### DIFF
--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -7,6 +7,7 @@
 //! an error, since this is a side view and never the reason the app is open.
 
 use anyhow::Result;
+use serde::de::IgnoredAny;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, process::Stdio, sync::OnceLock};
 use tokio::{process::Command, sync::Mutex};
@@ -95,6 +96,10 @@ pub struct PullRequest {
     pub author: String,
     pub base_ref_name: String,
     pub head_ref_name: String,
+    /// Whether that branch is still on the remote. `headRefName` survives the
+    /// branch itself — a merged PR keeps naming the branch it came from — so
+    /// the name cannot answer this and `headRef` going null is what does.
+    pub head_ref_exists: bool,
     /// `MERGEABLE`, `CONFLICTING`, or `UNKNOWN` while GitHub is still working
     /// the merge out — which it starts doing lazily, on being asked.
     pub mergeable: String,
@@ -156,7 +161,7 @@ const QUERY: &str = r#"
 query($owner:String!,$repo:String!,$branch:String!){
  repository(owner:$owner,name:$repo){
   pullRequests(headRefName:$branch,first:20,orderBy:{field:CREATED_AT,direction:DESC}){nodes{
-   number title url state isDraft baseRefName headRefName mergeable mergeStateStatus reviewDecision updatedAt
+   number title url state isDraft baseRefName headRefName headRef{name} mergeable mergeStateStatus reviewDecision updatedAt
    additions deletions changedFiles
    author{login avatarUrl}
    comments(first:50){nodes{author{login avatarUrl} body createdAt url}}
@@ -443,6 +448,12 @@ struct RawPr {
     base_ref_name: String,
     #[serde(default)]
     head_ref_name: String,
+    /// Null once the branch is deleted, and only then — the one field on the
+    /// node that tells a branch still there from one already gone. Only its
+    /// presence is read: GraphQL needs a selection under it, but the name it
+    /// would carry is `head_ref_name`, which outlives the ref.
+    #[serde(default)]
+    head_ref: Option<IgnoredAny>,
     #[serde(default)]
     mergeable: String,
     #[serde(default)]
@@ -681,6 +692,7 @@ impl RawPr {
             author: login(&self.author),
             base_ref_name: self.base_ref_name,
             head_ref_name: self.head_ref_name,
+            head_ref_exists: self.head_ref.is_some(),
             mergeable: self.mergeable,
             merge_state_status: self.merge_state_status,
             review_decision: self.review_decision.filter(|d| !d.is_empty()),
@@ -1130,6 +1142,29 @@ async fn merged_state(cwd: &str, number: u64) -> Option<bool> {
     Some(value.get("state")?.as_str()? == "MERGED")
 }
 
+/// Deletes the head branch from the remote, and nothing else.
+///
+/// The local branch and the worktree holding it belong to the settle flow,
+/// which already deletes both; the remote ref is the one thing nothing owned.
+/// Keeping the halves apart also sidesteps `git branch -D` refusing a branch
+/// some worktree still has checked out — the same refusal that keeps
+/// [`merge_pr`] from passing `--delete-branch`.
+///
+/// The REST endpoint rather than `git push --delete`: this takes no working
+/// tree, so it deletes the branch of a session whose checkout has already gone.
+/// A ref that is already deleted answers 422 rather than success, so the button
+/// is gated on `head_ref_exists` instead of this call being safe to repeat.
+#[tauri::command]
+pub async fn delete_branch(cwd: String, branch: String) -> Result<(), String> {
+    let (owner, repo) = repo_slug(&cwd).await?;
+
+    // `refs/heads/<branch>` is a path here, so a branch name carrying slashes
+    // needs no escaping — `fix/thing` addresses the ref it names.
+    let path = format!("repos/{owner}/{repo}/git/refs/heads/{branch}");
+
+    gh(&cwd, &["api", "-X", "DELETE", &path]).await.map(|_| ())
+}
+
 /// Reopens a PR closed elsewhere. There is no `close_pr` beside it on purpose:
 /// this panel exists to get work landed, and abandoning a PR is a decision with
 /// a discussion attached to it, which happens on GitHub.
@@ -1411,6 +1446,42 @@ mod tests {
     fn diff_counts_come_through() {
         let pr = parse();
         assert_eq!((pr.additions, pr.deletions, pr.changed_files), (2155, 66, 22));
+    }
+
+    /// `headRefName` outlives the branch — a merged PR goes on naming the one
+    /// it came from — so only `headRef` going null says the ref is gone.
+    /// Verified against the live API: deleting the branch flipped `headRef` to
+    /// null and left `headRefName` exactly as it was.
+    #[test]
+    fn head_ref_says_whether_the_branch_is_still_there() {
+        let out = |head_ref: &str| {
+            format!(
+                r#"{{"data":{{"repository":{{"pullRequests":{{"nodes":[
+                  {{"number":1,"headRefName":"fix/thing","headRef":{head_ref}}}]}}}}}}}}"#
+            )
+        };
+
+        let live = read_prs(&out(r#"{"name":"fix/thing"}"#)).expect("parses");
+        assert!(live[0].head_ref_exists);
+        assert_eq!(live[0].head_ref_name, "fix/thing");
+
+        let deleted = read_prs(&out("null")).expect("parses");
+        assert!(!deleted[0].head_ref_exists);
+        // The name survives, which is what lets the row go on naming it.
+        assert_eq!(deleted[0].head_ref_name, "fix/thing");
+    }
+
+    /// Absence has to read as *gone*, not as there. The button is the one
+    /// destructive thing on this pane, and a shape we failed to get back would
+    /// otherwise draw it over a branch that may not exist — a click answered
+    /// with a 422. Under-offering costs a trip to GitHub; over-offering costs
+    /// an error on work already landed.
+    #[test]
+    fn a_missing_head_ref_field_reads_as_gone() {
+        let out = r#"{"data":{"repository":{"pullRequests":{"nodes":[
+            {"number":1,"headRefName":"fix/thing"}]}}}}"#;
+        let prs = read_prs(out).expect("parses");
+        assert!(!prs[0].head_ref_exists);
     }
 
     /// The sidebar's query carries the branch and the draft flag, and a draft

--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -100,6 +100,14 @@ pub struct PullRequest {
     /// branch itself — a merged PR keeps naming the branch it came from — so
     /// the name cannot answer this and `headRef` going null is what does.
     pub head_ref_exists: bool,
+    /// Whether the head branch lives in a fork rather than in this repo.
+    ///
+    /// `head_ref_name` is bare either way — a PR from `alice/dray:feature`
+    /// reports `feature` — so the name cannot be told apart from a branch of
+    /// our own, and joining it to this repo's slug addresses a *different*
+    /// branch that merely shares its name. Unknown reads as `true`, because
+    /// the only thing this gates is a deletion.
+    pub is_cross_repository: bool,
     /// `MERGEABLE`, `CONFLICTING`, or `UNKNOWN` while GitHub is still working
     /// the merge out — which it starts doing lazily, on being asked.
     pub mergeable: String,
@@ -161,7 +169,7 @@ const QUERY: &str = r#"
 query($owner:String!,$repo:String!,$branch:String!){
  repository(owner:$owner,name:$repo){
   pullRequests(headRefName:$branch,first:20,orderBy:{field:CREATED_AT,direction:DESC}){nodes{
-   number title url state isDraft baseRefName headRefName headRef{name} mergeable mergeStateStatus reviewDecision updatedAt
+   number title url state isDraft baseRefName headRefName headRef{name} isCrossRepository mergeable mergeStateStatus reviewDecision updatedAt
    additions deletions changedFiles
    author{login avatarUrl}
    comments(first:50){nodes{author{login avatarUrl} body createdAt url}}
@@ -454,6 +462,10 @@ struct RawPr {
     /// would carry is `head_ref_name`, which outlives the ref.
     #[serde(default)]
     head_ref: Option<IgnoredAny>,
+    /// `Option` so that absent can be told from `false` and read as *fork* —
+    /// see [`PullRequest::is_cross_repository`].
+    #[serde(default)]
+    is_cross_repository: Option<bool>,
     #[serde(default)]
     mergeable: String,
     #[serde(default)]
@@ -693,6 +705,7 @@ impl RawPr {
             base_ref_name: self.base_ref_name,
             head_ref_name: self.head_ref_name,
             head_ref_exists: self.head_ref.is_some(),
+            is_cross_repository: self.is_cross_repository.unwrap_or(true),
             mergeable: self.mergeable,
             merge_state_status: self.merge_state_status,
             review_decision: self.review_decision.filter(|d| !d.is_empty()),
@@ -1142,7 +1155,8 @@ async fn merged_state(cwd: &str, number: u64) -> Option<bool> {
     Some(value.get("state")?.as_str()? == "MERGED")
 }
 
-/// Deletes the head branch from the remote, and nothing else.
+/// Deletes a merged or closed PR's head branch from the remote, and nothing
+/// else.
 ///
 /// The local branch and the worktree holding it belong to the settle flow,
 /// which already deletes both; the remote ref is the one thing nothing owned.
@@ -1150,19 +1164,59 @@ async fn merged_state(cwd: &str, number: u64) -> Option<bool> {
 /// some worktree still has checked out — the same refusal that keeps
 /// [`merge_pr`] from passing `--delete-branch`.
 ///
+/// **Takes the PR, not a branch name, and that is the guard.** A fork's PR
+/// reports its head as a bare `feature`, indistinguishable from a branch of
+/// ours, so a name from the UI joined to this repo's slug can address a
+/// different branch that merely shares it — deleting our `feature` while the
+/// fork's survives. The name is therefore read back from the PR here, behind a
+/// refusal for anything cross-repository, rather than composed anywhere the
+/// two could come apart. Same seam the permission rules keep: the durable,
+/// irreversible act is resolved in Rust and the UI only names which PR.
+///
+/// Unknown counts as a fork. A shape we failed to parse must not reach a
+/// delete, so both fields fail closed.
+///
 /// The REST endpoint rather than `git push --delete`: this takes no working
 /// tree, so it deletes the branch of a session whose checkout has already gone.
 /// A ref that is already deleted answers 422 rather than success, so the button
 /// is gated on `head_ref_exists` instead of this call being safe to repeat.
 #[tauri::command]
-pub async fn delete_branch(cwd: String, branch: String) -> Result<(), String> {
+pub async fn delete_branch(cwd: String, number: u64) -> Result<(), String> {
     let (owner, repo) = repo_slug(&cwd).await?;
+
+    let out = gh(
+        &cwd,
+        &["pr", "view", &number.to_string(), "--json", "headRefName,isCrossRepository"],
+    )
+    .await?;
+
+    let branch = head_ref_to_delete(&out)?;
 
     // `refs/heads/<branch>` is a path here, so a branch name carrying slashes
     // needs no escaping — `fix/thing` addresses the ref it names.
     let path = format!("repos/{owner}/{repo}/git/refs/heads/{branch}");
 
     gh(&cwd, &["api", "-X", "DELETE", &path]).await.map(|_| ())
+}
+
+/// The branch `delete_branch` may delete, or why it may not.
+///
+/// Split out from the call so the refusal is testable without a network: it is
+/// the half that decides whether an irreversible thing happens.
+fn head_ref_to_delete(json: &str) -> Result<String, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| format!("could not read that pull request: {e}"))?;
+
+    if value.get("isCrossRepository").and_then(serde_json::Value::as_bool) != Some(false) {
+        return Err("that branch lives in a fork, so it is not this repository's to delete".into());
+    }
+
+    value
+        .get("headRefName")
+        .and_then(serde_json::Value::as_str)
+        .filter(|branch| !branch.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| "that pull request reports no head branch".to_string())
 }
 
 /// Reopens a PR closed elsewhere. There is no `close_pr` beside it on purpose:
@@ -1464,11 +1518,50 @@ mod tests {
         let live = read_prs(&out(r#"{"name":"fix/thing"}"#)).expect("parses");
         assert!(live[0].head_ref_exists);
         assert_eq!(live[0].head_ref_name, "fix/thing");
+        // Absent from this payload, so it reads as a fork and draws no button.
+        assert!(live[0].is_cross_repository);
 
         let deleted = read_prs(&out("null")).expect("parses");
         assert!(!deleted[0].head_ref_exists);
         // The name survives, which is what lets the row go on naming it.
         assert_eq!(deleted[0].head_ref_name, "fix/thing");
+    }
+
+    /// A fork's head is reported bare — `feature`, not `alice/dray:feature` —
+    /// so joining it to this repo's slug addresses *our* `feature` and deletes
+    /// the wrong branch while the fork's survives. Verified against the live
+    /// API on a real cross-repo PR (`cli/cli#13807`): `headRefName` came back
+    /// as a plain branch name with `headRepository` naming the fork, and
+    /// `headRef` non-null, so nothing else here would have stopped it.
+    #[test]
+    fn a_fork_branch_is_not_ours_to_delete() {
+        let out = r#"{"headRefName":"feature","isCrossRepository":true}"#;
+        let err = head_ref_to_delete(out).expect_err("a fork branch is refused");
+        assert!(err.contains("fork"), "{err}");
+    }
+
+    /// Both halves fail closed. An answer we could not parse, or one missing
+    /// the flag, must not reach a delete — this is the one irreversible thing
+    /// on the pane, and "we could not tell" is not permission.
+    #[test]
+    fn an_unreadable_answer_is_refused_rather_than_guessed() {
+        for out in [
+            r#"{"headRefName":"feature"}"#,
+            r#"{"headRefName":"feature","isCrossRepository":null}"#,
+            r#"{"isCrossRepository":false}"#,
+            r#"{"headRefName":"","isCrossRepository":false}"#,
+            "not json at all",
+        ] {
+            assert!(head_ref_to_delete(out).is_err(), "should refuse: {out}");
+        }
+    }
+
+    /// The name comes back from the PR rather than from the caller, so what is
+    /// deleted is what GitHub says the head is.
+    #[test]
+    fn a_same_repo_branch_resolves_to_its_own_name() {
+        let out = r#"{"headRefName":"fix/slash","isCrossRepository":false}"#;
+        assert_eq!(head_ref_to_delete(out).unwrap(), "fix/slash");
     }
 
     /// Absence has to read as *gone*, not as there. The button is the one

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -612,6 +612,7 @@ pub fn run() {
             github::prs_for_branch,
             github::pr_marks,
             github::merge_pr,
+            github::delete_branch,
             github::reopen_pr,
             github::mark_pr_ready,
             quit::confirm_quit,

--- a/apps/desktop/src/components/PrPanel.tsx
+++ b/apps/desktop/src/components/PrPanel.tsx
@@ -219,11 +219,19 @@ function PrRow({
 
       {open && (
         <div className="flex flex-col gap-4 pb-3">
-          {/* Nothing left to say about a merged PR: it has no action on this
-              panel, no base worth naming once the work is on it, and the header
-              already carries the merge glyph. The word "Merged" alone was a
-              whole row repeating the icon two lines above it. */}
+          {/* Nothing left to say about a merged PR's *readiness*: it has no base
+              worth naming once the work is on it, and the header already carries
+              the merge glyph. The word "Merged" alone was a whole row repeating
+              the icon two lines above it. */}
           {pr.state !== "MERGED" && <Readiness pr={pr} acting={acting} act={act} />}
+
+          {/* Its branch is another matter, and the one thing nothing else here
+              cleans up: settling a session deletes the local branch and the
+              worktree, never the remote ref. Drawn on merged and closed alike,
+              which is where GitHub puts it too. */}
+          {pr.state !== "OPEN" && pr.headRefExists && (
+            <BranchCleanup pr={pr} acting={acting} act={act} />
+          )}
 
           <Section
             title="Checks"
@@ -301,7 +309,75 @@ const BUSY = "disabled:opacity-100";
 
 /// The verb, while it is happening.
 function busyLabel(kind: PrAction["kind"]): string {
-  return { merge: "Merging…", reopen: "Reopening…", ready: "Marking ready…" }[kind];
+  return {
+    merge: "Merging…",
+    reopen: "Reopening…",
+    ready: "Marking ready…",
+    delete_branch: "Deleting…",
+  }[kind];
+}
+
+/// The head branch, and the one button that removes it.
+///
+/// Only ever drawn where the branch is still on the remote (`headRefExists`),
+/// because deleting a ref twice is a 422 rather than a no-op — so the guard is
+/// the row existing, not the call being safe to repeat.
+///
+/// The branch is named here and nowhere else on the pane: the header carries
+/// the *session's* branch, which for a PR opened from another checkout is a
+/// different string, and this is the one action where deleting the wrong one
+/// cannot be undone from this window.
+function BranchCleanup({
+  pr,
+  acting,
+  act,
+}: {
+  pr: PullRequest;
+  acting: boolean;
+  act: (number: number, action: PrAction) => Promise<void>;
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  return (
+    <section className="flex min-h-7 items-center gap-2 px-3">
+      <p className="min-w-0 truncate text-ui text-muted-foreground" title={pr.headRefName}>
+        <span className="text-muted-foreground/50">branch</span> {pr.headRefName}
+      </p>
+
+      <div className="ml-auto flex shrink-0 items-center gap-1.5">
+        {confirming ? (
+          <>
+            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              className={BUSY}
+              disabled={acting}
+              onClick={() => {
+                setConfirming(false);
+                void act(pr.number, { kind: "delete_branch", branch: pr.headRefName });
+              }}
+            >
+              {acting && <Loader2 className="animate-spin" />}
+              {acting ? busyLabel("delete_branch") : "Delete branch"}
+            </Button>
+          </>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            className={BUSY}
+            disabled={acting}
+            onClick={() => setConfirming(true)}
+          >
+            Delete branch
+          </Button>
+        )}
+      </div>
+    </section>
+  );
 }
 
 const METHOD_LABEL: Record<MergeMethod, string> = {

--- a/apps/desktop/src/components/PrPanel.tsx
+++ b/apps/desktop/src/components/PrPanel.tsx
@@ -229,7 +229,7 @@ function PrRow({
               cleans up: settling a session deletes the local branch and the
               worktree, never the remote ref. Drawn on merged and closed alike,
               which is where GitHub puts it too. */}
-          {pr.state !== "OPEN" && pr.headRefExists && (
+          {pr.state !== "OPEN" && pr.headRefExists && !pr.isCrossRepository && (
             <BranchCleanup pr={pr} acting={acting} act={act} />
           )}
 
@@ -321,7 +321,9 @@ function busyLabel(kind: PrAction["kind"]): string {
 ///
 /// Only ever drawn where the branch is still on the remote (`headRefExists`),
 /// because deleting a ref twice is a 422 rather than a no-op — so the guard is
-/// the row existing, not the call being safe to repeat.
+/// the row existing, not the call being safe to repeat. And never for a fork's
+/// branch, which is not this repo's to delete; the backend refuses those too,
+/// so this decides whether to *offer* rather than whether it is allowed.
 ///
 /// The branch is named here and nowhere else on the pane: the header carries
 /// the *session's* branch, which for a PR opened from another checkout is a
@@ -357,7 +359,7 @@ function BranchCleanup({
               disabled={acting}
               onClick={() => {
                 setConfirming(false);
-                void act(pr.number, { kind: "delete_branch", branch: pr.headRefName });
+                void act(pr.number, { kind: "delete_branch" });
               }}
             >
               {acting && <Loader2 className="animate-spin" />}

--- a/apps/desktop/src/hooks/usePullRequest.ts
+++ b/apps/desktop/src/hooks/usePullRequest.ts
@@ -97,7 +97,11 @@ export function prTabVisible(prs: PullRequest[], error: PrUnavailable | null): b
 export type PrAction =
   | { kind: "merge"; method: MergeMethod }
   | { kind: "reopen" }
-  | { kind: "ready" };
+  | { kind: "ready" }
+  /// Carries the branch rather than letting the backend look it up, so the ref
+  /// deleted is the exact string the row named — this is the one action here
+  /// where hitting the wrong branch cannot be undone from this window.
+  | { kind: "delete_branch"; branch: string };
 
 type State = {
   /// Every PR opened from this branch, open ones first. Usually one, sometimes
@@ -290,6 +294,9 @@ export function usePullRequest(
       try {
         if (action.kind === "merge") {
           await invoke("merge_pr", { cwd, number, method: action.method });
+        } else if (action.kind === "delete_branch") {
+          // Takes no number: it deletes a ref, and the PR only ever named it.
+          await invoke("delete_branch", { cwd, branch: action.branch });
         } else {
           const command = action.kind === "reopen" ? "reopen_pr" : "mark_pr_ready";
           await invoke(command, { cwd, number });

--- a/apps/desktop/src/hooks/usePullRequest.ts
+++ b/apps/desktop/src/hooks/usePullRequest.ts
@@ -98,10 +98,10 @@ export type PrAction =
   | { kind: "merge"; method: MergeMethod }
   | { kind: "reopen" }
   | { kind: "ready" }
-  /// Carries the branch rather than letting the backend look it up, so the ref
-  /// deleted is the exact string the row named — this is the one action here
-  /// where hitting the wrong branch cannot be undone from this window.
-  | { kind: "delete_branch"; branch: string };
+  /// Carries no branch. A fork's head is reported bare, so a name from here
+  /// joined to this repo addresses a branch that merely shares it — the
+  /// backend reads the head off the PR and refuses anything cross-repository.
+  | { kind: "delete_branch" };
 
 type State = {
   /// Every PR opened from this branch, open ones first. Usually one, sometimes
@@ -295,8 +295,7 @@ export function usePullRequest(
         if (action.kind === "merge") {
           await invoke("merge_pr", { cwd, number, method: action.method });
         } else if (action.kind === "delete_branch") {
-          // Takes no number: it deletes a ref, and the PR only ever named it.
-          await invoke("delete_branch", { cwd, branch: action.branch });
+          await invoke("delete_branch", { cwd, number });
         } else {
           const command = action.kind === "reopen" ? "reopen_pr" : "mark_pr_ready";
           await invoke(command, { cwd, number });

--- a/apps/desktop/src/lib/pr.test.ts
+++ b/apps/desktop/src/lib/pr.test.ts
@@ -28,6 +28,7 @@ function pr(over: Partial<PullRequest> = {}): PullRequest {
     baseRefName: "main",
     headRefName: "feature",
     headRefExists: true,
+    isCrossRepository: false,
     mergeable: "MERGEABLE",
     mergeStateStatus: "CLEAN",
     reviewDecision: null,

--- a/apps/desktop/src/lib/pr.test.ts
+++ b/apps/desktop/src/lib/pr.test.ts
@@ -27,6 +27,7 @@ function pr(over: Partial<PullRequest> = {}): PullRequest {
     author: "a",
     baseRefName: "main",
     headRefName: "feature",
+    headRefExists: true,
     mergeable: "MERGEABLE",
     mergeStateStatus: "CLEAN",
     reviewDecision: null,

--- a/apps/desktop/src/types/events.ts
+++ b/apps/desktop/src/types/events.ts
@@ -664,6 +664,12 @@ export type PullRequest = { number: number, title: string, url: string,
  */
 state: string, isDraft: boolean, author: string, baseRefName: string, headRefName: string, 
 /**
+ * Whether that branch is still on the remote. `headRefName` survives the
+ * branch itself — a merged PR keeps naming the branch it came from — so
+ * the name cannot answer this and `headRef` going null is what does.
+ */
+headRefExists: boolean, 
+/**
  * `MERGEABLE`, `CONFLICTING`, or `UNKNOWN` while GitHub is still working
  * the merge out — which it starts doing lazily, on being asked.
  */

--- a/apps/desktop/src/types/events.ts
+++ b/apps/desktop/src/types/events.ts
@@ -670,6 +670,16 @@ state: string, isDraft: boolean, author: string, baseRefName: string, headRefNam
  */
 headRefExists: boolean, 
 /**
+ * Whether the head branch lives in a fork rather than in this repo.
+ *
+ * `head_ref_name` is bare either way — a PR from `alice/dray:feature`
+ * reports `feature` — so the name cannot be told apart from a branch of
+ * our own, and joining it to this repo's slug addresses a *different*
+ * branch that merely shares its name. Unknown reads as `true`, because
+ * the only thing this gates is a deletion.
+ */
+isCrossRepository: boolean, 
+/**
  * `MERGEABLE`, `CONFLICTING`, or `UNKNOWN` while GitHub is still working
  * the merge out — which it starts doing lazily, on being asked.
  */


### PR DESCRIPTION
## TLDR for human

- Adds a **Delete branch** button to merged and closed PRs in the panel, deleting the remote ref only.

---

Fixes DRA-65

Found while verifying DRA-54. Squash and merge works — PR #34 landed as a single-parent commit with its three branch commits collapsed. The branch surviving it is not a merge bug, it is a missing affordance: **nothing in Dray ever deleted a remote ref.** `remove_worktree` ends in `git branch -D`, which is local only, and `merge_pr` deliberately passes no `--delete-branch`.

### Why a button and not `--delete-branch`

The existing reason holds: a worktree session has that branch checked out, so `gh`'s local half fails and cleanup breaks *after* the merge has already landed. It would also only ever fire for merges made from this panel, leaving every branch merged on the web untouched.

A separate button is what GitHub does too — "Squash and merge" and "Delete branch" are two decisions there, because the merge method describes how commits land on the base and never the branch's lifetime.

### Shape

- **Merged and closed alike**, which is where GitHub puts it. The no-Close rule stands: this removes a branch behind a decision already made, it does not abandon anything.
- **Remote ref only.** The local branch and worktree belong to the settle flow, which already deletes both. Keeping the halves apart also sidesteps `git branch -D` refusing a branch some worktree still holds.
- **Arm-then-confirm**, the same two-step the merge button and sidebar delete use. There is no Restore here, which is what makes GitHub's one-click trade wrong for us.
- **The row names the branch**, because the header carries the *session's* branch and for a PR opened from another checkout that is a different string.

### `headRef` is the guard, and it had to be

`headRefName` outlives the branch — a merged PR goes on naming the one it came from — so the name cannot answer whether the ref is still there. `headRef` going null is what does, and it costs nothing: it sits on the `pullRequests` node selection `QUERY` already makes.

That matters because **deleting a ref twice answers HTTP 422, not success** — unlike `stop_task`, this one cannot swallow its own repeat. So the row existing is the guard, and it retires itself: `act` refetches after every write, `headRef` comes back null, the button stops drawing.

A missing `headRef` reads as **gone**, not as there. Under-offering costs a trip to GitHub; over-offering draws a destructive button over a branch that may not exist. Pinned by test.

### Verified against the live API

Not just unit-tested — run against real PRs on a scratch repo:

- Deleting a merged PR's branch through the exact call the command makes: exit 0, and `headRef` flipped `feat-squash` → `NULL` while `headRefName` stayed put.
- A slash-carrying branch (`fix/slash-probe`) deletes through the same unescaped path form, so `refs/heads/<branch>` needs no encoding.
- A second delete of an already-gone ref: `HTTP 422 Reference does not exist`.

### Tests

297 Rust, 217 frontend, clean `tsc && vite build`. Two new Rust tests cover `headRef` present/null and the missing-field direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
