### PR TITLE
docs(cli): require a review session to report back

### DIFF
--- a/apps/cli/skill/SKILL.md
+++ b/apps/cli/skill/SKILL.md
@@ -142,6 +142,10 @@ This is what makes review possible. Spawn a session with a different model or a
 different harness, point it at yours with `--from`, and it gets its own checkout
 of the same commits — so it collides with nobody while it reads.
 
+A session spawned to review this one's work must be told to send its findings
+back to this session — the user asked *you* for the review, so that is where it
+has to land. No other kind of session reports back unless the user says so.
+
 Three things to know:
 
 - **Committed work only.** The new worktree starts at a commit. Anything the

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -898,6 +898,21 @@ mod tests {
         assert!(SKILL.contains("Committed work only"));
     }
 
+    /// A review session is spawned because the user asked *this* session for a
+    /// review, so its findings have to arrive back here — landing them only in
+    /// another session's transcript is a session that ran for nothing. Nothing
+    /// in the app carries them: a spawned session's opening prompt names no
+    /// sender, so the caller has to ask for the report in the prompt. Which
+    /// makes the skill saying it the whole rule, same as the inheritance
+    /// thresholds above. The second half is pinned with it — a rule that read
+    /// as "always report back" would cost a turn per fanned-out session to say
+    /// what the sidebar already says.
+    #[test]
+    fn the_skill_says_a_review_session_reports_its_findings_back() {
+        assert!(SKILL.contains("must be told to send its findings"));
+        assert!(SKILL.contains("No other kind of session reports back unless the user says so."));
+    }
+
     /// A spawned session inherits model and effort, and two inherited answers
     /// are wrong often enough to be worth a question: Fable, which somebody
     /// picked for one chat, and a raised effort, which fanning out multiplies.


### PR DESCRIPTION
Three lines in the `dray` skill's `--from` section: a session spawned to review this one's work must be told to send its findings back here, and nothing else reports back unless the user asks.

Reporting back is the user's call everywhere else — a message per fanned-out session costs a turn to say what the sidebar already shows. A review is the exception: the user asked *this* session for it, so findings landing only in the reviewer's transcript is a session that ran for nothing. Nothing in the app can carry them, since a spawned session's opening prompt names no sender.

Skill only, not `system_prompt.md` — that would be a second copy on the app's release train drifting against the CLI's. Pinned by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
