### PR TITLE
Tell the agent to link issues; name what the branch button copies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,15 @@ File give Claude Code (claude.ai/code) guidance for work with code in this repo.
 
 **Housekeeping take no issue.** CLAUDE.md, plan note, tooling config — thing changing how we work, not what ship. Issue there = noise.
 
+**Minor update take no issue either.** Tooltip wording, copy tweak, one-line prompt change — issue there cost more to file than change take to make. Several small thing landing in one PR = one issue at most, never one each.
+
 **Description over ~1000 character open with `## TLDR for human`, closed by `---`.** One line per thing worked on, even when only one. Shorter description need none — it already scan faster than its own summary.
 
 **Status:** start → `In Progress`. After that, leave it — GitHub integration move issue to `In Review` on PR open and `Done` on merge, so setting either by hand = noise. **Exception: work pushed straight to `main`.** No PR = nothing for integration to read, so set `Done` yourself.
 
 **PR carry issue id so Linear link itself.** Body (`Fixes DRA-123`) or branch name — integration read both. Worktree branch = `worktree-<name>` minted by CLI, so body = reliable slot. Id = what arm the whole status rule above; PR without one leave issue sitting `In Progress` forever.
+
+**PR nobody need review carry `no-review` label.** Copy tweak, doc, prompt wording, config — label keep review bot off diff with nothing to find. Add at open (`gh pr create --label no-review`), since review fire on open. Anything touching behaviour = no label.
 
 **One team, `Dray`. Prefix `DRA-`. Assign every issue to `yogesh`.**
 

--- a/apps/desktop/src-tauri/src/harness/claude_code/system_prompt.md
+++ b/apps/desktop/src-tauri/src/harness/claude_code/system_prompt.md
@@ -30,3 +30,7 @@ You run inside Dray, an interactive desktop app. Your replies render as markdown
 # Orchestration
 
 When the user wants several independent pieces of work going at once, each can have its own Dray session, branch and worktree. The `dray` CLI creates them; run `dray --help`, or install it with `curl -fsSL https://www.drayhq.com/install.sh | sh` if it is missing.
+
+# Issues
+
+When this session creates a Linear issue, or works on one, link it: `dray issue link "$DRAY_SESSION_ID" DRA-53 --title "<title>" --url "<url>"`.

--- a/apps/desktop/src/components/layout/SessionHeader.tsx
+++ b/apps/desktop/src/components/layout/SessionHeader.tsx
@@ -106,11 +106,10 @@ export default function SessionHeader({
               {branch}
             </button>
           </TooltipTrigger>
-          {/* The path, because it is the thing being copied and the one thing
-              here that is not already on screen. */}
-          <TooltipContent className="max-w-sm break-all">
-            {copied ? "Copied" : cwd}
-          </TooltipContent>
+          {/* What the click does, not the path itself: a branch name says
+              nothing about being a button, and a long path drawn on every
+              hover buries that. The path is on the clipboard a click later. */}
+          <TooltipContent>{copied ? "Copied" : "Click to copy the working directory"}</TooltipContent>
         </Tooltip>
       )}
     </div>


### PR DESCRIPTION
Two small things.

- **System prompt** gains one line under `# Issues`: link a Linear issue this session creates or works on with `dray issue link "$DRAY_SESSION_ID" …`. The `dray` skill already carries the detail, but it is only read when an agent is fanning work out — a session that starts from a plain description and files an issue later never fetches it.
- **Session header**: the branch button's tooltip said the working directory. It now says what clicking does. The path stays on `aria-label` and on the clipboard.

Plus two CLAUDE.md rules: a PR nobody needs to review carries `no-review`, and a minor update takes no Linear issue.

Fixes DRA-75

🤖 Generated with [Claude Code](https://claude.com/claude-code)