### PR TITLE
Render a Skill call from its own fields

### DIFF
--- a/apps/desktop/src/components/chat/ToolCall.tsx
+++ b/apps/desktop/src/components/chat/ToolCall.tsx
@@ -6,7 +6,7 @@ import DiffView from "@/components/chat/DiffView";
 import ImageRow from "@/components/chat/ImageRow";
 import { cn } from "@/lib/utils";
 import { countChanges, editSides, readRange } from "@/lib/diff";
-import { formatToolInput, isRoutineError, toolLabel, toolSummary } from "@/lib/tools";
+import { formatToolInput, isRoutineError, skillBrief, toolLabel, toolSummary } from "@/lib/tools";
 import type { ToolResult, ToolType } from "@/types/events";
 import type { JsonValue } from "@/types/serde_json/JsonValue";
 
@@ -43,6 +43,11 @@ const EDIT_FIELDS = [
 
 // Same idea for a ranged read: the gutter already shows which lines these are.
 const READ_FIELDS = [...SUMMARY_FIELDS, "offset", "limit"];
+
+// A `Skill` call carries two fields and the row already draws both — the name in
+// the header, the brief as prose beneath it — so its argument body would be the
+// same call written out twice. Anything the tool grows later still shows.
+const SKILL_FIELDS = [...SUMMARY_FIELDS, "skill", "args"];
 
 // Long results are the norm — reads come back in the thousands of characters —
 // so expanding shows a head and the rest scrolls rather than pushing the
@@ -139,7 +144,18 @@ export default function ToolCall({
   // and the answer given, which is prose and reads as prose.
   const asked = name === "AskUserQuestion" && !rawInput;
 
-  const omit = sides ? EDIT_FIELDS : range ? READ_FIELDS : SUMMARY_FIELDS;
+  // A `Skill` call hands the skill a brief in the model's own words, so it reads
+  // as prose and not as arguments. Null is the common case — a skill named with
+  // nothing beside it — and then the row has nothing to open at all.
+  const brief = name === "Skill" && !rawInput ? skillBrief(input) : null;
+
+  const omit = sides
+    ? EDIT_FIELDS
+    : range
+      ? READ_FIELDS
+      : name === "Skill"
+        ? SKILL_FIELDS
+        : SUMMARY_FIELDS;
   const body = inert || asked ? null : rawInput ?? formatToolInput(input, omit);
 
   // A successful edit's result is boilerplate ("The file ... has been updated
@@ -147,7 +163,12 @@ export default function ToolCall({
   // read repeats its own output verbatim. Failures always show — that text is
   // the only place the reason lives.
   const echoesViewer = (sides !== null || range !== null || inert) && !failed;
-  const shownOutput = echoesViewer ? "" : output;
+
+  // A `Skill` launch answers "Launching skill: <name>", which is the row's own
+  // label and summary read back. A refusal still shows — that text is the only
+  // place the reason lives.
+  const echoesHeader = name === "Skill" && !failed;
+  const shownOutput = echoesViewer || echoesHeader ? "" : output;
   const shown =
     shownOutput.length > PREVIEW_CHARS
       ? `${shownOutput.slice(0, PREVIEW_CHARS)}…`
@@ -156,7 +177,8 @@ export default function ToolCall({
   // Output stays behind the expander regardless of length. Auto-showing short
   // results only made rows inconsistent — some opened, some didn't, with no
   // visible reason why.
-  const expandable = Boolean(body) || Boolean(shown) || sides !== null || range !== null;
+  const expandable =
+    Boolean(body) || Boolean(shown) || Boolean(brief) || sides !== null || range !== null;
 
   return (
     <div className="group/tool flex flex-col gap-1.5">
@@ -240,6 +262,12 @@ export default function ToolCall({
       {open && sides && <DiffView sides={sides} />}
 
       {open && range && <CodeView range={range} />}
+
+      {/* Unboxed and sans, for the reason an answered question is: this is a
+          sentence somebody wrote, and a code box frames prose as output. */}
+      {open && brief && (
+        <p className="whitespace-pre-wrap text-chat text-foreground/90">{brief}</p>
+      )}
 
       {open && body && (
         <pre className="overflow-x-auto rounded-md bg-surface-raised px-2.5 py-2 font-mono text-tool text-muted-foreground">

--- a/apps/desktop/src/lib/streaming.test.ts
+++ b/apps/desktop/src/lib/streaming.test.ts
@@ -113,6 +113,15 @@ describe("streamingCall", () => {
     expect(streamingCall("Write", '{"file_path":"/a/b/part').target).toBe(null);
   });
 
+  // `args` lands first on the wire and is a paragraph on a long brief, so the
+  // preview stays on the generic label until the short key behind it closes.
+  it("names a Skill once its name has landed, not while its brief streams", () => {
+    expect(streamingCall("Skill", '{"args":"screenshot localhost:1420').target).toBe(null);
+    expect(
+      streamingCall("Skill", '{"args":"screenshot localhost:1420","skill":"agent-browser"').target,
+    ).toBe("agent-browser");
+  });
+
   it("reads nothing out of an empty prefix", () => {
     expect(streamingCall("Write", "")).toEqual({ target: null, added: null });
   });

--- a/apps/desktop/src/lib/streaming.ts
+++ b/apps/desktop/src/lib/streaming.ts
@@ -113,6 +113,7 @@ const TARGET_KEYS: [key: string, path: boolean][] = [
   ["query", false],
   ["url", false],
   ["description", false],
+  ["skill", false],
 ];
 
 /// Where a whole-file payload lives: `Write` calls it `content`, `NotebookEdit`

--- a/apps/desktop/src/lib/tools.test.ts
+++ b/apps/desktop/src/lib/tools.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it } from "vitest";
 
-import { isRoutineError } from "./tools";
+import { groupLabel, isRoutineError, skillBrief, streamingLabel, toolLabel, toolSummary } from "./tools";
+
+// Every input here is a real `Skill` call taken out of `~/.dray/sessions`. The
+// harness classifies the tool as `other` and leaves `title` null, so the name
+// and the brief are the whole of what the row has to work with.
+describe("a Skill call", () => {
+  it("names the skill, not the tool", () => {
+    expect(toolSummary("Skill", "other", { skill: "caveman-commit" })).toBe("caveman-commit");
+    expect(
+      toolSummary("Skill", "other", { args: "screenshot localhost:1420", skill: "agent-browser" }),
+    ).toBe("agent-browser");
+  });
+
+  it("reads as a launch in both tenses", () => {
+    expect(toolLabel("Skill", true)).toBe("Launching");
+    expect(toolLabel("Skill", false)).toBe("Launched");
+    expect(groupLabel("Skill", 2, false)).toBe("Launched 2 skills");
+    expect(streamingLabel("Skill")).toBe("Launching a skill");
+  });
+
+  it("takes the brief only where one was written", () => {
+    expect(skillBrief({ args: "screenshot localhost:1420", skill: "agent-browser" })).toBe(
+      "screenshot localhost:1420",
+    );
+    expect(skillBrief({ skill: "caveman-commit" })).toBeNull();
+    expect(skillBrief({ args: "   ", skill: "caveman-commit" })).toBeNull();
+  });
+});
+
 
 // Every string here is a real `Bash` error taken out of `~/.dray/sessions`,
 // including the "Exit code N" prefix a shell failure actually arrives with —

--- a/apps/desktop/src/lib/tools.ts
+++ b/apps/desktop/src/lib/tools.ts
@@ -17,6 +17,10 @@ export function toolSummary(
   toolType: ToolType,
   input: JsonValue,
 ): string | null {
+  // Tool-keyed rather than field-keyed: the harness classifies `Skill` as
+  // `other`, and its only identifying field is the skill's own name.
+  if (name === "Skill") return field(input, "skill");
+
   const path = field(input, "file_path") ?? field(input, "path") ?? field(input, "notebook_path");
   if (path) return shortenPath(path);
 
@@ -69,7 +73,16 @@ const TOOL_VERBS: Record<string, Verbs> = {
   WebFetch: ["Fetching", "Fetched", "page"],
   WebSearch: ["Searching web", "Searched web", "query"],
   AskUserQuestion: ["Asking", "Asked", "question"],
+  Skill: ["Launching", "Launched", "skill"],
 };
+
+/// The brief a `Skill` call was given — the sentence the model wrote for the
+/// skill, not an argument to it. Null where the model named a skill and left it
+/// to read its own instructions, which is the common case.
+export function skillBrief(input: JsonValue): string | null {
+  const args = field(input, "args")?.trim();
+  return args ? args : null;
+}
 
 /// The label for a single tool-call row. `pending` picks the tense — a live call
 /// reads "Reading", a settled one "Read".
@@ -172,6 +185,9 @@ export function toolArgument(input: JsonValue): string | null {
     field(input, "pattern") ??
     field(input, "query") ??
     field(input, "url") ??
+    // Field-keyed where `toolSummary` keys on the tool: the card sees raw wire
+    // input and no name, and a `skill` string names a skill whatever carries it.
+    field(input, "skill") ??
     null
   );
 }


### PR DESCRIPTION
The harness classifies `Skill` as `other` and leaves `title` null, so the row read a bare **Skill** over `{"args":…,"skill":…}` as JSON, followed by a result that said `Launching skill: X` — the header again.

Now it draws from the two fields the call actually carries:

- Row reads **Launched `agent-browser`**. Verbs in `TOOL_VERBS`, so it groups ("Launched 2 skills") and previews ("Launching a skill") too.
- Expanding shows the brief (`args`) as prose — unboxed and sans, like an answered question. A skill named with no brief has nothing to open and gets no caret.
- The result is dropped on success, since it restates the row. A refusal still shows: that text is the only place the reason lives.
- `skill` joins the streaming target keys, so the name appears as soon as it lands instead of after the brief finishes. Field-keyed and last, so a tool carrying `command` too keeps that.

Inputs in the tests are real `Skill` calls out of `~/.dray/sessions`.

Fixes DRA-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)