### PR TITLE
Fork guards on the turn, not on background tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -784,7 +784,7 @@ Drawn with **no backdrop** and at `size-5`, both against component's own default
 ## Forking a session
 
 **Fork = one conversation carried on twice.** Sidebar row's right-click menu hold
-it, as submenu: **Fork here** and **Fork in new worktree**. Both copy whole
+it, as submenu: **Fork in new worktree** and **Fork here**. Both copy whole
 conversation — CLI have no way to fork at chosen message, `--fork-session` take
 session and nothing narrower — so two item differ only in *where* copy run.
 
@@ -803,12 +803,24 @@ what let frontend mint fork's id like it mint new session's, keeping one rule
 have to read it back off first `result`, which arrive turn later. Also verified:
 CLI write fork **complete standalone transcript** holding parent's history, so
 `--resume <fork>` after work with no reference to parent; and `-w` combine with
-all three, which what make second menu item possible at all.
+all three, which what make worktree item possible at all.
 
-**Refused while parent busy.** CLI fork by *reading* parent's transcript, which
-live child still appending to, so fork taken mid-turn inherit half a turn.
-Backend check `has_outstanding_work()`, submenu trigger disable on `in_progress` — second one
-save trip, not the guard.
+**Refused while parent's *turn* in flight, and nothing wider.** CLI fork by
+*reading* parent's transcript, which live child appending to mid-turn, so fork
+taken there inherit half a turn. Background task outstanding = not that case: it
+append *after* turn ended (how subagent report back), and fork = copy at point in
+time. Backend check `turn_in_flight()`, submenu trigger disable on
+`in_progress` — **same question**, since `InProgress` *is* `turn_in_flight` by
+construction, pinned by test in `session.rs`; frontend state rule once in
+[fork.ts](apps/desktop/src/lib/fork.ts) rather than inline in menu.
+
+Guard was `has_outstanding_work()` and that = bug: it safe-to-replace-the-child
+question, and fork replace no child — it borrowed guard written for path that
+kill one (effort respawn, update install, which keep wide reading). `local_bash`
+task never end, so session running dev server could not be forked again for rest
+of its life, **while menu item stay enabled** — same `result` had already moved
+status to `completed`. Two guard disagreeing = what made Fork read as broken
+rather than busy, which why they now answer one question.
 
 **Refused too where parent have no conversation.** Index entry written before
 spawn, so session whose child failed to start sit in sidebar with empty log and
@@ -885,7 +897,7 @@ either (`fork_from` cleared once CLI carry it out), so counting generation in
 title would promise more than rest of feature keep.
 
 **Submenu's digit picks by position, and the listener sits above the portal
-it names rows in.** `1`/`2` on Fork here / Fork in new worktree, same rule
+it names rows in.** `1`/`2` on Fork in new worktree / Fork here, same rule
 `VIEW_TABS` accelerator follow. `SubContent` render through Radix portal, so
 handler placed there only fire once focus — not just open submenu — move
 inside it; hovering trigger alone leave focus behind on trigger. Listener
@@ -1163,7 +1175,7 @@ Several things deliberately unfinished — don't mistake for bugs:
 
   **Max come from that same map's `contextWindow`**, so no window hardcoded per model and million-token model need no code; mapper remember `init`'s `model` to index it, since subagent on second model put two entries in it. Compaction clear tracked reading, so zeroed `result` landing _after_ boundary can't carry pre-compaction figure over `post_tokens` just published.
 
-- **Session status = state machine in `session.rs`, and it follow the turn alone.** `StatusTracker`: send or `init` → `in_progress`; `result` → `completed`, whatever background tasks outstanding. Background subagent run past `result` and CLI open promptless `init` later to report findings — that `init` reopen `in_progress` on own, so nothing gained by holding. Holding *was* the rule and it hung every session running a dev server, `Bash(run_in_background)` or `Monitor` — all `local_bash` (captured in `background_bash_monitor.jsonl`), and none ever end on own — until reader clicked Stop. Task set recorded beside status for two thing only: `has_outstanding_work()` (model call open *or* tasks outstanding) guard child-replacing paths — effort respawn, fork, update install — and Stop's `stop_task` fan-out name each id. Frontend keep tasks in live `tasksBySession` map, not off log: task outlive its turn, so `busy` no longer say whether log's last set current. `read_stdout` mint empty `background_tasks_changed` when child exit, since CLI cannot announce own death and last set would stand forever — emitted, **never logged**: live map need no closing entry, and it run after delete removed the file, where append would recreate it. Turn ending with task open keep its asks (task's subagent may be one asking); drain with no turn running clear them. `buildTranscript` take live task ids and keep spawning call pending while its task live — join = `SubagentRun.taskId`, since `task_id` ≠ `tool_use_id`. `completed` mean finished _and unread_: frontend clear it to `idle` when user view session (`mark_session_idle`), and persisted `in_progress` reset to `idle` at startup since no child survive restart. Status changes reach frontend as `session_status` events — derived state, never written to `.jsonl` log.
+- **Session status = state machine in `session.rs`, and it follow the turn alone.** `StatusTracker`: send or `init` → `in_progress`; `result` → `completed`, whatever background tasks outstanding. Background subagent run past `result` and CLI open promptless `init` later to report findings — that `init` reopen `in_progress` on own, so nothing gained by holding. Holding *was* the rule and it hung every session running a dev server, `Bash(run_in_background)` or `Monitor` — all `local_bash` (captured in `background_bash_monitor.jsonl`), and none ever end on own — until reader clicked Stop. Task set recorded beside status for two thing only: `has_outstanding_work()` (model call open *or* tasks outstanding) guard child-replacing paths — effort respawn, update install — and Stop's `stop_task` fan-out name each id. Fork **not** among them: it replace no child, so it guard on `turn_in_flight()` alone (see _Forking a session_). Frontend keep tasks in live `tasksBySession` map, not off log: task outlive its turn, so `busy` no longer say whether log's last set current. `read_stdout` mint empty `background_tasks_changed` when child exit, since CLI cannot announce own death and last set would stand forever — emitted, **never logged**: live map need no closing entry, and it run after delete removed the file, where append would recreate it. Turn ending with task open keep its asks (task's subagent may be one asking); drain with no turn running clear them. `buildTranscript` take live task ids and keep spawning call pending while its task live — join = `SubagentRun.taskId`, since `task_id` ≠ `tool_use_id`. `completed` mean finished _and unread_: frontend clear it to `idle` when user view session (`mark_session_idle`), and persisted `in_progress` reset to `idle` at startup since no child survive restart. Status changes reach frontend as `session_status` events — derived state, never written to `.jsonl` log.
 - **Codex = stub.** `Harness::Codex` parse from frontend, but `Session::init` bail on it.
 - **Composer toolbar = session's control surface.** [composer/](apps/desktop/src/components/composer) hold one component per control; `ComposerToolbar` hide project, branch, worktree toggle once session exist. `ChatInput` take row as `ReactNode` so it keep owning layout and measurement and nothing else.
 - **`isNewTask` = composer's two presentations, not one flag per effect.** Before session exist composer stand alone mid-window, so [ChatInput](apps/desktop/src/components/ChatInput.tsx) drop card's fill, border, padding, move toolbar above input, swap placeholder, replace send button with "Press ⏎ to send" hint. Dropping button safe only because Enter-to-send live in `onKeyDown` rather than in that button being form's submitter — make it submitter again and empty state lose its send path. `AppShell` have own `centered` prop for surrounding geometry. Horizontal alignment hand-tuned to single edge: toolbar's `-ml-2.5` cancel its `px-1` plus ghost button's 6px icon inset so `+` _glyph_ land on text edge. Change that button's size or variant and offset have to move with it.

--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -194,13 +194,18 @@ impl StatusTracker {
         self.model_call_open || !self.background_tasks.is_empty()
     }
 
-    /// Whether a model call is open right now, which is what decides that an
-    /// arriving prompt is queued rather than sent. Read *before* `on_send`,
-    /// which opens one unconditionally and would answer for itself.
+    /// Whether a model call is open right now. Two readers: it decides that an
+    /// arriving prompt is queued rather than sent — read *before* `on_send`,
+    /// which opens one unconditionally and would answer for itself — and it is
+    /// what [`SessionManager::fork`] refuses on.
+    ///
+    /// Also exactly what [`SessionStatus::InProgress`] reports, which is the
+    /// reading the sidebar's own fork guard takes. Neither side can call the
+    /// other, so that equivalence is pinned by test rather than assumed.
     ///
     /// Deliberately narrower than [`has_outstanding_work`](Self::has_outstanding_work). A background task
-    /// holds the session in-progress long after its turn ended, but the CLI's
-    /// main thread is idle and answers a prompt straight away — verified
+    /// keeps that one true long after its turn ended, but the CLI's main thread
+    /// is idle and answers a prompt straight away — verified
     /// against v2.1.232, where a prompt written with a background `sleep 300`
     /// outstanding was answered in 1.8s. Queueing on status instead held that
     /// prompt until the task drained, and since a `local_bash` task emits none
@@ -208,6 +213,12 @@ impl StatusTracker {
     /// whole wait.
     pub fn turn_in_flight(&self) -> bool {
         self.model_call_open
+    }
+
+    /// The status the sidebar draws from, so a guard here can be checked
+    /// against the word the frontend reads.
+    pub fn status(&self) -> SessionStatus {
+        self.status
     }
 
     /// The outstanding background tasks, for a Stop that has to name each one.
@@ -752,9 +763,23 @@ impl SessionManager {
     /// instruction for the first send. The copied log is what the fork replays
     /// meanwhile, so it opens reading exactly like its parent.
     ///
-    /// Refused while the parent is working. The CLI forks by reading the
-    /// parent's transcript, which a live child is still appending to, so a fork
-    /// taken mid-turn can inherit half of one.
+    /// Refused while the parent's turn is in flight, and on nothing wider. The
+    /// CLI forks by reading the parent's transcript, which a live child is
+    /// appending to mid-turn, so a fork taken there inherits half of one. A
+    /// background task outstanding is not that case: it appends *after* the
+    /// turn ended — that is how a subagent reports back — and what this takes
+    /// is a copy at a point in time, which is what a fork is.
+    ///
+    /// Reading [`has_outstanding_work`](StatusTracker::has_outstanding_work)
+    /// here was the bug. That is the safe-to-replace-the-child question, and
+    /// this replaces no child — it borrowed a guard written for the paths that
+    /// kill one. A `local_bash` task never ends on its own, so a session
+    /// running a dev server could not be forked again for the rest of its life,
+    /// while the menu item stayed enabled: the sidebar guards on
+    /// `status === "in_progress"`, which the same `result` had already moved to
+    /// `completed`. The two must answer one question, which they now do —
+    /// `InProgress` *is* `turn_in_flight`, pinned by test. An item offering
+    /// what this refuses reads as Fork being broken rather than busy.
     pub async fn fork(
         &self,
         session_id: &str,
@@ -766,8 +791,8 @@ impl SessionManager {
             .with_context(|| format!("unknown session {session_id}"))?;
 
         if let Some(s) = self.sessions.lock().await.get(session_id) {
-            if s.status.lock().await.has_outstanding_work() {
-                bail!("wait for the session to finish before forking it");
+            if s.status.lock().await.turn_in_flight() {
+                bail!("wait for the turn to finish before forking it");
             }
         }
 
@@ -1726,6 +1751,84 @@ mod tests {
             None
         );
         assert!(!tracker.has_outstanding_work());
+    }
+
+    /// What [`SessionManager::fork`] reads. A dev server, a Monitor, a poll
+    /// loop — a `local_bash` task never ends, so guarding fork on the wide
+    /// reading took Fork away from that session for the rest of its life. The
+    /// transcript it copies is not being appended to mid-turn here; the turn
+    /// ended, and a task reporting back later opens a turn of its own.
+    #[test]
+    fn a_session_carrying_a_background_task_can_still_be_forked() {
+        let mut tracker = StatusTracker::default();
+        tracker.on_send();
+
+        tracker.on_event(&AgentEventPayload::BackgroundTasksChanged {
+            tasks: vec![crate::events::BackgroundTask {
+                task_id: "b0n57ez9b".to_string(),
+                task_type: "local_bash".to_string(),
+                description: "pnpm dev".to_string(),
+            }],
+        });
+        assert!(tracker.turn_in_flight(), "mid-turn, fork is refused");
+
+        tracker.on_event(&turn_completed());
+        assert!(
+            tracker.has_outstanding_work(),
+            "the child still carries the task, so it must not be replaced"
+        );
+        assert!(
+            !tracker.turn_in_flight(),
+            "but no model call is open, so there is no half a turn to inherit"
+        );
+    }
+
+    /// The two guards on Fork are one question, and this is what keeps them so.
+    /// The backend refuses on `turn_in_flight`; the sidebar disables the menu
+    /// item on `status === "in_progress"`. Neither side can call the other, so
+    /// the rule is stated twice — and a disabled item disagreeing with a
+    /// refusal is exactly what made Fork read as broken rather than busy.
+    #[test]
+    fn the_fork_guard_is_the_status_the_sidebar_reads() {
+        let mut mapper = Mapper::default();
+        let mut tracker = StatusTracker::default();
+
+        let mut check = |tracker: &StatusTracker| {
+            assert_eq!(
+                tracker.turn_in_flight(),
+                tracker.status() == SessionStatus::InProgress,
+                "the backend's fork guard and the word the sidebar reads have drifted"
+            );
+        };
+
+        check(&tracker);
+        tracker.on_send();
+        check(&tracker);
+
+        // The state this is all about: the turn over, tasks still running.
+        let mut forkable_with_a_task_running = false;
+
+        for line in include_str!("harness/claude_code/fixtures/background_bash_monitor.jsonl")
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+        {
+            let Ok(Some(event)) = mapper.map(parser::parse_line(line).unwrap()) else {
+                continue;
+            };
+            tracker.on_event(&event.payload);
+            check(&tracker);
+            forkable_with_a_task_running |=
+                !tracker.turn_in_flight() && tracker.has_outstanding_work();
+        }
+
+        // Reading the finished session moves it off `Completed`, the one
+        // transition that touches the status without touching the turn.
+        tracker.mark_seen();
+        check(&tracker);
+        assert!(
+            forkable_with_a_task_running,
+            "the fixture runs its turn out with both tasks outstanding, which is the case that was refused"
+        );
     }
 
     /// Only a finished-and-unread session clears on read; selecting a running

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { burstConfetti } from "@/lib/confetti";
+import { forkBlocked } from "@/lib/fork";
 import type { ManualCheck } from "@/hooks/useUpdater";
 import { isToday, relativeTime } from "@/lib/format";
 import { sessionBranch } from "@/lib/pr";
@@ -1123,8 +1124,8 @@ function RowAction({
 /// so reordering moves the digits with it and there is no second table to fall
 /// out of step with the labels.
 const FORKS = [
-  { label: "Fork here", worktree: false },
   { label: "Fork in new worktree", worktree: true },
+  { label: "Fork here", worktree: false },
 ] as const;
 
 /// The row's right-click menu. Delete confirms in place — a second surface for
@@ -1148,9 +1149,11 @@ function RowMenu({
   children,
 }: {
   onFork: (worktree: boolean) => void;
-  /// The session is working. The CLI forks by reading its transcript, which a
-  /// live child is still appending to, so a fork taken now can inherit half a
-  /// turn. The backend refuses it too — this only saves the trip.
+  /// The session's turn is in flight. The CLI forks by reading its transcript,
+  /// which a live child is appending to mid-turn, so a fork taken now can
+  /// inherit half a turn. From [`forkBlocked`](@/lib/fork), which is where the
+  /// rule is written — the backend refuses on the same question, and this only
+  /// saves the trip.
   forkDisabled: boolean;
   onDelete: () => void;
   /// Absent on a row that isn't nested — there is nothing to detach from, and
@@ -1363,7 +1366,7 @@ function SessionRow({
   return (
     <RowMenu
       onFork={(worktree) => void onFork(item.sessionId, worktree)}
-      forkDisabled={status === "in_progress"}
+      forkDisabled={forkBlocked(status)}
       onDelete={() => void onDelete(item.sessionId)}
       onDetach={nested ? () => void onDetach(item.sessionId) : undefined}
     >

--- a/apps/desktop/src/lib/fork.test.ts
+++ b/apps/desktop/src/lib/fork.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { forkBlocked } from "@/lib/fork";
+
+describe("forkBlocked", () => {
+  it("refuses only while a turn is in flight", () => {
+    expect(forkBlocked("in_progress")).toBe(true);
+    expect(forkBlocked("completed")).toBe(false);
+    expect(forkBlocked("idle")).toBe(false);
+  });
+
+  // A session whose turn ended with a `local_bash` task still running reads
+  // `completed` — that is the whole of what the backend sees too, so the item
+  // is drawn enabled and the fork goes through. Guarding it here on anything
+  // wider would put the menu back out of step with `SessionManager::fork`.
+  it("offers a fork to a session still carrying a background task", () => {
+    expect(forkBlocked("completed")).toBe(false);
+  });
+
+  // A row whose status has not landed yet — the map is keyed by session id and
+  // holds only sessions this run has heard from. Nothing is running under an
+  // id nothing has reported on, so the item is drawn rather than dimmed.
+  it("reads an unknown status as not working", () => {
+    expect(forkBlocked(undefined)).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/fork.ts
+++ b/apps/desktop/src/lib/fork.ts
@@ -1,0 +1,18 @@
+import type { SessionStatus } from "@/types/events";
+
+/// Whether Fork is refused right now, which is the *turn* being in flight and
+/// nothing wider. The CLI forks by reading the parent's transcript, which a
+/// live child is appending to mid-turn, so a fork taken there inherits half a
+/// turn.
+///
+/// One question stated twice: `SessionManager::fork` refuses on
+/// `StatusTracker::turn_in_flight()`, and `in_progress` is exactly that
+/// predicate — pinned on the Rust side, since neither half can call the other.
+/// It sits here rather than inline in the menu so there is one place the rule
+/// is written, and the two cannot drift again: guarding on a background task
+/// outstanding took Fork away from every session running a dev server, while
+/// this side went on drawing the item enabled, so it looked available and
+/// errored on click.
+export function forkBlocked(status: SessionStatus | undefined): boolean {
+  return status === "in_progress";
+}


### PR DESCRIPTION
## TLDR for human

- `SessionManager::fork` guards on `turn_in_flight()` instead of `has_outstanding_work()` — a session carrying a background task can be forked again.
- Frontend and backend now answer one question, stated once per side and pinned by test, so the menu can't offer what the backend refuses.
- Effort respawn and update install keep the wide reading.
- Fork in new worktree is the first submenu item now (digits follow position, so it takes `1`).

---

## The bug

Two guards, two different questions.

Backend refused on `has_outstanding_work()` = `model_call_open || !background_tasks.is_empty()`. The sidebar disabled the submenu trigger on `status === "in_progress"`. Status goes `completed` at `result` whatever tasks are outstanding — the deliberate fix for sessions hanging on a dev server — so with a `Bash(run_in_background)` or a `Monitor` alive the item drew enabled and the call errored. And it never recovered: a `local_bash` task doesn't end on its own, so a session running a dev server couldn't be forked for the rest of its life.

## Why the guard was wrong, not just mismatched

The doc comment above `fork` gives its own reason: the CLI forks by reading the parent's transcript, which a live child is appending to mid-turn, so a fork taken there inherits half a turn. That is `turn_in_flight()` and nothing more. `has_outstanding_work()` is the safe-to-replace-the-child question — its own comment says so — and fork replaces no child; it copies the log and writes an index entry, leaving the running child alone. It had borrowed a guard written for effort respawn and update install, where killing the child would take the background task with it. Those two keep the wide reading.

## On the background subagent that reports back

Agreed with the issue, no change. A background task can append to the transcript after the turn ends — that's how a subagent reports back — so a fork taken while one is live copies a log that may grow a moment later. That is a copy taken at a point in time, which is what a fork is. The half-a-turn problem is specifically an open model call, and that's what the guard now reads.

## Keeping the two guards from drifting

`SessionStatus::InProgress` is exactly `turn_in_flight` by construction: every `InProgress`/`Completed` transition goes through `StatusTracker::set`, and `mark_seen` only moves `Completed` → `Idle`. Neither half can call the other, so the rule is stated twice and pinned twice:

- `the_fork_guard_is_the_status_the_sidebar_reads` walks the `background_bash_monitor` fixture asserting `turn_in_flight() == (status() == InProgress)` at every event, plus across `mark_seen`. It fails the moment either definition moves.
- `a_session_carrying_a_background_task_can_still_be_forked` pins the case that was refused: turn over, task outstanding, `has_outstanding_work()` true and `turn_in_flight()` false.
- The frontend reading moved out of JSX into `lib/fork.ts` as `forkBlocked`, with its own test — one place the rule is written on that side, naming its Rust counterpart.

## Checks

`cargo test` 354 pass (bare run, after the filtered one). `pnpm test` 296 pass. `pnpm build` clean.

Fixes DRA-84