### PR TITLE
Follow an unsettled session out of the settled view

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -625,6 +625,50 @@ function App() {
     go();
   };
 
+  /// Writes a session's settled or pinned flag and takes the sidebar wherever
+  /// that write left the row.
+  ///
+  /// One function because there are two ways to unsettle — the sidebar row's
+  /// menu and the composer's own bar — and they have to land in the same place.
+  /// The bar reached `setSessionFlags` directly at first, which wrote the flag
+  /// and nothing else: the row left the settled list it was drawn from, the
+  /// view stayed settled, and the session the reader had just taken back was
+  /// nowhere on screen.
+  const handleSetSessionFlags = async (
+    sessionId: string,
+    flags: { archived?: boolean; pinned?: boolean },
+  ) => {
+    await setSessionFlags(sessionId, flags);
+    if (flags.archived === true) {
+      playCelebration();
+
+      // Settling is the reader saying this work is done, which is the
+      // one moment the worktree behind it is provably spare. Asked
+      // after the flag write lands, so the question is about a task
+      // that is already settled rather than a condition of settling it.
+      const item = sessionIndexItems.find((i) => i.sessionId === sessionId);
+      if (item?.worktreeName) {
+        void askAboutWorktree(sessionId, item.worktreeName, item.title, "notice");
+      }
+    }
+    // Settling the open session leaves nothing to look at but the
+    // unsettle bar, so it goes back to the empty composer instead.
+    if (flags.archived === true && sessionId === selectedSessionId) {
+      goToSession(handleNewSession);
+    } else if (flags.archived === false) {
+      // The row has just left whichever list it was drawn from, so follow it to
+      // the one it landed in and keep it selected — from the sidebar's menu the
+      // reader pressed that row, and from the composer's bar they are reading
+      // its transcript. Either way, losing it is losing the thing they acted on.
+      //
+      // After the write, never before: `setSessionFlags` reads `showArchived`
+      // from its own closure to decide whether the row still belongs to the
+      // list on screen, and a flip ahead of it is invisible to that closure.
+      if (showArchived) setShowArchived(false);
+      goToSession(() => void handleSelectSessionIndexItem(sessionId));
+    }
+  };
+
   const toggleSidebar = () => setCollapsed((prev) => !prev);
   useHotkey("b", toggleSidebar);
   useHotkey("n", () => goToSession(handleNewSession));
@@ -772,32 +816,7 @@ function App() {
           onOpenIssues={() => setIssuesOpen(true)}
           issuesOpen={issuesOpen}
           onDetach={detachSession}
-          onSetFlags={async (sessionId, flags) => {
-            await setSessionFlags(sessionId, flags);
-            if (flags.archived === true) {
-              playCelebration();
-
-              // Settling is the reader saying this work is done, which is the
-              // one moment the worktree behind it is provably spare. Asked
-              // after the flag write lands, so the question is about a task
-              // that is already settled rather than a condition of settling it.
-              const item = sessionIndexItems.find((i) => i.sessionId === sessionId);
-              if (item?.worktreeName) {
-                void askAboutWorktree(sessionId, item.worktreeName, item.title, "notice");
-              }
-            }
-            // Settling the open session leaves nothing to look at but the
-            // unsettle bar, so it goes back to the empty composer instead.
-            if (flags.archived === true && sessionId === selectedSessionId) {
-              goToSession(handleNewSession);
-            } else if (flags.archived === false) {
-              // Unsettling only happens from the settled list, and the row
-              // just left it — follow it back to where it landed, onto the
-              // row itself.
-              if (showArchived) setShowArchived(false);
-              goToSession(() => void handleSelectSessionIndexItem(sessionId));
-            }
-          }}
+          onSetFlags={handleSetSessionFlags}
           onFork={forkSession}
           onDelete={deleteSession}
           showArchived={showArchived}
@@ -968,7 +987,8 @@ function App() {
           onDismissError={() => setError(null)}
           archived={selectedSession?.archived ?? false}
           onUnarchive={() =>
-            selectedSessionId && setSessionFlags(selectedSessionId, { archived: false })
+            selectedSessionId &&
+            void handleSetSessionFlags(selectedSessionId, { archived: false })
           }
           onRemoveWorktree={
             selectedSessionId && selectedSession?.worktreeName

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -638,7 +638,13 @@ function App() {
     sessionId: string,
     flags: { archived?: boolean; pinned?: boolean },
   ) => {
-    await setSessionFlags(sessionId, flags);
+    // Everything below describes a move the index has made. A failed write —
+    // or one naming a session that is no longer there — has moved nothing, so
+    // it gets no celebration, no worktree offer, and no navigation: the row is
+    // still where it was, and `setSessionFlags` has already put the reason on
+    // screen.
+    if (!(await setSessionFlags(sessionId, flags))) return;
+
     if (flags.archived === true) {
       playCelebration();
 
@@ -661,10 +667,14 @@ function App() {
       // reader pressed that row, and from the composer's bar they are reading
       // its transcript. Either way, losing it is losing the thing they acted on.
       //
-      // After the write, never before: `setSessionFlags` reads `showArchived`
-      // from its own closure to decide whether the row still belongs to the
-      // list on screen, and a flip ahead of it is invisible to that closure.
-      if (showArchived) setShowArchived(false);
+      // Unconditional, and after the write. Unconditional because the guard it
+      // replaces read `showArchived` from a closure captured before the await,
+      // so a reader who opened the settled view while the write was in flight
+      // was left in it with the row gone; setting a boolean to the value it
+      // already holds costs nothing. After, because the flip is what triggers
+      // the list refetch, and a refetch racing a write still in flight answers
+      // from an index that has not moved yet.
+      setShowArchived(false);
       goToSession(() => void handleSelectSessionIndexItem(sessionId));
     }
   };

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -648,19 +648,31 @@ const detachSession = async (sessionId: string) => {
   }
 };
 
+/// Writes a session's settled or pinned flag, and answers whether it landed.
+///
+/// The answer is what callers navigate on. A failed write leaves the row where
+/// it was, so acting anyway — following it to the other view, celebrating a
+/// settle that did not happen — describes a move the index never made.
 const setSessionFlags = async (
   sessionId: string,
   flags: { archived?: boolean; pinned?: boolean },
-) => {
+): Promise<boolean> => {
   try {
     const updated = await invoke<SessionIndexItem | null>("set_session_flags", {
       sessionId,
       archived: flags.archived ?? null,
       pinned: flags.pinned ?? null,
     });
-    if (!updated) return;
+    // Null is the backend finding no such session, which is a write that did
+    // not happen like any other.
+    if (!updated) return false;
     setSessionIndexItems((prev) => {
-      const belongsHere = updated.archived === showArchived;
+      // The ref, not the closure: this runs after the write, and the reader can
+      // toggle the split while one is in flight. Judged against the captured
+      // value it would sort the row into whichever view was open when the
+      // button was pressed — dropping it from the list now on screen, or
+      // inserting a settled row into the active one.
+      const belongsHere = updated.archived === showArchivedRef.current;
       // The row can be written from a view it was never drawn in: the settled
       // split keeps the selection across a toggle, so the composer's unsettle
       // bar is reachable while the sidebar is showing the active list. Left to
@@ -689,8 +701,10 @@ const setSessionFlags = async (
           : s,
       ),
     );
+    return true;
   } catch (e) {
     setError(String(e));
+    return false;
   }
 };
 

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -659,15 +659,26 @@ const setSessionFlags = async (
       pinned: flags.pinned ?? null,
     });
     if (!updated) return;
-    setSessionIndexItems((prev) =>
-      prev.flatMap((i) => {
+    setSessionIndexItems((prev) => {
+      const belongsHere = updated.archived === showArchived;
+      // The row can be written from a view it was never drawn in: the settled
+      // split keeps the selection across a toggle, so the composer's unsettle
+      // bar is reachable while the sidebar is showing the active list. Left to
+      // the map below that write lands nowhere — the row is in neither list,
+      // and the session the reader just took back has no row at all until
+      // something else refetches.
+      if (belongsHere && !prev.some((i) => i.sessionId === sessionId)) {
+        return [...prev, updated];
+      }
+
+      return prev.flatMap((i) => {
         if (i.sessionId !== sessionId) return [i];
         // Archiving from the active list — or unarchiving from the archived one —
         // moves the row to the other view, so it leaves this one rather than
         // sitting there contradicting the filter that produced the list.
-        return updated.archived === showArchived ? [updated] : [];
-      }),
-    );
+        return belongsHere ? [updated] : [];
+      });
+    });
     // The open transcript keeps its own copy of the index fields, and it's what
     // the composer reads `archived` from — left alone, settling the session on
     // screen would swap in the unsettle bar only after a reselect.


### PR DESCRIPTION
## TLDR for human

- Unsettle now returns the sidebar to the active list with that session still selected, from the composer's bar and the sidebar row's menu alike. Settle is unchanged.

---

Two affordances, one of them doing nothing but writing the flag. The composer's bar called `setSessionFlags` directly, so the row left the settled list it was drawn from, the view stayed settled, and the session the reader had just taken back was nowhere on screen. Both now go through one `handleSetSessionFlags` in `App`, which is where the sidebar's rule already lived.

The view flip alone did not cover it. The settled split keeps the selection across a toggle, so a settled session can be open while the sidebar shows the *active* list — and there the row belongs to the list on screen but has never been in it, so the write had no entry to map over and landed nowhere at all. `setSessionFlags` inserts it in that case.

Order is load-bearing and stays as it was: the flip follows the write, because `setSessionFlags` reads `showArchived` from its own closure to decide whether the row still belongs to the list on screen, and a flip ahead of it is invisible to that closure. Nothing else reads a stale flag — `showArchivedRef` is assigned during render, and the marks hook takes `repoPaths` reactively.

No test: this is hook and component wiring, where the repo's suite is scoped to pure logic that is invisible on screen. `tsc` clean, 369 frontend tests pass.

Fixes DRA-106
