### PR TITLE
feat(composer): add Run server button

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -970,6 +970,8 @@ function App() {
               useWorktree={useWorktree}
               onToggleWorktree={() => setUseWorktree((v) => !v)}
               onAttach={() => void pickAttachments(selectedSessionId)}
+              // Straight out as a prompt, like the handoff row's own buttons.
+              onRunServer={(prompt) => void handleSendMsg(prompt)}
               contextUsage={contextUsage}
               isNewSession={!selectedSessionId}
             />

--- a/apps/desktop/src/components/composer/ComposerToolbar.tsx
+++ b/apps/desktop/src/components/composer/ComposerToolbar.tsx
@@ -6,6 +6,7 @@ import ContextMeter from "@/components/composer/ContextMeter";
 import ModelSelector from "@/components/composer/ModelSelector";
 import PermissionSelector from "@/components/composer/PermissionSelector";
 import ProjectSelector from "@/components/composer/ProjectSelector";
+import RunServerButton from "@/components/composer/RunServerButton";
 import WorktreeToggle from "@/components/composer/WorktreeToggle";
 import { Button } from "@/components/ui/button";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
@@ -50,6 +51,11 @@ export type ComposerToolbarProps = {
   /// handed to `ChatInput` as an opaque node, so the two cannot share props.
   onAttach: () => void;
 
+  /// Sends the Run server prompt, exactly as if it had been typed. The button
+  /// owns the wording — see [RUN_SERVER_PROMPT] — so this is the same shape
+  /// `HandoffRow` hands its prompts back through.
+  onRunServer: (prompt: string) => void;
+
   /// How full the model's context is, or `null` before any turn has reported
   /// it. Sits at the far end of the row rather than among the pickers: it
   /// reports rather than sets, and nothing here changes it.
@@ -85,6 +91,7 @@ export default function ComposerToolbar({
   useWorktree,
   onToggleWorktree,
   onAttach,
+  onRunServer,
   contextUsage,
   isNewSession,
 }: ComposerToolbarProps) {
@@ -174,12 +181,20 @@ export default function ComposerToolbar({
       <PermissionSelector value={permissionMode} onChange={onPermissionModeChange} />
 
       {/* `ml-auto` rather than a spacer, so a long branch name still gets the
-          whole middle of the row and this stays pinned to the right edge. */}
-      {contextUsage && (
-        <div className="ml-auto">
+          whole middle of the row and this stays pinned to the right edge. It
+          sits on the pair rather than on the meter because the meter is absent
+          until a turn has reported one, and the button must not slide left
+          across the row when the first turn lands.
+
+          Run server needs a session to send into, so it is the mirror of the
+          three pickers above: those exist only before one starts, this only
+          after. */}
+      <div className="ml-auto flex items-center gap-0.5">
+        {!isNewSession && <RunServerButton onSend={onRunServer} />}
+        {contextUsage && (
           <ContextMeter used={contextUsage.used} max={contextUsage.max} />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/components/composer/RunServerButton.tsx
+++ b/apps/desktop/src/components/composer/RunServerButton.tsx
@@ -1,0 +1,43 @@
+import { Play } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { RUN_SERVER_PROMPT } from "@/lib/runServer";
+
+/// Sends [RUN_SERVER_PROMPT] as an ordinary prompt — the HandoffRow bargain, in
+/// the toolbar rather than parked behind it. A click is the reader typing
+/// "start the dev server" without typing it, and what it removes is a `cd`: a
+/// session's worktree sits at `<project>/.claude/worktrees/<name>`, a path that
+/// had to be found and pasted into a terminal once per session.
+///
+/// **No Stop beside it, and none wanted.** The server arrives as a `local_bash`
+/// background task, so the orb under the transcript already says one is running
+/// and the subagent panel already stops it. A second stop here would be a
+/// second owner of one process.
+///
+/// Nothing guards a second press. A send during a turn queues like any other,
+/// so the second one lands in a fresh turn where the agent can see its own
+/// server already running and say so.
+export default function RunServerButton({
+  onSend,
+}: {
+  onSend: (prompt: string) => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => onSend(RUN_SERVER_PROMPT)}
+          aria-label="Run server"
+          className="text-muted-foreground"
+        >
+          <Play />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top">Run server</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/desktop/src/lib/runServer.test.ts
+++ b/apps/desktop/src/lib/runServer.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { RUN_SERVER_PROMPT } from "./runServer";
+
+describe("RUN_SERVER_PROMPT", () => {
+  // The clause the button rests on. Without it the CLI runs the server in a
+  // foreground Bash, which times out and kills the thing it just started.
+  it("asks for the background", () => {
+    expect(RUN_SERVER_PROMPT).toContain("in the background");
+  });
+
+  // Vague on purpose: the agent picks the server by reading the repo, and
+  // anything named here is a spec that is wrong for some other stack.
+  it("names no command, port or URL", () => {
+    expect(RUN_SERVER_PROMPT).not.toMatch(/localhost|https?:|pnpm|npm|yarn|cargo|:\d/);
+  });
+});

--- a/apps/desktop/src/lib/runServer.ts
+++ b/apps/desktop/src/lib/runServer.ts
@@ -1,0 +1,18 @@
+/// What the composer's Run server button sends, verbatim, as if it had been
+/// typed.
+///
+/// Deliberately vague about *which* server and *how*. The agent reads the repo,
+/// so a monorepo with three apps, a Tauri app that opens a window instead of
+/// serving a URL, and a stack nobody has heard of all resolve from context —
+/// which is why this needs no config file and no stack detection behind it.
+///
+/// **"in the background" is the one clause that is not vague, and it is
+/// load-bearing.** Handed a bare "run server", the CLI runs `pnpm dev` in a
+/// *foreground* Bash, which blocks until that tool's own timeout, reports a
+/// timeout, and takes the server down with it. Intermittent, and it reads as
+/// the button being broken rather than as a prompt being wrong.
+///
+/// No URL clause either: a Tauri app, a worker or a CLI has none, and where
+/// there is one the dev server prints it into the tool output the transcript
+/// already renders.
+export const RUN_SERVER_PROMPT = "start the dev server in the background";


### PR DESCRIPTION
A button in the composer's control row, beside the context ring, that sends `start the dev server in the background` as an ordinary prompt.

**No backend.** It is the HandoffRow bargain — a click is the reader typing a word without typing it — and everything after the send already exists: the agent starts the server as a `local_bash` background task, the orb under the transcript shows it, and the subagent panel stops it. No Stop button here, because a second one would be a second owner of one process.

The pain it removes is a `cd`. A session's worktree sits at `<project>/.claude/worktrees/<name>`, so running the server by hand meant finding and pasting that path into a terminal, per session, every time.

**Which server is the agent's problem, and that's the feature.** A monorepo with three apps, a Tauri app that opens a window rather than serving a URL, a stack nobody has heard of — the agent reads the repo and picks. That is the stack detection, at a cost of zero lines, and it is why the config-file version of this was dropped.

**"in the background" is load-bearing.** Handed a bare `run server`, the CLI runs `pnpm dev` in a *foreground* Bash, which blocks until that tool's own timeout, reports a timeout, and takes the server down with it — intermittently, which reads as the button being broken rather than the prompt being wrong. The prompt lives in `lib/runServer.ts` with a test pinning that clause, and a second pinning that it names no command, port or URL.

Two smaller decisions:

- **Drawn only once a session exists**, the mirror of the three pickers that exist only before one starts. Nothing to send into before that, and it as an opening prompt makes a session titled after it that does nothing else.
- **`ml-auto` moved onto the button-and-meter pair**, not the meter alone. The meter is absent until a turn reports context, so leaving it there slid the button left across the row the moment the first turn landed.

Nothing guards a second press: a send during a turn queues like any other, so the second lands in a fresh turn where the agent can see its own server running and say so.

Fixes DRA-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)
