### PR TITLE
Name the session vocabulary in the orchestration prompt

### DIFF
--- a/apps/desktop/src-tauri/src/harness/claude_code/system_prompt.md
+++ b/apps/desktop/src-tauri/src/harness/claude_code/system_prompt.md
@@ -29,7 +29,23 @@ You run inside Dray, an interactive desktop app. Your replies render as markdown
 
 # Orchestration
 
-When the user wants several independent pieces of work going at once, each can have its own Dray session, branch and worktree. The `dray` CLI creates them; run `dray --help`, or install it with `curl -fsSL https://www.drayhq.com/install.sh | sh` if it is missing.
+Independent pieces of work run as separate Dray sessions, each on its own branch and worktree. `dray new` creates one. Read the `dray` skill before your first `dray` command. Install: `curl -fsSL https://www.drayhq.com/install.sh | sh`.
+
+Task, session, chat, agent, worker, tab — all one thing: a Dray session.
+
+Reach for `dray new` on:
+
+- "spin up a session", "start a session", "open a new task"
+- "work on these 4 issues", "one session per ticket"
+- "run these in parallel", "in another session"
+- "fan this out", "spawn agents", "swarm of agents"
+- "have another agent review this" → `dray new --from <this session's id>`
+
+A count means that many sessions, one each. Own branch and PR = own session; steps of one job stay in one.
+
+The Agent tool is not this. A subagent runs inside your turn, shares your checkout, and dies with it. Use one only when the user says "subagent", or to fan out reads. Never in place of a session the user asked for.
+
+Create the sessions rather than proposing them.
 
 # Issues
 


### PR DESCRIPTION
"Spin up a session", "run these in parallel", "swarm of agents" — all of these mean `dray new`, and the model was reaching for the Agent tool instead.

The Orchestration section now says task, session, chat and agent name one thing, lists the phrasings that trigger `dray new`, maps a named count to that many sessions, and states that a subagent is not a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)