### PR TITLE
Open markdown files in the side panel, with an edit mode

### DIFF
--- a/apps/desktop/src-tauri/src/docs.rs
+++ b/apps/desktop/src-tauri/src/docs.rs
@@ -1,0 +1,187 @@
+//! The disk half of the docs panel: read one markdown file, write it back.
+//!
+//! Both commands answer about a path the reader arrived at by clicking a link
+//! in a transcript, so every refusal here reaches them as a sentence in the
+//! panel rather than as a log line.
+
+use serde::Serialize;
+use tokio::fs;
+use ts_rs::TS;
+
+/// Past this a doc is refused rather than read. It happens to match `git.rs`'s
+/// own `MAX_BLOB`, and is kept separate because that one means "a blob whose
+/// diff we will render" — this one means a document small enough to read and
+/// edit in a third of a window.
+const MAX_DOC: u64 = 1 << 20;
+
+/// What a save did. `Stale` is not an error: the file moved under the reader,
+/// so their text is still in the editor and theirs to force through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[ts(export, export_to = "events.ts")]
+#[serde(rename_all = "snake_case")]
+pub enum SaveOutcome {
+    Saved,
+    Stale,
+}
+
+/// Reads one doc for the panel, or names why it can't.
+///
+/// The size is read before the body, so an oversized file is refused rather
+/// than pulled into memory and then rejected — the same reading `git.rs`'s two
+/// `cat-file` passes exist for.
+#[tauri::command]
+pub async fn read_doc(path: String) -> Result<String, String> {
+    let meta = fs::metadata(&path)
+        .await
+        .map_err(|_| "No file at this path.".to_string())?;
+    if !meta.is_file() {
+        return Err("Not a file — nothing to show here.".to_string());
+    }
+    if meta.len() > MAX_DOC {
+        return Err("File is too large to open here.".to_string());
+    }
+
+    let bytes = fs::read(&path).await.map_err(|e| e.to_string())?;
+    // Withheld rather than mangled: `from_utf8_lossy` would swap every invalid
+    // byte for U+FFFD and draw a confident view of a file that never existed —
+    // which the reader could then save back over the real one.
+    String::from_utf8(bytes).map_err(|_| "Not UTF-8 text — nothing to show.".to_string())
+}
+
+/// Writes a doc back, refusing to clobber a file that changed underneath.
+///
+/// `expect` is the text the editor was opened on: it is re-read here and
+/// compared, and a difference answers `Stale` with nothing written. `None` is
+/// the reader's own force — they were shown the clash and chose to overwrite —
+/// so it writes without comparing.
+#[tauri::command]
+pub async fn save_doc(
+    path: String,
+    text: String,
+    expect: Option<String>,
+) -> Result<SaveOutcome, String> {
+    // `fs::write` creates what it can't find, so this check is the whole of
+    // what keeps a mistyped path from quietly becoming a new file.
+    let meta = fs::metadata(&path)
+        .await
+        .map_err(|_| "No file at this path.".to_string())?;
+    if !meta.is_file() {
+        return Err("Not a file — nothing to save over.".to_string());
+    }
+
+    if let Some(base) = expect {
+        let current = fs::read(&path).await.map_err(|e| e.to_string())?;
+        if current != base.as_bytes() {
+            return Ok(SaveOutcome::Stale);
+        }
+    }
+
+    fs::write(&path, text).await.map_err(|e| e.to_string())?;
+    Ok(SaveOutcome::Saved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn scratch() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("dray-docs-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn at(dir: &PathBuf, name: &str) -> String {
+        dir.join(name).to_str().unwrap().to_string()
+    }
+
+    #[tokio::test]
+    async fn reads_back_what_it_saved() {
+        let dir = scratch();
+        let path = at(&dir, "notes.md");
+        std::fs::write(&path, "# one\n").unwrap();
+
+        assert_eq!(read_doc(path.clone()).await.unwrap(), "# one\n");
+        let outcome = save_doc(path.clone(), "# two\n".into(), Some("# one\n".into()))
+            .await
+            .unwrap();
+        assert_eq!(outcome, SaveOutcome::Saved);
+        assert_eq!(read_doc(path).await.unwrap(), "# two\n");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// The compare-and-swap is the point of the command: an outdated `expect`
+    /// has to leave the other writer's bytes exactly as they are.
+    #[tokio::test]
+    async fn a_stale_save_writes_nothing() {
+        let dir = scratch();
+        let path = at(&dir, "notes.md");
+        std::fs::write(&path, "# one\n").unwrap();
+        std::fs::write(&path, "# theirs\n").unwrap();
+
+        let outcome = save_doc(path.clone(), "# mine\n".into(), Some("# one\n".into()))
+            .await
+            .unwrap();
+        assert_eq!(outcome, SaveOutcome::Stale);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "# theirs\n");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_forced_save_lands_over_a_changed_file() {
+        let dir = scratch();
+        let path = at(&dir, "notes.md");
+        std::fs::write(&path, "# theirs\n").unwrap();
+
+        let outcome = save_doc(path.clone(), "# mine\n".into(), None).await.unwrap();
+        assert_eq!(outcome, SaveOutcome::Saved);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "# mine\n");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn refuses_a_directory() {
+        let dir = scratch();
+        let path = dir.to_str().unwrap().to_string();
+
+        assert!(read_doc(path).await.is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn refuses_bytes_that_are_not_text() {
+        let dir = scratch();
+        let path = at(&dir, "shot.md");
+        std::fs::write(&path, [0xff, 0xfe, 0x00]).unwrap();
+
+        assert!(read_doc(path).await.is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn refuses_a_file_over_the_cap() {
+        let dir = scratch();
+        let path = at(&dir, "huge.md");
+        std::fs::write(&path, vec![b'a'; MAX_DOC as usize + 1]).unwrap();
+
+        assert!(read_doc(path).await.is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn never_creates_a_missing_file() {
+        let dir = scratch();
+        let path = at(&dir, "typo.md");
+
+        assert!(save_doc(path.clone(), "# new\n".into(), None).await.is_err());
+        assert!(!std::path::Path::new(&path).exists());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/apps/desktop/src-tauri/src/docs.rs
+++ b/apps/desktop/src-tauri/src/docs.rs
@@ -6,6 +6,7 @@
 
 use serde::Serialize;
 use tokio::fs;
+use tokio::io::AsyncReadExt;
 use ts_rs::TS;
 
 /// Past this a doc is refused rather than read. It happens to match `git.rs`'s
@@ -28,7 +29,9 @@ pub enum SaveOutcome {
 ///
 /// The size is read before the body, so an oversized file is refused rather
 /// than pulled into memory and then rejected — the same reading `git.rs`'s two
-/// `cat-file` passes exist for.
+/// `cat-file` passes exist for. The read is capped as well as the metadata
+/// check, because the two are separate calls and a file being appended to
+/// between them would otherwise arrive at whatever length it had reached.
 #[tauri::command]
 pub async fn read_doc(path: String) -> Result<String, String> {
     let meta = fs::metadata(&path)
@@ -38,10 +41,10 @@ pub async fn read_doc(path: String) -> Result<String, String> {
         return Err("Not a file — nothing to show here.".to_string());
     }
     if meta.len() > MAX_DOC {
-        return Err("File is too large to open here.".to_string());
+        return Err(TOO_LARGE.to_string());
     }
 
-    let bytes = fs::read(&path).await.map_err(|e| e.to_string())?;
+    let bytes = read_capped(&path).await?;
     // Withheld rather than mangled: `from_utf8_lossy` would swap every invalid
     // byte for U+FFFD and draw a confident view of a file that never existed —
     // which the reader could then save back over the real one.
@@ -54,12 +57,27 @@ pub async fn read_doc(path: String) -> Result<String, String> {
 /// compared, and a difference answers `Stale` with nothing written. `None` is
 /// the reader's own force — they were shown the clash and chose to overwrite —
 /// so it writes without comparing.
+///
+/// **The comparison is a check, not a lock, and cannot be made into one.** A
+/// writer that lands between the read and the write is overwritten and this
+/// still answers `Saved`. Nothing here closes that: POSIX has no conditional
+/// write, and an advisory lock only binds writers who take it — the writer this
+/// guards against is an agent's own CLI, which takes none. What the check does
+/// buy is the case it was built for, where the file was rewritten at some point
+/// while the editor sat open, which is a window of minutes rather than of the
+/// microseconds between these two calls.
 #[tauri::command]
 pub async fn save_doc(
     path: String,
     text: String,
     expect: Option<String>,
 ) -> Result<SaveOutcome, String> {
+    // Checked on the way in as well as on the way out, or a reader could paste
+    // their way past the cap and save a file the panel then refuses to reopen.
+    if text.len() as u64 > MAX_DOC {
+        return Err(TOO_LARGE.to_string());
+    }
+
     // `fs::write` creates what it can't find, so this check is the whole of
     // what keeps a mistyped path from quietly becoming a new file.
     let meta = fs::metadata(&path)
@@ -70,7 +88,7 @@ pub async fn save_doc(
     }
 
     if let Some(base) = expect {
-        let current = fs::read(&path).await.map_err(|e| e.to_string())?;
+        let current = read_capped(&path).await?;
         if current != base.as_bytes() {
             return Ok(SaveOutcome::Stale);
         }
@@ -78,6 +96,28 @@ pub async fn save_doc(
 
     fs::write(&path, text).await.map_err(|e| e.to_string())?;
     Ok(SaveOutcome::Saved)
+}
+
+/// One sentence for both directions: a file too large to open is also one too
+/// large to write, and the reader meets the same limit either way.
+const TOO_LARGE: &str = "File is too large to open here.";
+
+/// Reads at most `MAX_DOC`, refusing anything longer rather than truncating it.
+///
+/// Reading one byte past the cap is what tells the two apart: a full buffer on
+/// its own only says the file is *at least* this long.
+async fn read_capped(path: &str) -> Result<Vec<u8>, String> {
+    let file = fs::File::open(path).await.map_err(|e| e.to_string())?;
+    let mut bytes = Vec::new();
+    file.take(MAX_DOC + 1)
+        .read_to_end(&mut bytes)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if bytes.len() as u64 > MAX_DOC {
+        return Err(TOO_LARGE.to_string());
+    }
+    Ok(bytes)
 }
 
 #[cfg(test)]
@@ -170,6 +210,21 @@ mod tests {
         std::fs::write(&path, vec![b'a'; MAX_DOC as usize + 1]).unwrap();
 
         assert!(read_doc(path).await.is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// The cap has to hold on the way in too, or a reader could paste their way
+    /// past it and save a file the panel then refuses to reopen.
+    #[tokio::test]
+    async fn refuses_to_save_past_the_cap() {
+        let dir = scratch();
+        let path = at(&dir, "notes.md");
+        std::fs::write(&path, "# one\n").unwrap();
+
+        let huge = "a".repeat(MAX_DOC as usize + 1);
+        assert!(save_doc(path.clone(), huge, None).await.is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "# one\n");
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod analytics;
 pub mod apps;
 pub mod attachments;
 pub mod binpath;
+pub mod docs;
 #[path = "events/events.rs"]
 pub mod events;
 pub mod files;
@@ -679,6 +680,8 @@ pub fn run() {
             github::mark_pr_ready,
             quit::confirm_quit,
             quit::dismiss_quit,
+            docs::read_doc,
+            docs::save_doc,
             apps::list_open_apps,
             apps::open_in_app,
             apps::open_login_terminal,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -8,6 +8,7 @@ import ChangesPanel from "@/components/ChangesPanel";
 import ChangesView from "@/components/changes/ChangesView";
 import ChatInput from "@/components/ChatInput";
 import DiffWorkerPool from "@/components/DiffWorkerPool";
+import DocsPanel from "@/components/DocsPanel";
 import NoticeStack from "@/components/NoticeStack";
 import QuitDialog from "@/components/QuitDialog";
 import SettingsDialog from "@/components/SettingsDialog";
@@ -42,6 +43,7 @@ import ViewTabs, { type ViewTab } from "@/components/layout/ViewTabs";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { pickAttachments } from "@/hooks/useAttachments";
 import { useCodeTheme } from "@/hooks/useCodeTheme";
+import { refreshActiveDoc, saveActiveDoc, useDocs } from "@/hooks/useDocs";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { useGlass } from "@/hooks/useGlass";
 import { warmHighlighter } from "@/hooks/useHighlighter";
@@ -448,7 +450,13 @@ function App() {
 
   const issueData = useSessionIssues(sessionIssues, panelShown && activeTabIsIssue);
 
-  const tabs = tabOrder({ pr: hasPrTab, issue: hasIssueTab });
+  // Read here rather than in the panel, for the PR tab's reason: the row has to
+  // know whether the tab exists before that tab has ever been drawn.
+  const { docs, activePath: activeDocPath, opened: docsOpened } = useDocs();
+  const hasDocsTab = docs.length > 0;
+  const activeDoc = docs.find((doc) => doc.path === activeDocPath) ?? null;
+
+  const tabs = tabOrder({ pr: hasPrTab, docs: hasDocsTab, issue: hasIssueTab });
 
   // One rule, read rather than written back: an explicit pick wins wherever it
   // still names a tab this session draws, and otherwise the derived default
@@ -572,7 +580,12 @@ function App() {
         ? { onRefresh: pullRequests.refresh, loading: pullRequests.loading }
         : activeTab === "issue"
           ? { onRefresh: issueData.refresh, loading: issueData.loading }
-          : null;
+          : activeTab === "docs"
+            ? {
+                onRefresh: refreshActiveDoc,
+                loading: activeDoc?.body.status === "loading",
+              }
+            : null;
 
   // Same order the sidebar draws, so the walk matches the list even when the
   // sidebar is collapsed and there is nothing on screen to follow — project
@@ -601,6 +614,23 @@ function App() {
       void handleSelectSessionIndexItem(item.sessionId);
     }
   };
+
+  // A click on a markdown path in the transcript, which is the one route in.
+  // Off the counter rather than off `docs.length`, since reopening a file that
+  // is already open leaves the list unchanged and still has to bring the pane
+  // forward.
+  //
+  // The pick moves as well as the pane, and has to, for the same reason
+  // `usePullRequest`'s `onOpened` writes one: `activeTab` honours a standing
+  // pick over the derived default, and `handleTogglePanel` stores "changes"
+  // every time the pane opens onto a turn that touched files.
+  const lastOpened = useRef(docsOpened);
+  useEffect(() => {
+    if (docsOpened === lastOpened.current) return;
+    lastOpened.current = docsOpened;
+    setPanelTab("docs");
+    setPanelOpen(true);
+  }, [docsOpened, setPanelTab, setPanelOpen]);
 
   // The pane is one piece of app-wide state, so a new task would otherwise
   // inherit whichever pane the last session left open — invisibly, since the
@@ -669,6 +699,10 @@ function App() {
     }
     if (panelShown) panelRefresh?.onRefresh();
   });
+  // ⌘S writes the doc on screen. Unregistered rather than a no-op off that tab:
+  // `useHotkey` claims every chord it matches, and ⌘S is the browser's own save
+  // — left bound everywhere it would eat the key from nothing at all.
+  useHotkey("s", saveActiveDoc, { enabled: panelShown && activeTab === "docs" });
   // By position in the tab row, so a third view needs only a third line here.
   // No-ops without a session, where there is no row to switch — and on the
   // issues page, where the row is not drawn: switching an invisible tab looks
@@ -913,8 +947,12 @@ function App() {
               // already says, and the count is news exactly when there is more
               // than one thing behind it.
               issue: sessionIssues.length > 1 ? sessionIssues.length : 0,
+              // Same rule, and beside it so the rule reads once: the count is
+              // news exactly when there is more than one file behind the tab.
+              docs: docs.length > 1 ? docs.length : 0,
             }}
             pr={hasPrTab}
+            docs={hasDocsTab}
             issue={hasIssueTab}
             refresh={panelRefresh}
             cwd={selectedSession.cwd}
@@ -934,6 +972,9 @@ function App() {
             </TabBody>
             <TabBody active={hasPrTab && activeTab === "pr"}>
               <PrPanel branch={prBranch} {...pullRequests} />
+            </TabBody>
+            <TabBody active={hasDocsTab && activeTab === "docs"}>
+              <DocsPanel />
             </TabBody>
             <TabBody active={hasIssueTab && activeTab === "issue"}>
               <IssuePanel

--- a/apps/desktop/src/components/DocsPanel.tsx
+++ b/apps/desktop/src/components/DocsPanel.tsx
@@ -80,6 +80,7 @@ export default function DocsPanel() {
         {active && isDirty(active) && (
           <Button
             size="sm"
+            variant="outline"
             // Full strength while the write is out: the spinner beside the verb
             // is the state, and dimming it too makes the one live thing in the
             // row the hardest part of it to read.
@@ -193,7 +194,11 @@ function ModeToggle({
   onChange: (next: DocMode) => void;
 }) {
   return (
-    <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-muted/50 p-0.5">
+    // `--surface-well`, the track token, rather than a muted fill: the well is
+    // a black scrim in both modes, so on a light page it cuts *into* the row
+    // instead of sitting a shade off it — which is what lets the thumb read as
+    // raised rather than as the one segment that happens to be greyer.
+    <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-surface-well p-0.5">
       {/* No tooltip. Both options are drawn side by side, so the pair says what
           each one does by contrast — a tooltip naming the glyph under the
           cursor tells the reader what they can already see. `aria-label` still
@@ -207,8 +212,13 @@ function ModeToggle({
           aria-pressed={value === mode}
           className={cn(
             "rounded-[min(var(--radius-md),6px)] p-1 transition-colors",
+            // The thumb has to come up past the surface the row is drawn at,
+            // out of the well the track cuts — so it takes `--surface-thumb`
+            // and the button shadow, the pair the composer's own segmented
+            // control uses. An accent fill is a veil, and a veil over a scrim
+            // is a few percent of light that reads as nothing.
             value === mode
-              ? "bg-sidebar-accent text-sidebar-accent-foreground"
+              ? "bg-surface-thumb text-foreground shadow-(--shadow-button)"
               : "text-muted-foreground hover:text-foreground",
           )}
         >

--- a/apps/desktop/src/components/DocsPanel.tsx
+++ b/apps/desktop/src/components/DocsPanel.tsx
@@ -80,7 +80,10 @@ export default function DocsPanel() {
         {active && isDirty(active) && (
           <Button
             size="sm"
-            className="shrink-0"
+            // Full strength while the write is out: the spinner beside the verb
+            // is the state, and dimming it too makes the one live thing in the
+            // row the hardest part of it to read.
+            className="shrink-0 disabled:opacity-100"
             disabled={active.body.status === "ready" && active.body.saving}
             onClick={() => saveDoc(active.path)}
           >

--- a/apps/desktop/src/components/DocsPanel.tsx
+++ b/apps/desktop/src/components/DocsPanel.tsx
@@ -53,6 +53,10 @@ export default function DocsPanel() {
   const active = docs.find((doc) => doc.path === activePath) ?? null;
 
   const close = (doc: Doc) => {
+    // Stated here as well as on the button, which is disabled for it: the
+    // dialog this opens promises the file is untouched, and a save already
+    // with the OS makes that untrue.
+    if (doc.body.status === "ready" && doc.body.saving) return;
     if (isDirty(doc)) return setConfirming(doc.path);
     closeDoc(doc.path);
   };
@@ -133,6 +137,7 @@ function Chip({
   onClose: () => void;
 }) {
   const { name } = splitPath(doc.path);
+  const saving = doc.body.status === "ready" && doc.body.saving;
 
   return (
     // The two buttons sit side by side inside the chip rather than nested, so
@@ -162,11 +167,17 @@ function Chip({
         <span aria-label="Unsaved" className="size-1.5 shrink-0 rounded-full bg-current" />
       )}
 
+      {/* Held back while a save is out, because closing cannot call it off.
+          The write is already with the OS, so "Discard edits" would name
+          something this app can no longer do — and the file would land with
+          the very text the reader was told had been thrown away. A save is a
+          keystroke's worth of wait; the button comes back on its own. */}
       <button
         type="button"
         onClick={onClose}
+        disabled={saving}
         aria-label={`Close ${name}`}
-        className="shrink-0 rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
+        className="shrink-0 rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
       >
         <X className="size-3" strokeWidth={1.5} />
       </button>

--- a/apps/desktop/src/components/DocsPanel.tsx
+++ b/apps/desktop/src/components/DocsPanel.tsx
@@ -1,0 +1,321 @@
+import { useState } from "react";
+import { Eye, Loader2, Pencil, X } from "lucide-react";
+
+import FileIcon from "@/components/FileIcon";
+import { Markdown } from "@/components/chat/Markdown";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  closeDoc,
+  isDirty,
+  reloadDoc,
+  saveDoc,
+  selectDoc,
+  setDocDraft,
+  setDocMode,
+  useDocs,
+  type Doc,
+  type DocMode,
+} from "@/hooks/useDocs";
+import { splitPath } from "@/lib/changes";
+import { cn } from "@/lib/utils";
+
+/// A markdown file from the transcript, rendered and editable.
+///
+/// A plain textarea rather than an editor library. Native undo, the caret and
+/// IME all come free, the app takes no new dependency, and the composer next
+/// door already proves the mirrored-overlay technique is here if syntax
+/// colouring is ever wanted for this too.
+///
+/// Reads the store directly rather than taking it as props. `App` holds the
+/// hook because the tab row has to know whether the tab exists before this is
+/// ever drawn, but every mutator is already a module-level export — so
+/// threading them through would put the panel's whole surface into `App`'s JSX
+/// to say what `useDocs` says here.
+///
+/// No empty state: the tab is only drawn while something is open.
+export default function DocsPanel() {
+  const { docs, activePath } = useDocs();
+  // Named by path rather than held as the doc, so the dialog cannot go on
+  // asking about a file that has since been closed from somewhere else.
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  const active = docs.find((doc) => doc.path === activePath) ?? null;
+
+  const close = (doc: Doc) => {
+    if (isDirty(doc)) return setConfirming(doc.path);
+    closeDoc(doc.path);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* One row, not two. With a single file open, a strip of chips and a
+          separate filename header say the same thing twice. */}
+      <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border px-2">
+        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+          {docs.map((doc) => (
+            <Chip
+              key={doc.path}
+              doc={doc}
+              active={doc.path === activePath}
+              onSelect={() => selectDoc(doc.path)}
+              onClose={() => close(doc)}
+            />
+          ))}
+        </div>
+
+        {/* Only while there is something to write. A Save that is always drawn
+            and mostly disabled explains nothing about why it cannot be
+            pressed. */}
+        {active && isDirty(active) && (
+          <Button
+            size="sm"
+            className="shrink-0"
+            disabled={active.body.status === "ready" && active.body.saving}
+            onClick={() => saveDoc(active.path)}
+          >
+            {active.body.status === "ready" && active.body.saving && (
+              <Loader2 className="animate-spin" />
+            )}
+            Save
+          </Button>
+        )}
+
+        {active && (
+          <ModeToggle
+            value={active.mode}
+            onChange={(mode) => setDocMode(active.path, mode)}
+          />
+        )}
+      </div>
+
+      {active && <Strip doc={active} />}
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        {active && <Body doc={active} />}
+      </div>
+
+      <CloseConfirm
+        path={confirming}
+        onConfirm={() => {
+          if (confirming) closeDoc(confirming);
+          setConfirming(null);
+        }}
+        onClose={() => setConfirming(null)}
+      />
+    </div>
+  );
+}
+
+function Chip({
+  doc,
+  active,
+  onSelect,
+  onClose,
+}: {
+  doc: Doc;
+  active: boolean;
+  onSelect: () => void;
+  onClose: () => void;
+}) {
+  const { name } = splitPath(doc.path);
+
+  return (
+    // The two buttons sit side by side inside the chip rather than nested, so
+    // each is its own tab stop and neither is a control inside a control.
+    <div
+      // `title` carries the full path, which is the one thing this row is
+      // truncating — and the only place a doc opened from another project's
+      // transcript says where it came from.
+      title={doc.path}
+      className={cn(
+        "flex shrink-0 items-center gap-1 rounded-md pl-1.5 pr-1 text-ui",
+        active
+          ? "bg-sidebar-accent text-sidebar-accent-foreground"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        className="flex min-w-0 items-center gap-1.5 py-1"
+      >
+        <FileIcon path={doc.path} className="size-3.5" />
+        <span className="max-w-40 truncate">{name}</span>
+      </button>
+
+      {isDirty(doc) && (
+        <span aria-label="Unsaved" className="size-1.5 shrink-0 rounded-full bg-current" />
+      )}
+
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label={`Close ${name}`}
+        className="shrink-0 rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
+      >
+        <X className="size-3" strokeWidth={1.5} />
+      </button>
+    </div>
+  );
+}
+
+const MODES: { value: DocMode; label: string; Icon: typeof Eye }[] = [
+  { value: "view", label: "Read", Icon: Eye },
+  { value: "edit", label: "Edit", Icon: Pencil },
+];
+
+/// Both options drawn, with the active one filled — the same control the diff
+/// pane's split/unified toggle is, and for its reason: a single glyph that
+/// swapped on click reads as a picture of the current state rather than as
+/// something that can be pressed.
+///
+/// Per doc, not one setting for the panel. A reader flipping their notes into
+/// edit mode has said nothing about the readme in the chip beside it.
+function ModeToggle({
+  value,
+  onChange,
+}: {
+  value: DocMode;
+  onChange: (next: DocMode) => void;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-muted/50 p-0.5">
+      {MODES.map(({ value: mode, label, Icon }) => (
+        <Tooltip key={mode}>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => onChange(mode)}
+              aria-label={label}
+              aria-pressed={value === mode}
+              className={cn(
+                "rounded-[min(var(--radius-md),6px)] p-1 transition-colors",
+                value === mode
+                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Icon className="size-3.5" strokeWidth={1.5} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">{label}</TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}
+
+/// What the reader has to settle before the body means anything.
+///
+/// Neither Reload nor Overwrite takes the destructive fill, because both lose
+/// something: one drops the reader's edits, the other drops whatever wrote the
+/// file underneath them. Red belongs on the one irreversible thing in a
+/// dialog, and here there are two of them with nothing to choose between on
+/// colour alone.
+function Strip({ doc }: { doc: Doc }) {
+  if (doc.body.status !== "ready") return null;
+  const { stale, saveError } = doc.body;
+  if (!stale && !saveError) return null;
+
+  return (
+    <div className="shrink-0 space-y-1.5 border-b border-border px-3 py-2 text-ui">
+      {stale && (
+        <div className="flex items-center gap-2">
+          <span className="min-w-0 flex-1 text-muted-foreground">
+            This file changed on disk since you opened it.
+          </span>
+          <Button size="sm" variant="outline" onClick={() => reloadDoc(doc.path)}>
+            Reload
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => saveDoc(doc.path, { force: true })}
+          >
+            Overwrite
+          </Button>
+        </div>
+      )}
+      {saveError && <p className="text-destructive">{saveError}</p>}
+    </div>
+  );
+}
+
+function Body({ doc }: { doc: Doc }) {
+  if (doc.body.status === "loading") {
+    return <p className="px-3 py-2 text-ui text-muted-foreground">Reading the file…</p>;
+  }
+  if (doc.body.status === "error") {
+    return <p className="px-3 py-2 text-ui text-destructive">{doc.body.message}</p>;
+  }
+
+  if (doc.mode === "view") {
+    return (
+      <div className="px-3 py-2">
+        {/* `linkFilePaths` stays off. It is on for the assistant's own messages
+            alone, and a doc's relative links are markdown the author wrote —
+            Streamdown's business, not this app's. */}
+        <Markdown>{doc.body.draft}</Markdown>
+      </div>
+    );
+  }
+
+  return (
+    <textarea
+      // Per doc, so switching chips gives each file its own element and the
+      // caret cannot arrive in one file where it was left in another. The tab
+      // being hidden keeps this mounted either way.
+      key={doc.path}
+      value={doc.body.draft}
+      onChange={(e) => setDocDraft(doc.path, e.target.value)}
+      spellCheck={false}
+      // Tab is deliberately left alone: stealing it takes the keyboard's way
+      // out of this box, and markdown lists need no indent to be written.
+      className="h-full w-full resize-none bg-transparent px-3 py-2 font-mono text-code outline-none"
+    />
+  );
+}
+
+function CloseConfirm({
+  path,
+  onConfirm,
+  onClose,
+}: {
+  path: string | null;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <AlertDialog open={path !== null} onOpenChange={(next) => !next && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Close without saving?</AlertDialogTitle>
+          <AlertDialogDescription>
+            <span className="font-medium text-foreground">
+              {path && splitPath(path).name}
+            </span>{" "}
+            has unsaved edits. Closing it here discards them. The file on disk is
+            untouched.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep editing</AlertDialogCancel>
+          <AlertDialogAction destructive onClick={onConfirm}>
+            Discard edits
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/desktop/src/components/DocsPanel.tsx
+++ b/apps/desktop/src/components/DocsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Eye, Loader2, Pencil, X } from "lucide-react";
 
 import FileIcon from "@/components/FileIcon";
@@ -14,7 +14,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   closeDoc,
   isDirty,
@@ -28,6 +27,7 @@ import {
   type DocMode,
 } from "@/hooks/useDocs";
 import { splitPath } from "@/lib/changes";
+import { FIRST_SECTIONS, SECTION_STEP, splitMarkdownSections } from "@/lib/markdown";
 import { cn } from "@/lib/utils";
 
 /// A markdown file from the transcript, rendered and editable.
@@ -194,26 +194,26 @@ function ModeToggle({
 }) {
   return (
     <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-muted/50 p-0.5">
+      {/* No tooltip. Both options are drawn side by side, so the pair says what
+          each one does by contrast — a tooltip naming the glyph under the
+          cursor tells the reader what they can already see. `aria-label` still
+          carries the word for anyone not reading the shape. */}
       {MODES.map(({ value: mode, label, Icon }) => (
-        <Tooltip key={mode}>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => onChange(mode)}
-              aria-label={label}
-              aria-pressed={value === mode}
-              className={cn(
-                "rounded-[min(var(--radius-md),6px)] p-1 transition-colors",
-                value === mode
-                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <Icon className="size-3.5" strokeWidth={1.5} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="left">{label}</TooltipContent>
-        </Tooltip>
+        <button
+          key={mode}
+          type="button"
+          onClick={() => onChange(mode)}
+          aria-label={label}
+          aria-pressed={value === mode}
+          className={cn(
+            "rounded-[min(var(--radius-md),6px)] p-1 transition-colors",
+            value === mode
+              ? "bg-sidebar-accent text-sidebar-accent-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <Icon className="size-3.5" strokeWidth={1.5} />
+        </button>
       ))}
     </div>
   );
@@ -264,14 +264,9 @@ function Body({ doc }: { doc: Doc }) {
   }
 
   if (doc.mode === "view") {
-    return (
-      <div className="px-3 py-2">
-        {/* `linkFilePaths` stays off. It is on for the assistant's own messages
-            alone, and a doc's relative links are markdown the author wrote —
-            Streamdown's business, not this app's. */}
-        <Markdown>{doc.body.draft}</Markdown>
-      </div>
-    );
+    // Keyed on the path so switching chips starts the next document at its own
+    // top rather than inheriting how far the last one had mounted.
+    return <Rendered key={doc.path} text={doc.body.draft} />;
   }
 
   return (
@@ -287,6 +282,48 @@ function Body({ doc }: { doc: Doc }) {
       // out of this box, and markdown lists need no indent to be written.
       className="h-full w-full resize-none bg-transparent px-3 py-2 font-mono text-code outline-none"
     />
+  );
+}
+
+/// The document, mounted a few sections at a time.
+///
+/// One commit was what made a long file take seconds to open: 282KB of markdown
+/// measured at 930ms of parsing before any of the 608KB of HTML it produces
+/// reached the DOM, and the commit and layout of that tree after it. A reader
+/// opens a document at its top, so the top is what has to be on screen — the
+/// rest arrives behind it, which is the bargain the transcript's own backfill
+/// makes for a long session.
+///
+/// The total work is unchanged. What changes is that the main thread comes back
+/// between steps, so the panel is readable and scrollable throughout instead of
+/// frozen until the last section lands.
+function Rendered({ text }: { text: string }) {
+  const sections = useMemo(() => splitMarkdownSections(text), [text]);
+  const [mounted, setMounted] = useState(FIRST_SECTIONS);
+
+  useEffect(() => {
+    if (mounted >= sections.length) return;
+    // A macrotask rather than a frame: this is parse work, and yielding to the
+    // event loop is what keeps a click or a keystroke from queueing behind it.
+    const id = setTimeout(() => setMounted((n) => n + SECTION_STEP), 0);
+    return () => clearTimeout(id);
+  }, [mounted, sections.length]);
+
+  return (
+    <div className="px-3 py-2">
+      {sections.slice(0, mounted).map((section, i) => (
+        // `Markdown` strips its own first child's top margin, which is right for
+        // one message in a transcript and wrong for a section stacked under
+        // another — without this every heading after the first would sit flush
+        // against the paragraph above it.
+        <div key={i} className={i > 0 ? "mt-4" : undefined}>
+          {/* `linkFilePaths` stays off. It is on for the assistant's own
+              messages alone, and a doc's relative links are markdown the author
+              wrote — Streamdown's business, not this app's. */}
+          <Markdown>{section}</Markdown>
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -257,8 +257,6 @@ export default function RightPanel({
   heading,
   children,
 }: RightPanelProps) {
-  // Read once rather than per render of the row: the count decides whether the
-  // keycaps are affordable as well as what gets drawn.
   const tabs = tabOrder({ pr, docs, issue });
 
   return (
@@ -282,23 +280,41 @@ export default function RightPanel({
           // lands on the same baseline whichever frame it is wearing.
           <span className="px-2 py-1 text-ui font-medium">{heading}</span>
         ) : (
-          // `min-w-0` and its own scroll, so a row that outgrows the pane gives
-          // way here rather than pushing Open and Refresh past the right edge.
-          // The controls are what a reader reaches for by position; a tab they
-          // can still scroll to is the cheaper thing to lose.
-          <div className="flex min-w-0 items-center gap-0.5 overflow-x-auto">
-            {tabs.map((value) => (
-              <TabButton
-                key={value}
-                active={tab === value}
-                onClick={() => onTabChange(value)}
-              >
-                {LABELS[value]}
-                {!!counts?.[value] && (
-                  <span className="ml-1 text-muted-foreground">{counts[value]}</span>
-                )}
-              </TabButton>
-            ))}
+          // A wrapping row clipped to one line's height, which is what sheds the
+          // keycaps exactly when they stop fitting and never a tab sooner.
+          //
+          // Flex breaks a line *between* items, never through one, so the caps
+          // are dropped whole — where clipping them with `overflow-hidden`
+          // alone leaves half a cap on screen, which reads as broken rather
+          // than as a hint that stood down. `h-full` on this row and on the
+          // caps beside it is what fixes the line's height without naming a
+          // number: the caps define the line, the line is the container, and
+          // anything sent to a second line is outside it.
+          //
+          // `content-start` pins that first line to the top, or a two-line
+          // layout would centre both and clip the tabs' own tops. Measuring in
+          // JS would answer the same question and is not worth a resize
+          // observer on a row this small.
+          <div className="flex h-full min-w-0 flex-wrap content-start items-center gap-0.5 overflow-hidden">
+            {/* The tabs are one item on that line, with their own scroll: a row
+                that outgrows the pane even after the caps have gone gives way
+                here rather than pushing Open and Refresh past the right edge.
+                The controls are what a reader reaches for by position; a tab
+                they can still scroll to is the cheaper thing to lose. */}
+            <div className="flex min-w-0 items-center gap-0.5 overflow-x-auto">
+              {tabs.map((value) => (
+                <TabButton
+                  key={value}
+                  active={tab === value}
+                  onClick={() => onTabChange(value)}
+                >
+                  {LABELS[value]}
+                  {!!counts?.[value] && (
+                    <span className="ml-1 text-muted-foreground">{counts[value]}</span>
+                  )}
+                </TabButton>
+              ))}
+            </div>
 
             {/* Beside the tabs rather than at the far end, and with no label:
                 next to the thing it acts on, the caps read as belonging to the
@@ -307,12 +323,12 @@ export default function RightPanel({
                 because a chord for a row of two or three tabs is one nobody
                 goes looking for.
 
-                Which is also why they go once the row is longer than that. The
-                argument for drawing them was a short row nobody would think to
-                explore, and at four tabs it stops holding while the caps go on
-                costing the ~70px that pushed Open and Refresh off the edge. The
-                hint is the only thing in this row that does nothing, so it is
-                the first thing to give up when the row cannot afford it.
+                Last in the row and the only thing in it allowed to wrap, so a
+                pane too full for both loses these ~70px rather than its Open
+                and Refresh controls. The hint is the one element here that does
+                nothing, which makes it the one to give up — but only when the
+                row genuinely cannot afford it, not at a tab count guessed in
+                advance.
 
                 Three caps, not four: `[ ]` is one key with two ends rather than
                 two alternatives, so splitting it reads as a chord wanting
@@ -327,13 +343,11 @@ export default function RightPanel({
                 light takes no opacity at all; the caps there are already quieter
                 than their dark twins, `--muted` being a black veil on a near-white
                 page rather than a white one on near-black. */}
-            {tabs.length <= 3 && (
-              <KbdGroup className="ml-1.5 shrink-0 dark:opacity-50">
-                <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
-                <Kbd>⇧</Kbd>
-                <Kbd>[ ]</Kbd>
-              </KbdGroup>
-            )}
+            <KbdGroup className="ml-1.5 h-full shrink-0 dark:opacity-50">
+              <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+              <Kbd>⇧</Kbd>
+              <Kbd>[ ]</Kbd>
+            </KbdGroup>
           </div>
         )}
 

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -117,7 +117,7 @@ export function PanelToggle({
 
 /// Which body the right panel is showing. This is the set, not the order —
 /// see `tabOrder`.
-export const PANEL_TABS = ["changes", "subagents", "pr", "issue"] as const;
+export const PANEL_TABS = ["changes", "subagents", "pr", "issue", "docs"] as const;
 
 export type PanelTab = (typeof PANEL_TABS)[number];
 
@@ -127,6 +127,9 @@ const LABELS: Record<PanelTab, string> = {
   // Singular, and not "Linear": the panel is about the work's issue whoever
   // tracks it, and a session usually carries one.
   issue: "Issue",
+  // Plural where Issue is singular: a session takes up one piece of tracked
+  // work and opens as many files as it takes to read it.
+  docs: "Docs",
   // Not "Pull Request": the short form is what anyone working on one calls it,
   // and the long one is the widest label in a row of three.
   pr: "PR",
@@ -148,8 +151,20 @@ const LABELS: Record<PanelTab, string> = {
 /// The PR tab is absent entirely for a session that has no PR to show — see
 /// `prTabVisible`. A tab whose only content is "there is nothing here" is one
 /// the eye has to skip past on every session that will never have one.
-export function tabOrder({ pr, issue }: { pr: boolean; issue: boolean }): readonly PanelTab[] {
+export function tabOrder({
+  pr,
+  docs,
+  issue,
+}: {
+  pr: boolean;
+  /// At least one markdown file is open in the pane — see
+  /// [useDocs](../hooks/useDocs.ts). Absent otherwise, for the PR tab's reason.
+  docs: boolean;
+  issue: boolean;
+}): readonly PanelTab[] {
   const tabs: PanelTab[] = pr ? ["pr", "changes"] : ["changes"];
+  // After Changes, which is what keeps Issue immediately before Subagents.
+  if (docs) tabs.push("docs");
   // Immediately before Subagents wherever it is drawn, so the row's order is
   // the same one ⌘⇧[ steps whether or not a session has an issue on it.
   if (issue) tabs.push("issue");
@@ -170,6 +185,8 @@ type RightPanelProps = {
   counts?: Partial<Record<PanelTab, number>>;
   /// There is a pull request tab to draw at all — see `prTabVisible`.
   pr?: boolean;
+  /// At least one markdown file is open in the pane.
+  docs?: boolean;
   /// This session is tagged with at least one issue. Absent otherwise, for the
   /// PR tab's reason: a tab whose only content is "there is nothing here" is one
   /// the eye skips past on every session that will never have one.
@@ -233,6 +250,7 @@ export default function RightPanel({
   onTabChange,
   counts,
   pr = false,
+  docs = false,
   issue = false,
   refresh,
   cwd,
@@ -261,7 +279,7 @@ export default function RightPanel({
           <span className="px-2 py-1 text-ui font-medium">{heading}</span>
         ) : (
           <>
-            {tabOrder({ pr, issue }).map((value) => (
+            {tabOrder({ pr, docs, issue }).map((value) => (
               <TabButton
                 key={value}
                 active={tab === value}

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -286,10 +286,16 @@ export default function RightPanel({
           // Flex breaks a line *between* items, never through one, so the caps
           // are dropped whole — where clipping them with `overflow-hidden`
           // alone leaves half a cap on screen, which reads as broken rather
-          // than as a hint that stood down. `h-full` on this row and on the
-          // caps beside it is what fixes the line's height without naming a
-          // number: the caps define the line, the line is the container, and
-          // anything sent to a second line is outside it.
+          // than as a hint that stood down. `h-full` on this row and on both
+          // items in it is what fixes the line's height without naming a
+          // number: the first line is the container, so a second one is
+          // entirely outside it.
+          //
+          // Both items, not just the caps. A line is only as tall as what is
+          // left on it, so caps that carried the height alone took it with them
+          // when they wrapped — the row collapsed to the tabs' own height and
+          // the second line surfaced in the ~10px left over, drawing the top of
+          // every cap it was meant to have dropped.
           //
           // `content-start` pins that first line to the top, or a two-line
           // layout would centre both and clip the tabs' own tops. Measuring in
@@ -301,7 +307,7 @@ export default function RightPanel({
                 here rather than pushing Open and Refresh past the right edge.
                 The controls are what a reader reaches for by position; a tab
                 they can still scroll to is the cheaper thing to lose. */}
-            <div className="flex min-w-0 items-center gap-0.5 overflow-x-auto">
+            <div className="flex h-full min-w-0 items-center gap-0.5 overflow-x-auto">
               {tabs.map((value) => (
                 <TabButton
                   key={value}

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -280,33 +280,22 @@ export default function RightPanel({
           // lands on the same baseline whichever frame it is wearing.
           <span className="px-2 py-1 text-ui font-medium">{heading}</span>
         ) : (
-          // A wrapping row clipped to one line's height, which is what sheds the
-          // keycaps exactly when they stop fitting and never a tab sooner.
+          // A wrapping row clipped to one line, which sheds the keycaps when
+          // they stop fitting and never a tab sooner — the CSS answer to a
+          // question a resize observer would otherwise have to measure.
           //
-          // Flex breaks a line *between* items, never through one, so the caps
-          // are dropped whole — where clipping them with `overflow-hidden`
-          // alone leaves half a cap on screen, which reads as broken rather
-          // than as a hint that stood down. `h-full` on this row and on both
-          // items in it is what fixes the line's height without naming a
-          // number: the first line is the container, so a second one is
-          // entirely outside it.
-          //
-          // Both items, not just the caps. A line is only as tall as what is
-          // left on it, so caps that carried the height alone took it with them
-          // when they wrapped — the row collapsed to the tabs' own height and
-          // the second line surfaced in the ~10px left over, drawing the top of
-          // every cap it was meant to have dropped.
-          //
-          // `content-start` pins that first line to the top, or a two-line
-          // layout would centre both and clip the tabs' own tops. Measuring in
-          // JS would answer the same question and is not worth a resize
-          // observer on a row this small.
+          // Flex breaks a line between items, never through one, so the caps go
+          // whole where `overflow-hidden` alone would leave half of one on
+          // screen. `h-full` on **both** items is what holds the line open: a
+          // line is only as tall as what is left on it, so caps carrying the
+          // height alone took it with them when they wrapped and the second
+          // line surfaced in the slack. `content-start` pins the first line to
+          // the top, or two lines would centre and clip the tabs.
           <div className="flex h-full min-w-0 flex-wrap content-start items-center gap-0.5 overflow-hidden">
-            {/* The tabs are one item on that line, with their own scroll: a row
-                that outgrows the pane even after the caps have gone gives way
-                here rather than pushing Open and Refresh past the right edge.
-                The controls are what a reader reaches for by position; a tab
-                they can still scroll to is the cheaper thing to lose. */}
+            {/* Their own scroll, so a row still too long after the caps have
+                gone gives way here rather than pushing Open and Refresh past
+                the edge: those are reached for by position, where a tab can
+                still be scrolled to. */}
             <div className="flex h-full min-w-0 items-center gap-0.5 overflow-x-auto">
               {tabs.map((value) => (
                 <TabButton
@@ -329,12 +318,10 @@ export default function RightPanel({
                 because a chord for a row of two or three tabs is one nobody
                 goes looking for.
 
-                Last in the row and the only thing in it allowed to wrap, so a
-                pane too full for both loses these ~70px rather than its Open
-                and Refresh controls. The hint is the one element here that does
-                nothing, which makes it the one to give up — but only when the
-                row genuinely cannot afford it, not at a tab count guessed in
-                advance.
+                Last in the row and the only thing allowed to wrap: the hint is
+                the one element here that does nothing, so it is the one to give
+                up — but only when the row cannot afford it, never at a tab
+                count guessed in advance.
 
                 Three caps, not four: `[ ]` is one key with two ends rather than
                 two alternatives, so splitting it reads as a chord wanting

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -257,6 +257,10 @@ export default function RightPanel({
   heading,
   children,
 }: RightPanelProps) {
+  // Read once rather than per render of the row: the count decides whether the
+  // keycaps are affordable as well as what gets drawn.
+  const tabs = tabOrder({ pr, docs, issue });
+
   return (
     <aside
       className={cn(
@@ -278,8 +282,12 @@ export default function RightPanel({
           // lands on the same baseline whichever frame it is wearing.
           <span className="px-2 py-1 text-ui font-medium">{heading}</span>
         ) : (
-          <>
-            {tabOrder({ pr, docs, issue }).map((value) => (
+          // `min-w-0` and its own scroll, so a row that outgrows the pane gives
+          // way here rather than pushing Open and Refresh past the right edge.
+          // The controls are what a reader reaches for by position; a tab they
+          // can still scroll to is the cheaper thing to lose.
+          <div className="flex min-w-0 items-center gap-0.5 overflow-x-auto">
+            {tabs.map((value) => (
               <TabButton
                 key={value}
                 active={tab === value}
@@ -299,6 +307,13 @@ export default function RightPanel({
                 because a chord for a row of two or three tabs is one nobody
                 goes looking for.
 
+                Which is also why they go once the row is longer than that. The
+                argument for drawing them was a short row nobody would think to
+                explore, and at four tabs it stops holding while the caps go on
+                costing the ~70px that pushed Open and Refresh off the edge. The
+                hint is the only thing in this row that does nothing, so it is
+                the first thing to give up when the row cannot afford it.
+
                 Three caps, not four: `[ ]` is one key with two ends rather than
                 two alternatives, so splitting it reads as a chord wanting
                 both. */}
@@ -312,12 +327,14 @@ export default function RightPanel({
                 light takes no opacity at all; the caps there are already quieter
                 than their dark twins, `--muted` being a black veil on a near-white
                 page rather than a white one on near-black. */}
-            <KbdGroup className="ml-1.5 shrink-0 dark:opacity-50">
-              <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
-              <Kbd>⇧</Kbd>
-              <Kbd>[ ]</Kbd>
-            </KbdGroup>
-          </>
+            {tabs.length <= 3 && (
+              <KbdGroup className="ml-1.5 shrink-0 dark:opacity-50">
+                <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+                <Kbd>⇧</Kbd>
+                <Kbd>[ ]</Kbd>
+              </KbdGroup>
+            )}
+          </div>
         )}
 
         {/* The far end of the row, and one group rather than two `ml-auto`s:

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -236,7 +236,7 @@ function OpenFilesRow() {
       label="Open files with"
       description={
         unavailable ??
-        "Where a filename in the chat opens. Finder selects the file instead of opening it."
+        "Where a filename in the chat opens. Markdown opens in the panel instead, and Finder selects a file rather than opening it."
       }
     >
       {/* Opening the menu re-reads the list — see `refresh`. */}

--- a/apps/desktop/src/components/changes/DiffPane.tsx
+++ b/apps/desktop/src/components/changes/DiffPane.tsx
@@ -155,7 +155,11 @@ function StyleToggle({
   onChange: (next: DiffStyle) => void;
 }) {
   return (
-    <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-muted/50 p-0.5">
+    // `--surface-well`, the track token, rather than a muted fill: the well is
+    // a black scrim in both modes, so on a light page it cuts *into* the row
+    // instead of sitting a shade off it — which is what lets the thumb read as
+    // raised rather than as the one segment that happens to be greyer.
+    <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-surface-well p-0.5">
       {STYLES.map(({ value: style, label, Icon }) => (
         <Tooltip key={style}>
           <TooltipTrigger asChild>
@@ -166,8 +170,14 @@ function StyleToggle({
               aria-pressed={value === style}
               className={cn(
                 "rounded-[min(var(--radius-md),6px)] p-1 transition-colors",
+                // The thumb has to come up past the surface the row is drawn
+                // at, out of the well the track cuts — so it takes
+                // `--surface-thumb` and the button shadow, the pair the
+                // composer's own segmented control uses. An accent fill is a
+                // veil, and a veil over a scrim is a few percent of light that
+                // reads as nothing.
                 value === style
-                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                  ? "bg-surface-thumb text-foreground shadow-(--shadow-button)"
                   : "text-muted-foreground hover:text-foreground",
               )}
             >

--- a/apps/desktop/src/components/chat/FileLink.tsx
+++ b/apps/desktop/src/components/chat/FileLink.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode, SyntheticEvent } from "react";
 
-import { openFile } from "@/lib/openWith";
+import { openPath } from "@/hooks/useDocs";
 import { cn } from "@/lib/utils";
 
 /// A path anywhere in the chat, drawn as something that opens.
@@ -39,7 +39,9 @@ export default function FileLink({
 }) {
   const open = (e: SyntheticEvent) => {
     e.stopPropagation();
-    void openFile(path);
+    // Markdown opens in the Docs panel and everything else in the reader's
+    // editor. A file this app can already render is not one to leave Dray for.
+    openPath(path);
   };
 
   return (

--- a/apps/desktop/src/components/chat/FileLink.tsx
+++ b/apps/desktop/src/components/chat/FileLink.tsx
@@ -28,8 +28,9 @@ export default function FileLink({
   children,
 }: {
   /// Absolute, and already resolved. This draws whatever it is given and asks
-  /// nothing about whether the file is there, since `openFile` reveals as its
-  /// fallback and revealing something gone is a click that does nothing.
+  /// nothing about whether the file is there: a markdown path that names
+  /// nothing opens a doc whose panel says so, and every other one falls through
+  /// to a reveal, where revealing something gone is a click that does nothing.
   path: string;
   title?: string;
   /// This was a markdown link before it was a file link, so draw it as one.

--- a/apps/desktop/src/hooks/useDocs.test.ts
+++ b/apps/desktop/src/hooks/useDocs.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { isDirty, withDiskText, type Doc, type DocBody } from "./useDocs";
+
+const ready = (base: string, draft = base, rest: Partial<DocBody> = {}) =>
+  ({
+    status: "ready",
+    base,
+    draft,
+    stale: false,
+    saving: false,
+    saveError: null,
+    ...rest,
+  }) as Extract<DocBody, { status: "ready" }>;
+
+const doc = (body: DocBody): Doc => ({ path: "/a/README.md", mode: "view", body });
+
+describe("isDirty", () => {
+  it("is the draft against what it was made from, and nothing else", () => {
+    expect(isDirty(doc(ready("hi")))).toBe(false);
+    expect(isDirty(doc(ready("hi", "hi there")))).toBe(true);
+  });
+
+  // A doc edited back to what it said is not something to warn about closing,
+  // which is the whole reason this is read off the text rather than latched by
+  // the first keystroke.
+  it("goes clean again where the reader types the file back", () => {
+    expect(isDirty(doc(ready("hi", "hi")))).toBe(false);
+  });
+
+  it("says no before the text has arrived, and where it never will", () => {
+    expect(isDirty(doc({ status: "loading" }))).toBe(false);
+    expect(isDirty(doc({ status: "error", message: "not a regular file" }))).toBe(false);
+  });
+});
+
+describe("withDiskText", () => {
+  it("takes the file where the reader has changed nothing", () => {
+    const next = withDiskText(ready("old"), "new");
+    expect(next.base).toBe("new");
+    expect(next.draft).toBe("new");
+    expect(next.stale).toBe(false);
+  });
+
+  it("keeps the draft and flags it where both sides moved", () => {
+    const next = withDiskText(ready("old", "mine"), "theirs");
+    expect(next.draft).toBe("mine");
+    expect(next.stale).toBe(true);
+  });
+
+  // `base` is what the next save sends as `expect`. Moving it to the disk text
+  // would make the backend's compare-and-swap pass and quietly overwrite the
+  // write that caused the flag in the first place.
+  it("leaves base alone on the stale branch, so the next save still refuses", () => {
+    expect(withDiskText(ready("old", "mine"), "theirs").base).toBe("old");
+  });
+
+  it("is no news where the file says what it said", () => {
+    const before = ready("old", "mine");
+    expect(withDiskText(before, "old")).toBe(before);
+  });
+
+  // A doc already flagged and then reloaded elsewhere must not clear its own
+  // warning by adopting: the draft is still unsaved.
+  it("keeps a standing flag while the draft is still dirty", () => {
+    expect(withDiskText(ready("old", "mine", { stale: true }), "later").stale).toBe(true);
+  });
+
+  it("clears the flag once the draft matches base again", () => {
+    const next = withDiskText(ready("old", "old", { stale: true }), "theirs");
+    expect(next.stale).toBe(false);
+    expect(next.draft).toBe("theirs");
+  });
+});

--- a/apps/desktop/src/hooks/useDocs.ts
+++ b/apps/desktop/src/hooks/useDocs.ts
@@ -1,0 +1,355 @@
+import { useSyncExternalStore } from "react";
+
+import { invoke } from "@tauri-apps/api/core";
+
+import { isMarkdownPath } from "@/lib/markdown";
+import { openFile } from "@/lib/openWith";
+import type { SaveOutcome } from "@/types/events";
+
+/// Whether the reader is reading the file or writing it. Per doc, not one
+/// setting for the panel: a reader flipping one file into edit mode has said
+/// nothing about the next one they open.
+export type DocMode = "view" | "edit";
+
+/// A tagged union over the read's lifecycle, so there is no state in which a
+/// draft exists without the text it was made from. A `text` field plus a
+/// `loaded` boolean is the same data with one extra way to be wrong.
+export type DocBody =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | {
+      status: "ready";
+      /// The text this draft was made from, and what the next save compares
+      /// against.
+      base: string;
+      draft: string;
+      /// The file changed on disk under a dirty draft. A clean doc adopts the
+      /// new text instead, so this is only ever set where something would be
+      /// lost either way.
+      stale: boolean;
+      saving: boolean;
+      /// Why the last write failed, where it failed for a reason other than
+      /// staleness — and a re-read the reader *asked* for, which fails the same
+      /// way and has the same one line of the stale strip to say so in.
+      saveError: string | null;
+    };
+
+export type Doc = { path: string; mode: DocMode; body: DocBody };
+
+/// A ready body, named so the rules below can take one without restating the
+/// union member.
+type Ready = Extract<DocBody, { status: "ready" }>;
+
+/// Whether the draft has moved off what was read.
+///
+/// Derived on every read rather than stored beside the text, because a stored
+/// flag is what lets the two disagree — an edit that forgets to set it leaves a
+/// changed file the panel calls clean, and a save that forgets to clear it
+/// leaves a saved one it calls dirty.
+export function isDirty(doc: Doc): boolean {
+  return doc.body.status === "ready" && doc.body.draft !== doc.body.base;
+}
+
+/// What a doc becomes when the file underneath it is read again.
+///
+/// A clean doc takes the new text outright: nothing is lost, and the reader is
+/// looking at what the file says rather than at what it said. A dirty one keeps
+/// its draft and is flagged instead — the two versions are both wanted, and
+/// only the reader can say which. Disk text equal to `base` is no news at all,
+/// so it leaves the doc exactly as it was.
+///
+/// `base` deliberately stays put on the stale branch. It is what the next save
+/// sends as `expect`, and moving it to the disk text would turn the backend's
+/// compare-and-swap into a silent overwrite of the write that caused this.
+export function withDiskText(body: Ready, disk: string): Ready {
+  if (disk === body.base) return body;
+  if (body.draft === body.base) {
+    return { ...body, base: disk, draft: disk, stale: false };
+  }
+  return { ...body, stale: true };
+}
+
+/// Open docs, in the order they were opened.
+///
+/// Keyed by absolute path and held for the whole app rather than per session,
+/// for two reasons. A file on disk is one thing, so two sessions each holding
+/// their own draft of it would be a race with nothing on screen to see it
+/// happen. And an open doc has to survive a session switch — the same bargain
+/// the panel's hide-don't-unmount makes, since the reader's place in a file is
+/// as much context as their scroll position in a diff.
+///
+/// The cost is that a doc opened from one project's transcript stays on screen
+/// while another session is selected. Its full path is on the chip's `title`.
+let docs: Doc[] = [];
+let activePath: string | null = null;
+/// Bumped every time a path is opened by a click, an already-open one included.
+/// What tells `App` to bring the pane forward — the count cannot, since
+/// reopening an open file leaves it unchanged.
+let opened = 0;
+
+const listeners = new Set<() => void>();
+
+/// Bumped whenever a read or a save is issued for a path, and whenever the path
+/// is closed. An async answer only lands where the number it captured is still
+/// current, which is what stops a slow read from writing over a newer one and
+/// stops either from re-adding a doc the reader has closed.
+///
+/// Per path rather than one counter for the store, unlike `usePrMarks`: a
+/// single number would make opening a second file discard the first file's
+/// read, and one draft's edits have nothing to say about another's.
+const seqByPath = new Map<string, number>();
+
+function issue(path: string): number {
+  const next = (seqByPath.get(path) ?? 0) + 1;
+  seqByPath.set(path, next);
+  return next;
+}
+
+function current(path: string, seq: number): boolean {
+  return seqByPath.get(path) === seq;
+}
+
+type DocsSnapshot = { docs: Doc[]; activePath: string | null; opened: number };
+
+/// What `useSyncExternalStore` reads. Rebuilt in `emit` rather than on read,
+/// because the getter *is* the change signal — an object built fresh each call
+/// is a new identity every render, which React reads as an endless stream of
+/// changes and re-renders forever.
+let snapshot: DocsSnapshot = { docs, activePath, opened };
+
+function emit() {
+  snapshot = { docs, activePath, opened };
+  for (const listener of listeners) listener();
+}
+
+function find(path: string): Doc | undefined {
+  return docs.find((doc) => doc.path === path);
+}
+
+/// Replaces one doc in place, leaving the rest and their identities alone.
+/// A no-op where the path is gone, which is what most of the async guards below
+/// come down to.
+function patch(path: string, next: (doc: Doc) => Doc) {
+  const at = docs.findIndex((doc) => doc.path === path);
+  if (at === -1) return;
+  docs = docs.map((doc, i) => (i === at ? next(doc) : doc));
+  emit();
+}
+
+/// Same, for the ready case alone — every rule below is about a doc whose text
+/// has already arrived.
+function patchReady(path: string, next: (body: Ready) => Ready) {
+  patch(path, (doc) =>
+    doc.body.status === "ready" ? { ...doc, body: next(doc.body) } : doc,
+  );
+}
+
+/// What a click on a path in the transcript does.
+///
+/// Markdown is something this app already renders, so handing it to an external
+/// editor would be a trip out of Dray to read a file Dray can show. Everything
+/// else falls through to the reader's own editor, unchanged.
+///
+/// The decision lives here rather than in [openWith](../lib/openWith.ts): that
+/// module is about the apps on this machine, and having it reach into a panel's
+/// store would put the docs feature's own rule somewhere it cannot be read from.
+export function openPath(path: string): void {
+  if (isMarkdownPath(path)) return openDoc(path);
+  void openFile(path);
+}
+
+/// Opens a markdown file in the panel, reading it if it is not already open.
+///
+/// A path that is already open is only activated. It is not re-read, which
+/// would be a way for a second click on a chip's own file to throw away a draft.
+export function openDoc(path: string): void {
+  opened += 1;
+  activePath = path;
+
+  if (find(path)) return emit();
+
+  docs = [...docs, { path, mode: "view", body: { status: "loading" } }];
+  emit();
+
+  const seq = issue(path);
+  invoke<string>("read_doc", { path })
+    .then((text) => {
+      if (!current(path, seq)) return;
+      patch(path, (doc) => ({
+        ...doc,
+        body: { status: "ready", base: text, draft: text, stale: false, saving: false, saveError: null },
+      }));
+    })
+    .catch((err) => {
+      if (!current(path, seq)) return;
+      patch(path, (doc) => ({ ...doc, body: { status: "error", message: String(err) } }));
+    });
+}
+
+/// Brings an already-open doc forward.
+export function selectDoc(path: string) {
+  if (activePath === path) return;
+  activePath = path;
+  emit();
+}
+
+/// Closes a doc, discarding whatever draft it held.
+///
+/// Closing the active one has to leave `activePath` naming a doc that is still
+/// open, or `null` once the last one goes. A strip of chips pointing at nothing
+/// is what a stale `activePath` looks like on screen.
+export function closeDoc(path: string) {
+  const at = docs.findIndex((doc) => doc.path === path);
+  if (at === -1) return;
+  // A read or save still out for this path must not write into the store after
+  // the reader has closed it.
+  issue(path);
+  docs = docs.filter((doc) => doc.path !== path);
+  if (activePath === path) {
+    activePath = docs[at]?.path ?? docs[at - 1]?.path ?? null;
+  }
+  emit();
+}
+
+/// Switches one doc between reading and writing.
+export function setDocMode(path: string, mode: DocMode) {
+  patch(path, (doc) => (doc.mode === mode ? doc : { ...doc, mode }));
+}
+
+/// Takes a keystroke. The draft is the only thing that moves — dirtiness is read
+/// back off it, and staleness is about the file rather than about the edit.
+export function setDocDraft(path: string, draft: string) {
+  patchReady(path, (body) => (body.draft === draft ? body : { ...body, draft }));
+}
+
+/// Re-reads the file and takes it, discarding the draft. What the stale strip's
+/// Reload offers.
+export function reloadDoc(path: string) {
+  const doc = find(path);
+  if (doc?.body.status !== "ready" || doc.body.saving) return;
+
+  const seq = issue(path);
+  invoke<string>("read_doc", { path })
+    .then((text) => {
+      if (!current(path, seq)) return;
+      patchReady(path, (body) => ({
+        ...body,
+        base: text,
+        draft: text,
+        stale: false,
+        saveError: null,
+      }));
+    })
+    .catch((err) => {
+      if (!current(path, seq)) return;
+      patchReady(path, (body) => ({ ...body, saveError: String(err) }));
+    });
+}
+
+/// Writes the draft, refusing to clobber a file that moved underneath it.
+///
+/// `expect` is the text this draft was made from, and the backend re-reads
+/// before writing — so a save that would lose somebody else's write answers
+/// `"stale"` and writes nothing. `force` sends `null` instead, which is the
+/// reader saying they have read the strip and want their own version anyway.
+export function saveDoc(path: string, { force = false }: { force?: boolean } = {}) {
+  const doc = find(path);
+  if (doc?.body.status !== "ready" || doc.body.saving) return;
+
+  // Captured now. The reader can type while the write is out, so adopting
+  // whatever the draft holds when the promise resolves would mark an edit made
+  // mid-save as already saved.
+  const sent = doc.body.draft;
+  const expect = force ? null : doc.body.base;
+  const seq = issue(path);
+
+  patchReady(path, (body) => ({ ...body, saving: true, saveError: null }));
+
+  invoke<SaveOutcome>("save_doc", { path, text: sent, expect })
+    .then((outcome) => {
+      if (!current(path, seq)) return;
+      patchReady(path, (body) =>
+        outcome === "stale"
+          ? { ...body, saving: false, stale: true }
+          : { ...body, saving: false, base: sent, stale: false, saveError: null },
+      );
+    })
+    .catch((err) => {
+      if (!current(path, seq)) return;
+      patchReady(path, (body) => ({ ...body, saving: false, saveError: String(err) }));
+    });
+}
+
+/// What ⌘S calls. A no-op where there is nothing to write, so the chord is free
+/// to be pressed out of habit.
+export function saveActiveDoc() {
+  if (!activePath) return;
+  const doc = find(activePath);
+  if (!doc || !isDirty(doc)) return;
+  saveDoc(activePath);
+}
+
+/// Re-reads the doc on screen, per `withDiskText` — a clean one adopts the file,
+/// a dirty one is flagged and keeps its draft.
+///
+/// A courtesy, and only for the active doc. The guarantee is the compare-and-
+/// swap at save time, which holds whether or not anything ever re-read; this
+/// exists so a reader watching an agent write the file they have open finds out
+/// before they press Save. Background docs are left alone, since a flag nobody
+/// is looking at buys nothing and every read is a round trip.
+///
+/// A doc whose first read failed is retried outright. ⌘R and the tab row's one
+/// button both land here, and a Refresh that did nothing on the one state with
+/// a visible error would be a control that provably cannot help.
+export function refreshActiveDoc() {
+  if (!activePath) return;
+  const path = activePath;
+  const doc = find(path);
+  if (!doc || doc.body.status === "loading") return;
+  if (doc.body.status === "ready" && doc.body.saving) return;
+
+  const seq = issue(path);
+  invoke<string>("read_doc", { path })
+    .then((text) => {
+      if (!current(path, seq)) return;
+      patch(path, (it) =>
+        it.body.status === "ready"
+          ? { ...it, body: withDiskText(it.body, text) }
+          : {
+              ...it,
+              body: {
+                status: "ready",
+                base: text,
+                draft: text,
+                stale: false,
+                saving: false,
+                saveError: null,
+              },
+            },
+      );
+    })
+    .catch((err) => {
+      if (!current(path, seq)) return;
+      patch(path, (it) =>
+        it.body.status === "ready"
+          ? { ...it, body: { ...it.body, saveError: String(err) } }
+          : { ...it, body: { status: "error", message: String(err) } },
+      );
+    });
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot() {
+  return snapshot;
+}
+
+/// The open docs, and which one the panel is showing.
+export function useDocs(): DocsSnapshot {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/apps/desktop/src/lib/markdown.test.ts
+++ b/apps/desktop/src/lib/markdown.test.ts
@@ -73,6 +73,36 @@ describe("splitMarkdownSections", () => {
     expect(splitMarkdownSections("a\n   # indented\nb")).toHaveLength(1);
   });
 
+  // A closing fence takes no info string, so this opens rather than closes.
+  // Read as a close, the rest of the block came back into play and the next
+  // `#` inside it became a cut.
+  it("does not close a fence on a line carrying an info string", () => {
+    const text = "# One\n\n```\n```js\n# still inside\n```\n\n## Two";
+    expect(splitMarkdownSections(text)).toHaveLength(2);
+  });
+
+  // The pieces have to mean what the whole meant, not merely rejoin to it.
+  describe("leaves a document alone where cutting it would change the render", () => {
+    it("keeps a link reference definition with the link that uses it", () => {
+      expect(splitMarkdownSections("see [docs][d]\n\n# One\n\n[d]: /x")).toHaveLength(1);
+    });
+
+    it("keeps an HTML block whole, since a heading does not end one", () => {
+      expect(splitMarkdownSections("<div>\n\n# One\n\n</div>")).toHaveLength(1);
+    });
+
+    it("leaves front matter alone", () => {
+      expect(splitMarkdownSections("---\ntitle: x\n---\n\n# One\n\n# Two")).toHaveLength(1);
+    });
+
+    // Both tests are loose on purpose: over-reading one costs a slower render,
+    // under-reading one costs a wrong one.
+    it("is not fooled by either construct sitting inside a fence", () => {
+      const text = "# One\n\n```\n[d]: /x\n<div>\n```\n\n## Two";
+      expect(splitMarkdownSections(text)).toHaveLength(2);
+    });
+  });
+
   it("rejoins to the input, whatever it was given", () => {
     rejoins("# One\na\n\n## Two\nb\n");
     rejoins("no headings at all");

--- a/apps/desktop/src/lib/markdown.test.ts
+++ b/apps/desktop/src/lib/markdown.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { isMarkdownPath } from "./markdown";
+
+describe("isMarkdownPath", () => {
+  it("takes both spellings", () => {
+    expect(isMarkdownPath("/Users/me/app/README.md")).toBe(true);
+    expect(isMarkdownPath("/Users/me/app/notes.markdown")).toBe(true);
+  });
+
+  it("ignores case, since a repo is free to shout its readme", () => {
+    expect(isMarkdownPath("/Users/me/app/README.MD")).toBe(true);
+    expect(isMarkdownPath("/Users/me/app/NOTES.Markdown")).toBe(true);
+  });
+
+  // The panel renders with Streamdown, which would draw a component tag as
+  // prose. An MDX file is better off in the reader's editor.
+  it("refuses .mdx", () => {
+    expect(isMarkdownPath("/Users/me/app/page.mdx")).toBe(false);
+  });
+
+  it("needs the extension at the end of the name, not anywhere in it", () => {
+    expect(isMarkdownPath("/Users/me/app/README.md.bak")).toBe(false);
+    expect(isMarkdownPath("/Users/me/app/md/index.ts")).toBe(false);
+  });
+
+  it("says no to a path with no extension, and to a directory", () => {
+    expect(isMarkdownPath("/Users/me/app/Makefile")).toBe(false);
+    expect(isMarkdownPath("/Users/me/app/docs/")).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/markdown.test.ts
+++ b/apps/desktop/src/lib/markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isMarkdownPath } from "./markdown";
+import { isMarkdownPath, splitMarkdownSections } from "./markdown";
 
 describe("isMarkdownPath", () => {
   it("takes both spellings", () => {
@@ -27,5 +27,56 @@ describe("isMarkdownPath", () => {
   it("says no to a path with no extension, and to a directory", () => {
     expect(isMarkdownPath("/Users/me/app/Makefile")).toBe(false);
     expect(isMarkdownPath("/Users/me/app/docs/")).toBe(false);
+  });
+});
+
+describe("splitMarkdownSections", () => {
+  // The property the whole approach rests on: the pieces are the file, so
+  // stacking their renders draws what one render of the whole would.
+  const rejoins = (text: string) =>
+    expect(splitMarkdownSections(text).join("\n")).toBe(text);
+
+  it("cuts at every top-level heading", () => {
+    expect(splitMarkdownSections("# One\na\n\n## Two\nb")).toEqual([
+      "# One\na\n",
+      "## Two\nb",
+    ]);
+  });
+
+  it("keeps what comes before the first heading", () => {
+    expect(splitMarkdownSections("intro\n\n# One\na")).toEqual(["intro\n", "# One\na"]);
+  });
+
+  it("gives one section back for a file with no headings", () => {
+    expect(splitMarkdownSections("just\n\nprose")).toEqual(["just\n\nprose"]);
+  });
+
+  // A `#` comment in a bash block is ordinary, and cutting there would leave an
+  // unterminated fence in one piece and an orphaned one in the next.
+  it("does not cut inside a fenced block", () => {
+    const text = "# One\n\n```bash\n# not a heading\n```\n\n## Two";
+    expect(splitMarkdownSections(text)).toEqual([
+      "# One\n\n```bash\n# not a heading\n```\n",
+      "## Two",
+    ]);
+  });
+
+  it("closes a fence only on its own character", () => {
+    const text = "# One\n\n~~~\n# no\n```\n# still no\n~~~\n\n## Two";
+    expect(splitMarkdownSections(text)).toHaveLength(2);
+  });
+
+  // `#foo` is not a heading in CommonMark, and an indented one is code or a
+  // list continuation rather than a cut point.
+  it("wants a real heading, not a bare hash or an indented one", () => {
+    expect(splitMarkdownSections("a\n#foo\nb")).toHaveLength(1);
+    expect(splitMarkdownSections("a\n   # indented\nb")).toHaveLength(1);
+  });
+
+  it("rejoins to the input, whatever it was given", () => {
+    rejoins("# One\na\n\n## Two\nb\n");
+    rejoins("no headings at all");
+    rejoins("");
+    rejoins("# One\n\n```\n# fence\n```\n\n### Three\n\ntrailing\n");
   });
 });

--- a/apps/desktop/src/lib/markdown.ts
+++ b/apps/desktop/src/lib/markdown.ts
@@ -36,8 +36,13 @@ export const SECTION_STEP = 2;
 ///
 /// Joining the result with a newline gives the input back exactly, which is the
 /// property worth holding on to — it is what makes "the pieces draw the whole"
-/// checkable rather than asserted.
+/// checkable rather than asserted. It is not sufficient on its own, though:
+/// concatenating to the input says the *text* survived, not that parsing the
+/// pieces separately means what parsing the whole meant. `isSplittable` is
+/// where that second half lives.
 export function splitMarkdownSections(text: string): string[] {
+  if (!isSplittable(text)) return [text];
+
   const sections: string[] = [];
   let current: string[] = [];
   let fence: string | null = null;
@@ -46,8 +51,14 @@ export function splitMarkdownSections(text: string): string[] {
     const marker = /^ {0,3}(`{3,}|~{3,})/.exec(line)?.[1];
 
     if (fence) {
-      // Closed only by its own character, and only by at least as many of them.
-      if (marker && marker[0] === fence[0] && marker.length >= fence.length) fence = null;
+      // Closed only by its own character, by at least as many of them, and by
+      // nothing else on the line: a closing fence takes no info string, so
+      // ```` ```not-a-close ```` opens a nested-looking block rather than
+      // ending this one. Reading it as a close put the rest of the fence back
+      // in play and cut the file at the next `#` inside it.
+      if (marker && marker[0] === fence[0] && marker.length >= fence.length) {
+        if (!line.slice(line.indexOf(marker) + marker.length).trim()) fence = null;
+      }
     } else if (marker) {
       fence = marker;
     } else if (/^#{1,6}(\s|$)/.test(line) && current.length) {
@@ -60,4 +71,53 @@ export function splitMarkdownSections(text: string): string[] {
 
   sections.push(current.join("\n"));
   return sections;
+}
+
+/// Whether cutting this document at its headings draws what one render would.
+///
+/// A heading ends every open *block*, which is what makes it a safe cut — but
+/// two things in markdown reach across one, and a section parsed alone cannot
+/// see them:
+///
+/// - **A link reference definition.** `[text][ref]` resolves against a
+///   `[ref]: url` line that may sit under a later heading, and in its own
+///   section the link falls back to literal text.
+/// - **An HTML block.** It runs until a blank line rather than until a heading,
+///   so a `#` inside one is part of it, and cutting there leaves an unclosed
+///   tag in one piece and an orphaned one in the next.
+///
+/// Front matter goes with them: a `---` at the top of the file is a block this
+/// splitter has no concept of at all.
+///
+/// So the answer is the whole document's, not the section's — one construct
+/// anywhere means the file renders in one commit. Slow is the safe side to be
+/// wrong on here, and both tests are deliberately loose: an autolink alone on a
+/// line reads as an HTML block by this rule and costs nothing but speed, where
+/// missing a real one costs a wrong render.
+function isSplittable(text: string): boolean {
+  if (/^---\s*$/.test(text.split("\n", 1)[0] ?? "")) return false;
+
+  let fence: string | null = null;
+  for (const line of text.split("\n")) {
+    const marker = /^ {0,3}(`{3,}|~{3,})/.exec(line)?.[1];
+    if (fence) {
+      if (
+        marker &&
+        marker[0] === fence[0] &&
+        marker.length >= fence.length &&
+        !line.slice(line.indexOf(marker) + marker.length).trim()
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+    if (marker) {
+      fence = marker;
+      continue;
+    }
+    if (/^ {0,3}\[[^\]]*\]:/.test(line)) return false;
+    if (/^ {0,3}</.test(line)) return false;
+  }
+
+  return true;
 }

--- a/apps/desktop/src/lib/markdown.ts
+++ b/apps/desktop/src/lib/markdown.ts
@@ -1,0 +1,10 @@
+/// Whether this path is one the Docs panel can render.
+///
+/// `.mdx` is deliberately out. It is JSX inside markdown, and Streamdown has no
+/// idea what a component is — a `<Callout>` would be drawn as prose or dropped
+/// by the sanitizer, so the panel would show a confidently wrong version of the
+/// file. It goes to the external editor with everything else.
+export function isMarkdownPath(path: string): boolean {
+  const name = path.slice(path.lastIndexOf("/") + 1).toLowerCase();
+  return name.endsWith(".md") || name.endsWith(".markdown");
+}

--- a/apps/desktop/src/lib/markdown.ts
+++ b/apps/desktop/src/lib/markdown.ts
@@ -8,3 +8,56 @@ export function isMarkdownPath(path: string): boolean {
   const name = path.slice(path.lastIndexOf("/") + 1).toLowerCase();
   return name.endsWith(".md") || name.endsWith(".markdown");
 }
+
+/// How many sections the panel draws on its first commit, and how many it adds
+/// per deferred step after that.
+///
+/// Two is a screenful of prose at any height this app runs at, and a step of
+/// two keeps each one to a few tens of milliseconds — the point is that the
+/// main thread comes back between steps, not that the total gets smaller.
+export const FIRST_SECTIONS = 2;
+export const SECTION_STEP = 2;
+
+/// The document cut at its top-level headings, in order.
+///
+/// Rendering a long file in one commit is what made this panel take seconds to
+/// open: a 282KB document measured at 930ms of parsing alone, before any of the
+/// 608KB of HTML it produces reached the DOM. Cut into sections, the top is on
+/// screen at once and the rest mounts behind it.
+///
+/// A heading is the cut because an unindented ATX heading terminates every open
+/// block before it — paragraph, list, blockquote — so stacking the pieces draws
+/// what one render of the whole would. A blank line looks like the easier cut
+/// and is not one: a list with blank lines between its items would come apart
+/// into one list per item.
+///
+/// Fenced code is skipped, or the `#` on a comment inside a bash block would
+/// cut the file mid-fence and leave both halves unparseable.
+///
+/// Joining the result with a newline gives the input back exactly, which is the
+/// property worth holding on to — it is what makes "the pieces draw the whole"
+/// checkable rather than asserted.
+export function splitMarkdownSections(text: string): string[] {
+  const sections: string[] = [];
+  let current: string[] = [];
+  let fence: string | null = null;
+
+  for (const line of text.split("\n")) {
+    const marker = /^ {0,3}(`{3,}|~{3,})/.exec(line)?.[1];
+
+    if (fence) {
+      // Closed only by its own character, and only by at least as many of them.
+      if (marker && marker[0] === fence[0] && marker.length >= fence.length) fence = null;
+    } else if (marker) {
+      fence = marker;
+    } else if (/^#{1,6}(\s|$)/.test(line) && current.length) {
+      sections.push(current.join("\n"));
+      current = [];
+    }
+
+    current.push(line);
+  }
+
+  sections.push(current.join("\n"));
+  return sections;
+}

--- a/apps/desktop/src/lib/openWith.ts
+++ b/apps/desktop/src/lib/openWith.ts
@@ -19,6 +19,10 @@ export const OPEN_DIR_KEY = "ade.openWith";
 /// choice and holds terminals and Finder too — so a reader who last opened
 /// their checkout in Ghostty would find that clicking a filename opened a
 /// terminal, which is no answer to "show me this file".
+///
+/// Markdown never reaches this: it opens in the Docs panel, which is Dray's own
+/// answer to "show me this file". See `openPath` in
+/// [useDocs](../hooks/useDocs.ts).
 export const OPEN_FILE_KEY = "ade.openFileWith";
 
 /// The last answer, so a control drawn after the first read paints at once

--- a/apps/desktop/src/types/events.ts
+++ b/apps/desktop/src/types/events.ts
@@ -1051,6 +1051,12 @@ export type RateLimit = { usedPercent: number | null, windowMinutes: number | nu
 resetsAt: string | null, planType: string | null, };
 
 /**
+ * What a save did. `Stale` is not an error: the file moved under the reader,
+ * so their text is still in the editor and theirs to force through.
+ */
+export type SaveOutcome = "saved" | "stale";
+
+/**
  * What a send did. The two fields are mutually exclusive in practice — a
  * session being created cannot already be running a turn — but they answer
  * different questions and the frontend acts on each separately.


### PR DESCRIPTION
Clicking a `.md` file in the transcript handed it to an external app. It now opens in a **Docs** tab in the right panel, rendered with the same `Markdown` component the transcript uses, with an edit mode behind a view/edit toggle. Everything that is not markdown still goes to the reader's editor, unchanged.

## What was settled

**Where it sits.** A new tab between Changes and Issue, drawn only while something is open — the PR tab's rule. Closing the last doc takes the tab with it, and `activeTab` already falls back to the derived default without writing the pick back, so returning to a session with docs open lands on Docs again.

**Several files.** A horizontal strip of chips in the header row, which costs one row of height whatever the count, where a vertical list costs one per file. The mode toggle and Save share that row, so there is no second header saying what the chip already says. Full path on the chip's `title`.

**Saving is explicit.** ⌘S or the Save button, which is drawn only while the doc is dirty. No autosave: the checkout is shared with a live agent, and a write is a thing the reader chose at a moment, not a thing that happens per keystroke.

**The agent rewriting an open dirty file.** Every write is a compare-and-swap in Rust — `save_doc` re-reads the file, compares it to the text the draft was made from, and answers `stale` with nothing written if it moved. That is the guarantee, and it holds whether or not anything ever re-read. On top of it, ⌘R and the tab row's refresh button re-read the doc on screen: a clean one silently adopts the file, a dirty one is flagged with a strip offering **Reload** or **Overwrite**. Neither takes destructive fill, because both lose something.

**Scope of the store.** Keyed by absolute path for the whole app rather than per session. A file on disk is one thing, so two sessions each holding their own draft would be a race with nothing on screen to see it happen — and an open doc survives a session switch, the same bargain the panel's hide-don't-unmount makes. The cost: a doc opened from one project stays on screen while another session is selected.

**The editor is a plain textarea.** No new dependency. Native undo, caret and IME come free, and the composer already proves the mirrored-overlay technique is here if syntax colouring is ever wanted.

Closing a dirty doc confirms through the app's `AlertDialog`. `.mdx` is deliberately excluded — Streamdown would draw the JSX as prose.

## Verification

- `cargo test` — 434 passed (7 new, covering the compare-and-swap, the forced save, and that a save never creates a missing file)
- `pnpm test` — 383 passed (new: `isMarkdownPath`, and the store's pure `isDirty` / `withDiskText` rules)
- `pnpm build` — clean

Fixes DRA-108

🤖 Generated with [Claude Code](https://claude.com/claude-code)