### PR TITLE
Make the composer picker readable over the transcript

### DIFF
--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -55,6 +55,13 @@
      its own name: the composer is not a popover, and the next change to
      floating surfaces should not have to wonder whether it wanted that too. */
   --composer: var(--surface-card);
+  /* The composer's `/`, `@` and `#` picker. A popover by every other measure,
+     and it takes its own name for one reason: it is the tallest floating
+     surface in the app, so the wash that reads as glass on a menu covers a
+     third of the transcript here and reads as a smear of it. `--veil-panel`
+     under glass rather than `--veil-float`; the same fill as every other
+     surface off it. */
+  --picker: var(--surface-card);
   --secondary: var(--muted);
   --accent: var(--muted);
   --card-foreground: var(--foreground);
@@ -196,6 +203,15 @@
      frames, which is what stops the transcript showing through the words. */
   --veil-float: color-mix(in oklab, var(--surface-card) 62%, transparent);
 
+  /* Above the float, below a slab, and the difference from the number over it
+     is area. A menu is a few rows over a fixed strip of page; the picker is
+     fourteen rems of list over a live transcript, so at 62% the words behind it
+     move under the words in it and the blur that hides them reads as a smear
+     rather than as glass. Both ends were looked at on screen: 62% read as
+     blurry, 88% read as a slab, and this sits between them — the surface still
+     transmits, and nothing behind it resolves. */
+  --veil-panel: color-mix(in oklab, var(--surface-card) 76%, transparent);
+
   /* Enough to lift a filled button off the surface and no more: on a dark
      palette a filled button and its background are two flat fields, and without
      this the only thing saying "button" is the fill itself. Straight down, no
@@ -254,6 +270,9 @@
      desktop, and the same alpha reads as a washed-out surface rather than a
      glass one. */
   --veil-float: color-mix(in oklab, var(--surface-card) 74%, transparent);
+  /* Tighter than dark's 88% for the same reason this ramp's float is tighter
+     than dark's: a bright desktop through a light surface washes it out. */
+  --veil-panel: color-mix(in oklab, var(--surface-card) 84%, transparent);
 
   /* Far lighter than dark's 45%. A shadow that reads as depth against near-black
      reads as dirt against near-white. */
@@ -418,6 +437,7 @@
   --color-primary: var(--primary);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
+  --color-picker: var(--picker);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
   --color-composer: var(--composer);
@@ -572,6 +592,10 @@
        for. */
     --popover: var(--veil-float);
     --composer: var(--veil-float);
+    /* Heavier than the two above it — see `--veil-panel`. This is the one
+       floating surface tall enough that the wash reads as what is behind it
+       rather than as glass. */
+    --picker: var(--veil-panel);
     /* The one highlight that lands on the backdrop rather than inside a menu:
        the sidebar has no fill here, so a selected session row — and the panel's
        active tab, which shares the token — is drawn straight onto it. The `/50`

--- a/apps/desktop/src/components/ChatInput.tsx
+++ b/apps/desktop/src/components/ChatInput.tsx
@@ -607,11 +607,17 @@ export default function ChatInput({
             leave them floating rather than tucked. */}
         {!isNewTask && handoff}
 
-        {/* The ring lives on the card so the whole composer reads as one control.
+        {/* The picker anchors to this wrapper rather than to the card, and it has
+            to: an element carrying `backdrop-filter` is a backdrop root for
+            everything inside it, so the list's own blur — nested in the card —
+            sampled the card's empty interior instead of the transcript behind
+            it, and did nothing at all. That is the same trap one layer out from
+            the one that sends every menu through a portal. The wrapper's box is
+            the card's, so `top-full`/`bottom-full` land where they always did.
+
+            The ring lives on the card so the whole composer reads as one control.
             --input bakes in its own alpha, which makes Tailwind's /40-style opacity
             modifiers silently no-op, so both states set an explicit color.
-            `relative` anchors the command picker, which opens upward out of the
-            card rather than displacing anything as it filters.
 
             `bg-composer`, not `bg-card`, and that is a vibrancy fix rather than
             a colour change: the two tokens carry the same value, and they part
@@ -622,14 +628,7 @@ export default function ChatInput({
             takes. It was the one raised surface that could never be glass, back
             when it hid the handoff row by being opaque; [HandoffRow] clips
             itself now, which is what freed it. */}
-        <div
-          ref={cardRef}
-          className={cn(
-            "relative rounded-2xl transition-colors",
-            !isNewTask &&
-              "border border-hairline bg-composer backdrop-blur-xl focus-within:border-hairline-strong",
-          )}
-        >
+        <div className="relative">
           {/* Two separate consequences of the empty state, passed separately
               because they are separate things that happen to coincide. The
               toolbar sits above the input there and the window is empty below
@@ -666,189 +665,198 @@ export default function ChatInput({
               />
             ))}
 
-          {/* Covers the card rather than replacing anything, so the text and
-              the tray stay legible underneath and the box doesn't resize the
-              moment a file crosses the window. Inert to pointer events — the
-              drop is the OS's, and Tauri delivers it whatever is on top. */}
-          {dragging && (
-            <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center gap-2 rounded-2xl border-2 border-muted-foreground/25 bg-background/70 text-ui text-muted-foreground">
-              <Paperclip className="size-3.5" strokeWidth={2} />
-              Drop to attach
-            </div>
-          )}
-
-          {/* Inside the card and above the text, so an attachment reads as part
-              of the message being composed rather than as a separate control.
-              Padded on the same edges as the textarea below it. */}
-          {attachments.length > 0 && (
-            <div className={cn("pt-3", isNewTask ? "px-0" : "px-3")}>
-              <AttachmentTray
-                attachments={attachments}
-                onRemove={(path) => removeAttachment(sessionId, path)}
-              />
-            </div>
-          )}
-
-          {/* Both buttons sit on the last line. At one line that reads as
-              centered anyway, because the textarea's vertical padding below is
-              tuned to match the buttons' own height — no `self-center` needed,
-              and nothing drifts as the box grows. */}
-          <div className={cn("flex items-end gap-1 py-3", isNewTask ? "px-0" : "px-3")}>
-            <div className="relative min-w-0 flex-1">
-              <textarea
-                ref={textareaRef}
-                rows={1}
-                autoFocus
-                value={message}
-                // Kept in step with the overlay below, which cannot scroll itself.
-                onScroll={(e) => {
-                  const mirror = mirrorRef.current;
-                  if (mirror) mirror.scrollTop = e.currentTarget.scrollTop;
-                }}
-                // Names `#` only where it would do something. An unconnected
-                // reader offered a tag they cannot use learns the app is
-                // missing a feature rather than that they haven't set one up.
-                placeholder={
-                  isNewTask
-                    ? issuesConnected
-                      ? "Describe a task. #issues. @files. /skills and commands."
-                      : "Describe a task. @files. /skills and commands."
-                    : "Send follow-up"
-                }
-                onChange={(e) => {
-                  setMessage(e.currentTarget.value);
-                  setCaret(e.currentTarget.selectionStart);
-                }}
-                // Fires for arrow keys, clicks, and drags alike, so the picker
-                // follows the caret however it moved rather than only on typing.
-                onSelect={(e) => setCaret(e.currentTarget.selectionStart)}
-                onKeyDown={(e) => {
-                  // Whichever picker is open owns these keys, and only while it
-                  // is — Enter completes the highlighted row instead of sending,
-                  // which is the one place the composer's usual rule gives way.
-                  if (menuOpen && !e.nativeEvent.isComposing) {
-                    if (e.key === "ArrowDown") {
-                      e.preventDefault();
-                      setActiveIndex((active + 1) % rowCount);
-                      return;
-                    }
-                    if (e.key === "ArrowUp") {
-                      e.preventDefault();
-                      setActiveIndex((active - 1 + rowCount) % rowCount);
-                      return;
-                    }
-                    if (e.key === "Enter" || e.key === "Tab") {
-                      e.preventDefault();
-                      pickRow(active);
-                      return;
-                    }
+          <div
+            ref={cardRef}
+            className={cn(
+              "relative rounded-2xl transition-colors",
+              !isNewTask &&
+                "border border-hairline bg-composer backdrop-blur-xl focus-within:border-hairline-strong",
+            )}
+          >
+            {/* Covers the card rather than replacing anything, so the text and
+                the tray stay legible underneath and the box doesn't resize the
+                moment a file crosses the window. Inert to pointer events — the
+                drop is the OS's, and Tauri delivers it whatever is on top. */}
+            {dragging && (
+              <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center gap-2 rounded-2xl border-2 border-muted-foreground/25 bg-background/70 text-ui text-muted-foreground">
+                <Paperclip className="size-3.5" strokeWidth={2} />
+                Drop to attach
+              </div>
+            )}
+  
+            {/* Inside the card and above the text, so an attachment reads as part
+                of the message being composed rather than as a separate control.
+                Padded on the same edges as the textarea below it. */}
+            {attachments.length > 0 && (
+              <div className={cn("pt-3", isNewTask ? "px-0" : "px-3")}>
+                <AttachmentTray
+                  attachments={attachments}
+                  onRemove={(path) => removeAttachment(sessionId, path)}
+                />
+              </div>
+            )}
+  
+            {/* Both buttons sit on the last line. At one line that reads as
+                centered anyway, because the textarea's vertical padding below is
+                tuned to match the buttons' own height — no `self-center` needed,
+                and nothing drifts as the box grows. */}
+            <div className={cn("flex items-end gap-1 py-3", isNewTask ? "px-0" : "px-3")}>
+              <div className="relative min-w-0 flex-1">
+                <textarea
+                  ref={textareaRef}
+                  rows={1}
+                  autoFocus
+                  value={message}
+                  // Kept in step with the overlay below, which cannot scroll itself.
+                  onScroll={(e) => {
+                    const mirror = mirrorRef.current;
+                    if (mirror) mirror.scrollTop = e.currentTarget.scrollTop;
+                  }}
+                  // Names `#` only where it would do something. An unconnected
+                  // reader offered a tag they cannot use learns the app is
+                  // missing a feature rather than that they haven't set one up.
+                  placeholder={
+                    isNewTask
+                      ? issuesConnected
+                        ? "Describe a task. #issues. @files. /skills and commands."
+                        : "Describe a task. @files. /skills and commands."
+                      : "Send follow-up"
                   }
-
-                  // Esc is not read here — it is the document listener's, so it
-                  // works with the composer unfocused too.
-
-                  // Shift+Enter is the only way to get a newline; plain Enter sends.
-                  if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
-                    e.preventDefault();
-                    submit();
-                  }
-                }}
-                // `py-1` puts one line at 28px — the buttons' own height — so the
-                // first row looks centered against them without being. `min-w-0`
-                // moved to the wrapper, where it still stops one long unbroken
-                // token setting the flex item's floor and pushing the buttons off
-                // the row.
-                className={cn(
-                  "block w-full resize-none overflow-y-auto bg-transparent placeholder:text-muted-foreground focus:outline-none",
-                  TEXT_BOX,
-                  isNewTask ? "px-0" : "px-1",
-                  // Hands the glyphs to the overlay only while there is something
-                  // to colour. Every other moment the textarea draws its own text
-                  // as before, so the usual case keeps no dependency on the
-                  // overlay rendering correctly.
-                  highlighted ? "text-transparent caret-foreground" : "text-foreground",
-                )}
-              />
-
-              {/* Draws the text the textarea is hiding, so a command or a file
-                  mention can take a colour — a textarea has no way to style part
-                  of its value. Painted *over* the textarea rather than under it,
-                  so a selection band sits behind these glyphs instead of covering
-                  them; the caret still shows, since it falls between them.
-
-                  Mounted only alongside `text-transparent` above, and built from
-                  the same segments the transcript renders, so neither the two
-                  copies of the text nor the two surfaces can disagree about what
-                  is coloured. `TEXT_BOX` and the padding are shared with the
-                  textarea for the same reason — any drift shows up as doubled
-                  text. */}
-              {highlighted && (
-                <div
-                  ref={mirrorRef}
-                  aria-hidden
+                  onChange={(e) => {
+                    setMessage(e.currentTarget.value);
+                    setCaret(e.currentTarget.selectionStart);
+                  }}
+                  // Fires for arrow keys, clicks, and drags alike, so the picker
+                  // follows the caret however it moved rather than only on typing.
+                  onSelect={(e) => setCaret(e.currentTarget.selectionStart)}
+                  onKeyDown={(e) => {
+                    // Whichever picker is open owns these keys, and only while it
+                    // is — Enter completes the highlighted row instead of sending,
+                    // which is the one place the composer's usual rule gives way.
+                    if (menuOpen && !e.nativeEvent.isComposing) {
+                      if (e.key === "ArrowDown") {
+                        e.preventDefault();
+                        setActiveIndex((active + 1) % rowCount);
+                        return;
+                      }
+                      if (e.key === "ArrowUp") {
+                        e.preventDefault();
+                        setActiveIndex((active - 1 + rowCount) % rowCount);
+                        return;
+                      }
+                      if (e.key === "Enter" || e.key === "Tab") {
+                        e.preventDefault();
+                        pickRow(active);
+                        return;
+                      }
+                    }
+  
+                    // Esc is not read here — it is the document listener's, so it
+                    // works with the composer unfocused too.
+  
+                    // Shift+Enter is the only way to get a newline; plain Enter sends.
+                    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                      e.preventDefault();
+                      submit();
+                    }
+                  }}
+                  // `py-1` puts one line at 28px — the buttons' own height — so the
+                  // first row looks centered against them without being. `min-w-0`
+                  // moved to the wrapper, where it still stops one long unbroken
+                  // token setting the flex item's floor and pushing the buttons off
+                  // the row.
                   className={cn(
-                    "pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words text-foreground",
+                    "block w-full resize-none overflow-y-auto bg-transparent placeholder:text-muted-foreground focus:outline-none",
                     TEXT_BOX,
                     isNewTask ? "px-0" : "px-1",
+                    // Hands the glyphs to the overlay only while there is something
+                    // to colour. Every other moment the textarea draws its own text
+                    // as before, so the usual case keeps no dependency on the
+                    // overlay rendering correctly.
+                    highlighted ? "text-transparent caret-foreground" : "text-foreground",
                   )}
-                >
-                  {segments.map((segment, i) => {
-                    // Every glyph the textarea lays out has to be laid out here
-                    // too, so a mention is dimmed rather than shortened — the
-                    // transcript is where it collapses to the filename.
-                    if (segment.kind === "mention") {
-                      const { dir, name } = splitMention(segment.text);
-
+                />
+  
+                {/* Draws the text the textarea is hiding, so a command or a file
+                    mention can take a colour — a textarea has no way to style part
+                    of its value. Painted *over* the textarea rather than under it,
+                    so a selection band sits behind these glyphs instead of covering
+                    them; the caret still shows, since it falls between them.
+  
+                    Mounted only alongside `text-transparent` above, and built from
+                    the same segments the transcript renders, so neither the two
+                    copies of the text nor the two surfaces can disagree about what
+                    is coloured. `TEXT_BOX` and the padding are shared with the
+                    textarea for the same reason — any drift shows up as doubled
+                    text. */}
+                {highlighted && (
+                  <div
+                    ref={mirrorRef}
+                    aria-hidden
+                    className={cn(
+                      "pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words text-foreground",
+                      TEXT_BOX,
+                      isNewTask ? "px-0" : "px-1",
+                    )}
+                  >
+                    {segments.map((segment, i) => {
+                      // Every glyph the textarea lays out has to be laid out here
+                      // too, so a mention is dimmed rather than shortened — the
+                      // transcript is where it collapses to the filename.
+                      if (segment.kind === "mention") {
+                        const { dir, name } = splitMention(segment.text);
+  
+                        return (
+                          <span key={i} className={SEGMENT_COLOR.mention}>
+                            <span className="opacity-45">{dir}</span>
+                            {name}
+                          </span>
+                        );
+                      }
+  
                       return (
-                        <span key={i} className={SEGMENT_COLOR.mention}>
-                          <span className="opacity-45">{dir}</span>
-                          {name}
+                        <span key={i} className={SEGMENT_COLOR[segment.kind]}>
+                          {segment.text}
                         </span>
                       );
-                    }
-
-                    return (
-                      <span key={i} className={SEGMENT_COLOR[segment.kind]}>
-                        {segment.text}
-                      </span>
-                    );
-                  })}
-                </div>
-              )}
+                    })}
+                  </div>
+                )}
+              </div>
+  
+              {/* One button, two jobs, and what is typed decides which. Stopping
+                  is what an empty composer during a turn is for; with text in it
+                  the prompt is queued onto the running turn instead, so Send has
+                  to stay reachable — refusing it is the behaviour this replaced.
+                  `type="button"` on Stop so pressing it can't also submit.
+  
+                  Enter-to-send lives in `onKeyDown`, not in this button being the
+                  form's submitter, so the empty state can drop it for the hint
+                  below without losing the keyboard path. Neither `busy` nor a
+                  queue is reachable there — nothing runs before a session
+                  exists. */}
+              {!isNewTask &&
+                (() => {
+                  const stopping = busy && !canSend;
+  
+                  return (
+                    <Button
+                      type={stopping ? "button" : "submit"}
+                      size="icon-sm"
+                      disabled={stopping ? !onStop : !canSend}
+                      onClick={stopping ? onStop : undefined}
+                      title={stopping ? "Stop" : busy ? "Send — queued onto this turn" : "Send"}
+                      className="rounded-full"
+                    >
+                      {stopping ? (
+                        <Square className="fill-current" />
+                      ) : (
+                        <ArrowUp strokeWidth={2} />
+                      )}
+                    </Button>
+                  );
+                })()}
             </div>
-
-            {/* One button, two jobs, and what is typed decides which. Stopping
-                is what an empty composer during a turn is for; with text in it
-                the prompt is queued onto the running turn instead, so Send has
-                to stay reachable — refusing it is the behaviour this replaced.
-                `type="button"` on Stop so pressing it can't also submit.
-
-                Enter-to-send lives in `onKeyDown`, not in this button being the
-                form's submitter, so the empty state can drop it for the hint
-                below without losing the keyboard path. Neither `busy` nor a
-                queue is reachable there — nothing runs before a session
-                exists. */}
-            {!isNewTask &&
-              (() => {
-                const stopping = busy && !canSend;
-
-                return (
-                  <Button
-                    type={stopping ? "button" : "submit"}
-                    size="icon-sm"
-                    disabled={stopping ? !onStop : !canSend}
-                    onClick={stopping ? onStop : undefined}
-                    title={stopping ? "Stop" : busy ? "Send — queued onto this turn" : "Send"}
-                    className="rounded-full"
-                  >
-                    {stopping ? (
-                      <Square className="fill-current" />
-                    ) : (
-                      <ArrowUp strokeWidth={2} />
-                    )}
-                  </Button>
-                );
-              })()}
           </div>
         </div>
 

--- a/apps/desktop/src/components/composer/PickerMenu.tsx
+++ b/apps/desktop/src/components/composer/PickerMenu.tsx
@@ -181,6 +181,25 @@ export default function PickerMenu<T>({
           clips the scrollbar to the curve, so it stops short of the corners the
           way the rows do.
 
+          `bg-picker`, not `bg-popover`, and it is the same fill everywhere but
+          on glass. This is by some way the tallest floating surface in the app —
+          fourteen rems of list over a live transcript — so the wash that reads
+          as glass on a menu covers a third of the page here, and the words
+          behind move under the words in it. `--veil-panel` is the heavier
+          wash it takes instead; the arithmetic is beside it in App.css.
+
+          A blur goes with it, and is not decoration: a wash is not a fill, so
+          without one what shows through stays legible rather than resolving to a
+          tint. Every floating frame in the app carries the pair; this one was
+          the last that did not.
+
+          `lg` here against the `xl` those frames take, and the two numbers move
+          together — wash and blur are one lever with two ends. A menu is thin
+          enough to need the heavier blur to hide a strip of page; this surface
+          already spends the heavier wash, so only a quarter of the backdrop is
+          left to hide and 24px of blur on it read as a smear of the transcript
+          rather than as glass over it.
+
           `bare` drops the fill along with the border, the radius and the
           shadow, and they do go together: it is only ever the empty state,
           where the composer stands alone and the transcript is not rendered at
@@ -197,25 +216,29 @@ export default function PickerMenu<T>({
           "overflow-hidden",
           bare
             ? "text-foreground"
-            : "rounded-xl border border-hairline-strong bg-popover text-popover-foreground shadow-md",
+            : "rounded-xl border border-hairline-strong bg-picker backdrop-blur-lg text-popover-foreground shadow-md",
         )}
       >
         <div
           ref={listRef}
           role="listbox"
           aria-label={label}
+          // One inset, not two: `p-1` rather than a taller `py`, so the gap above
+          // the first row is the gap beside it. Uneven, the top read as a band
+          // of empty surface above the list while the sides read as an edge.
+          //
           // Seven rows either way, and that is why there are two heights: 7 ×
           // the row's own `h-8` is 14rem, and the bordered state adds the
-          // 0.5rem of `py-2` at each end. Written out rather than computed, so
+          // 0.25rem of `p-1` at each end. Written out rather than computed, so
           // it costs nothing at render — but it does mean these numbers, `h-8`
-          // and `py-2` have to move together.
+          // and `p-1` have to move together.
           //
           // `bare` drops the inset with the box it was insetting from: with no
           // border there is nothing for the rows to be held away from, and the
           // gap only reads as the list sitting oddly short of its own edge.
           className={cn(
             "overflow-x-hidden overflow-y-auto overscroll-contain",
-            bare ? "max-h-[14rem]" : "max-h-[15rem] px-1 py-2",
+            bare ? "max-h-[14rem]" : "max-h-[14.5rem] p-1",
           )}
         >
           {groups.map((group, g) => (


### PR DESCRIPTION
The `@` / `/` / `#` picker was the last floating frame in the app without a backdrop blur. Under transparency `--popover` is `--veil-float`, a 62% wash rather than a fill, so the transcript scrolling behind the list stayed legible through it and the two sets of text interleaved.

Adding the blur alone did nothing, and that is the part worth reading. The picker rendered inside the composer card, and that card carries `backdrop-blur-xl`. An element with a backdrop-filter is a backdrop root for its descendants, so the picker's blur sampled the card's empty interior instead of the page behind it — the same class of trap as the one that already sends every Radix menu through a portal, one layer out.

## What changed

- **The picker anchors to a plain `relative` wrapper outside the card**, so its blur resolves against the page. The wrapper's box is the card's, so `top-full` / `bottom-full` land exactly where they did. This is most of the diff — the card block is reindented one level, no other change to it.
- **New `--picker` alias**, taking `--veil-panel` under glass where `--popover` takes `--veil-float`. This is by some way the tallest floating surface in the app — fourteen rems of list over a live transcript — so the wash that reads as glass on a menu covers a third of the page here. Own name rather than a tweak to `--popover`, since the reason is specific to this surface and every other menu, dialog and tooltip should keep the lighter wash.
- **`backdrop-blur-lg` rather than `xl`.** Wash and blur are one lever with two ends: this surface already spends the heavier wash, so only a quarter of the backdrop is left to hide.
- **The scroller's inset is `p-1`, not `px-1 py-2`**, so the gap above the first row is the gap beside it. Its max-height moves with it (seven rows plus the inset at each end), so the list still shows seven.

The two wash numbers were tuned on screen rather than picked: 62% read as blurry, 88% read as a slab, 76% dark / 84% light sits between them.

## Verified

`tsc --noEmit` clean, 348 frontend tests pass, and every value here was looked at in the running app.

Fixes DRA-95

🤖 Generated with [Claude Code](https://claude.com/claude-code)