### PR TITLE
docs(cli): tighten the connect-failure section in the skill

### DIFF
--- a/apps/cli/skill/SKILL.md
+++ b/apps/cli/skill/SKILL.md
@@ -243,29 +243,18 @@ nothing was sent, so retrying after the fix is safe.
 
 ## When a command cannot reach the app
 
-Every `dray` command talks to the app over a unix socket, so every one of them
-needs permission to reach it — `ls` as much as `new`. Three answers, and they
-want three different things from you.
+Every `dray` command reaches the app over a unix socket — `ls` as much as `new` —
+so a failure to connect is one of three things, and the line tells you which.
 
-> permission denied reaching Dray at … The app may well be running: a sandbox,
-> or the filesystem permissions on that path, blocked the connection. If this
-> command is sandboxed, retry this one command with escalated permissions.
-
-**This is not the app telling you it is closed.** Usually a sandbox is refusing
-the connection, and retrying with escalated permissions goes through. Ask for
-the escalation on that one command: do not ask for a sandbox-free shell, and do
-not go looking for another route in. If the retry is refused the same way it is
-the other cause — ordinary permissions on the socket path, which no escalation
-fixes. Say so and name the path.
-
-> Dray isn't running. Start the app and try again.
-
-The app is closed, and you cannot fix that from here. Tell the user.
-
-> could not connect to Dray at … : *reason*
-
-Something else failed, and the line names it. Report it as written. It says
-nothing about whether the app is running, so do not tell the user it is down.
+- **`permission denied reaching Dray at …`** — something blocked the connection,
+  usually a sandbox. If this command is sandboxed, retry this one command with
+  escalated permissions; ask on that command alone, never for a sandbox-free
+  shell. A retry refused the same way is the socket path's own permissions, which
+  no escalation fixes — say so and name the path.
+- **`Dray isn't running. Start the app and try again.`** — the app is closed and
+  you cannot fix it from here. Only this sentence means that.
+- **`could not connect to Dray at …`** — the line names its own reason. Report it
+  as written; it says nothing about whether the app is up.
 
 Nothing was created and nothing was sent in any of the three, so retrying after
 the cure is safe.


### PR DESCRIPTION
Follow-up to #74, prose only.

The skill ships inside the CLI binary and is read into an agent's context on every `dray` task, so length there is a cost every session pays — including the many that never fail to connect at all. The section landed at 29 lines to say three things.

Three blockquotes each trailed by a paragraph are now one bullet per answer: **29 lines to 18**. What went was prose restating the sentence quoted directly above it, not any of the guidance.

The clauses the tests pin — `permission denied reaching Dray`, `retry this one command with escalated permissions`, and the full `Dray isn't running…` sentence — are untouched, which is what proves nothing load-bearing was cut. `cargo test` in `apps/cli`: 34 passed.

Refs DRA-104