### PR TITLE
docs(prompt): tell the agent to name files by absolute path

### DIFF
--- a/apps/desktop/src-tauri/src/harness/claude_code/system_prompt.md
+++ b/apps/desktop/src-tauri/src/harness/claude_code/system_prompt.md
@@ -5,6 +5,7 @@ You run inside Dray, an interactive desktop app. Your replies render as markdown
 # Tone and style
 
 - Be concise and direct. Write simply. Write short sentences, no clutter.
+- Name a file by its absolute path (`/Users/me/project/src/app.ts`). The transcript turns that into a link; a bare filename links nowhere.
 
 ## Closing Text
 


### PR DESCRIPTION
The Claude Code system prompt said nothing about how to name a file in prose, so the agent wrote bare filenames — and a bare filename links nowhere.

One line added under Tone and style, asking for an absolute path.

## Why absolute, not repo-relative

The issue expected repo-relative to be enough. It is not. Checked against the real matcher in `apps/desktop/src/lib/filePath.ts`:

- `isFilePath` requires `startsWith("/")`, and `findFilePaths` only scans from a `/` that opens a word — so `src/lib/filePath.ts` in prose is never even a candidate.
- The cwd that resolves a relative `@mention` reaches `UserMessage` only. Agent prose goes through `rehypeFilePaths`, which has no cwd and never gets one.

Pinned with a scratch vitest run against `findFilePaths`, then deleted:

| prose | links |
| --- | --- |
| `/Users/me/project/src/app.ts` | yes |
| `/Users/me/project/src/app.ts:42` | yes, locator stripped |
| `src/lib/filePath.ts` | no |
| `app.ts` | no |
| `/Users/me/My Project/app.ts` | no, dropped as ambiguous |

The other two premises held: a trailing `:line` is stripped before the path is judged, and a path holding a space is dropped rather than halved. Neither needed a word in the prompt — the line stays one line.

Codex is out of scope; it has its own `developer_instructions.md`.

`cargo test`: 426 passed, 0 failed.

Fixes DRA-107

🤖 Generated with [Claude Code](https://claude.com/claude-code)