### PR TITLE
Changes view: a Branch tab for this session's own commits

### DIFF
--- a/apps/desktop/src-tauri/src/git.rs
+++ b/apps/desktop/src-tauri/src/git.rs
@@ -916,6 +916,90 @@ pub async fn log_commits(cwd: &str, limit: u32, skip: u32) -> Result<Vec<Commit>
     Ok(parse_log(&raw))
 }
 
+/// The commit this branch forked from, read out of the branch's own reflog.
+///
+/// `claude -w` and `dray new --from` both create the branch with
+/// `git worktree add --no-track -B`, which writes `branch: Created from <base>`
+/// on first creation and `branch: Reset to <base>` when the branch already
+/// existed. The entry's own `%H` **is** the base commit, because the branch
+/// starts life pointing at it. An ordinary `git checkout -b feature
+/// origin/main` writes the same entry, so this covers plain sessions too.
+///
+/// `None` on a detached HEAD, and where nothing on record names a base — an
+/// expired reflog, or `core.logAllRefUpdates` turned off.
+async fn fork_point(cwd: &str) -> Option<String> {
+    let branch = current_branch(cwd).await?;
+    let refname = format!("refs/heads/{branch}");
+    let reflog = git(cwd, &["reflog", "show", "--format=%H%x09%gs", &refname]).await?;
+
+    // The newest matching entry, which is the one git prints first: `-B` on a
+    // pre-existing branch resets it, so an older entry names a base this
+    // session never had.
+    reflog.lines().find_map(|line| {
+        let (sha, message) = line.split_once('\t')?;
+        let names_base = message.starts_with("branch: Created from ")
+            || message.starts_with("branch: Reset to ");
+        names_base.then(|| sha.trim().to_string())
+    })
+}
+
+/// A page of the commits this branch made on its own, newest first.
+///
+/// [`log_commits`] logs HEAD whole, which buries a session's work under
+/// however long the branch it forked from is. This excludes the fork point and
+/// the default base, so what is left is what this session did.
+///
+/// The default base goes as well as the fork point because a session that
+/// merges `origin/main` into its branch pulls upstream commits into HEAD that
+/// the fork point does not exclude, and those are not this session's work.
+///
+/// Empty when **no** exclusion resolves, rather than logging HEAD whole: a
+/// branch with no nameable base has no honest answer here, and the history
+/// beside it already shows everything.
+///
+/// Over-reports after a rebase that replays another branch's commits onto a new
+/// base, since git no longer knows whose were whose — the safe direction, and
+/// the same reading the unpushed-commit count takes.
+pub async fn log_branch_commits(cwd: &str, limit: u32, skip: u32) -> Result<Vec<Commit>> {
+    let limit = limit.clamp(1, MAX_LOG_PAGE).to_string();
+    let skip = format!("--skip={skip}");
+
+    let mut wanted = Vec::new();
+    // Hex-checked for [`is_tree_id`]'s reason: this one comes off a reflog
+    // line, and a value opening with `-` would parse as a flag.
+    if let Some(base) = fork_point(cwd).await.filter(|sha| is_tree_id(sha)) {
+        wanted.push(base);
+    }
+    if let Some(base) = default_base(cwd).await {
+        wanted.push(base);
+    }
+
+    // One exclusion that doesn't resolve makes the whole command fatal, and
+    // `git` swallows that into `None` — so the list would read empty with
+    // nothing saying why. `default_base` is the live case: it resolves
+    // `refs/remotes/origin/HEAD` without checking the target was ever fetched.
+    let mut excludes = Vec::new();
+    for base in wanted {
+        if resolve_commit(cwd, &base).await.is_some() {
+            excludes.push(base);
+        }
+    }
+
+    if excludes.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut args = vec!["log", "-z", LOG_FORMAT, "-n", &limit, &skip, "HEAD", "--not"];
+    args.extend(excludes.iter().map(String::as_str));
+    args.push("--");
+
+    let Some(raw) = git(cwd, &args).await else {
+        return Ok(Vec::new());
+    };
+
+    Ok(parse_log(&raw))
+}
+
 fn parse_log(raw: &str) -> Vec<Commit> {
     raw.split('\0')
         .filter(|record| !record.trim().is_empty())
@@ -2512,6 +2596,168 @@ mod tests {
         fs::create_dir_all(&dir).await.unwrap();
 
         assert!(log_commits(dir.to_str().unwrap(), 50, 0).await.unwrap().is_empty());
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    /// The whole point of the branch list: a session forked from somebody
+    /// else's branch reports what it did, not what that branch had already
+    /// done. `origin/<default>..HEAD` gets this one wrong — the base's own
+    /// commits are not on the default branch either.
+    #[tokio::test]
+    async fn a_forked_branch_logs_only_its_own_commits() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        run(at, &["checkout", "-q", "-b", "authors-work"]).await.unwrap();
+        fs::write(dir.join("feature.txt"), "the work\n").await.unwrap();
+        run(at, &["add", "-A"]).await.unwrap();
+        run(at, &["commit", "-qm", "author's commit"]).await.unwrap();
+        run(at, &["checkout", "-q", "-"]).await.unwrap();
+
+        let path = create_worktree(at, "reviewer", "authors-work")
+            .await
+            .expect("a branch that exists is a base");
+        fs::write(Path::new(&path).join("review.txt"), "mine\n")
+            .await
+            .unwrap();
+        run(&path, &["add", "-A"]).await.unwrap();
+        run(&path, &["commit", "-qm", "reviewer's commit"]).await.unwrap();
+
+        let page = log_branch_commits(&path, 50, 0).await.unwrap();
+        assert_eq!(
+            page.iter().map(|c| c.subject.as_str()).collect::<Vec<_>>(),
+            ["reviewer's commit"],
+        );
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    /// The newest entry wins. Reusing a worktree name resets the branch it
+    /// left behind, so the reflog holds both bases and only the later one is
+    /// where this session actually started.
+    #[tokio::test]
+    async fn a_reset_branch_forks_from_the_base_it_was_reset_to() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        run(at, &["checkout", "-q", "-b", "base-work"]).await.unwrap();
+        fs::write(dir.join("base.txt"), "one\n").await.unwrap();
+        run(at, &["add", "-A"]).await.unwrap();
+        run(at, &["commit", "-qm", "base one"]).await.unwrap();
+
+        let path = create_worktree(at, "reviewer", "base-work").await.unwrap();
+        // The tree goes and the branch stays, which is what makes the second
+        // create a `Reset to` rather than another `Created from`.
+        run(at, &["worktree", "remove", "--force", &path]).await.unwrap();
+
+        fs::write(dir.join("base.txt"), "two\n").await.unwrap();
+        run(at, &["commit", "-aqm", "base two"]).await.unwrap();
+
+        let path = create_worktree(at, "reviewer", "base-work").await.unwrap();
+        fs::write(Path::new(&path).join("mine.txt"), "mine\n")
+            .await
+            .unwrap();
+        run(&path, &["add", "-A"]).await.unwrap();
+        run(&path, &["commit", "-qm", "session work"]).await.unwrap();
+
+        let page = log_branch_commits(&path, 50, 0).await.unwrap();
+        assert_eq!(
+            page.iter().map(|c| c.subject.as_str()).collect::<Vec<_>>(),
+            ["session work"],
+            "read the base this branch was reset to, not the older one it was created from",
+        );
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    /// The `-w` shape, forked from `origin/<default>`, and the reason the
+    /// default base is excluded as well as the fork point: a session that
+    /// merges upstream in mid-flight pulls commits into HEAD that the fork
+    /// point predates. Drop the `default_base` exclusion and this one fails.
+    #[tokio::test]
+    async fn upstream_merged_in_after_the_fork_is_not_this_branch_s_work() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        let bare = std::env::temp_dir().join(format!("dray-origin-{}", Uuid::now_v7()));
+        fs::create_dir_all(&bare).await.unwrap();
+        run(bare.to_str().unwrap(), &["init", "-q", "--bare", "."])
+            .await
+            .unwrap();
+
+        run(at, &["remote", "add", "origin", bare.to_str().unwrap()])
+            .await
+            .unwrap();
+        // Named rather than pushed by whatever `git init` called the branch, so
+        // the remote side reads the same on a machine configured either way.
+        run(at, &["push", "-q", "origin", "HEAD:refs/heads/main"])
+            .await
+            .unwrap();
+        run(at, &["remote", "set-head", "origin", "main"]).await.unwrap();
+        assert_eq!(default_base(at).await.as_deref(), Some("origin/main"));
+
+        let path = create_worktree(at, "worker", "origin/main")
+            .await
+            .expect("the default base is a base");
+        fs::write(Path::new(&path).join("one.txt"), "1\n").await.unwrap();
+        run(&path, &["add", "-A"]).await.unwrap();
+        run(&path, &["commit", "-qm", "session work"]).await.unwrap();
+
+        // Upstream moves after the fork, and the session merges it in. The push
+        // is what carries it onto `origin/main`, which the worktree shares.
+        fs::write(dir.join("keep.txt"), "a\nb\nc\nd\n").await.unwrap();
+        run(at, &["commit", "-aqm", "upstream work"]).await.unwrap();
+        run(at, &["push", "-q", "origin", "HEAD:refs/heads/main"])
+            .await
+            .unwrap();
+        run(&path, &["merge", "-q", "--no-edit", "origin/main"])
+            .await
+            .unwrap();
+
+        let subjects = log_branch_commits(&path, 50, 0)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.subject)
+            .collect::<Vec<_>>();
+
+        assert!(subjects.iter().any(|s| s == "session work"), "{subjects:?}");
+        assert!(
+            !subjects.iter().any(|s| s == "upstream work"),
+            "an upstream commit the fork point predates: {subjects:?}"
+        );
+
+        fs::remove_dir_all(&dir).await.ok();
+        fs::remove_dir_all(&bare).await.ok();
+    }
+
+    /// No remote, and an initial commit whose reflog says `commit (initial)` —
+    /// so nothing on record names a base. Empty rather than the whole of HEAD,
+    /// which the history beside it already draws.
+    #[tokio::test]
+    async fn a_branch_with_no_nameable_base_logs_nothing() {
+        let dir = scratch_repo().await;
+
+        let page = log_branch_commits(dir.to_str().unwrap(), 50, 0)
+            .await
+            .unwrap();
+        assert!(page.is_empty(), "logged HEAD whole: {page:?}");
+
+        fs::remove_dir_all(&dir).await.ok();
+    }
+
+    /// A folder the user attached that git knows nothing about. Empty like
+    /// every other read here, never an error.
+    #[tokio::test]
+    async fn a_directory_that_is_not_a_repo_has_no_branch_history() {
+        let dir = std::env::temp_dir().join(format!("dray-nonrepo-{}", Uuid::now_v7()));
+        fs::create_dir_all(&dir).await.unwrap();
+
+        assert!(log_branch_commits(dir.to_str().unwrap(), 50, 0)
+            .await
+            .unwrap()
+            .is_empty());
 
         fs::remove_dir_all(&dir).await.ok();
     }

--- a/apps/desktop/src-tauri/src/git.rs
+++ b/apps/desktop/src-tauri/src/git.rs
@@ -946,54 +946,75 @@ async fn fork_point(cwd: &str) -> Option<String> {
 /// A page of the commits this branch made on its own, newest first.
 ///
 /// [`log_commits`] logs HEAD whole, which buries a session's work under
-/// however long the branch it forked from is. This excludes the fork point and
-/// the default base, so what is left is what this session did.
+/// however long the branch it forked from is. This excludes the fork point, so
+/// what is left is what this session did.
 ///
-/// The default base goes as well as the fork point because a session that
-/// merges `origin/main` into its branch pulls upstream commits into HEAD that
-/// the fork point does not exclude, and those are not this session's work.
+/// **One exclusion, and it has to be an immutable one.** Excluding
+/// `origin/<default>` as well looks like it would cover a session that merges
+/// upstream in, and it does — right up until that session's own work lands on
+/// that branch and someone fetches, at which point the ref *contains* the
+/// commits and the list empties itself exactly when the work shipped. A moving
+/// ref cannot be an exclusion here. `--first-parent` covers the merge case
+/// instead: a merge of `origin/main` reaches this branch's own spine through
+/// the first parent and the upstream commits through the second, so walking the
+/// spine alone drops them without any ref being named.
 ///
-/// Empty when **no** exclusion resolves, rather than logging HEAD whole: a
-/// branch with no nameable base has no honest answer here, and the history
-/// beside it already shows everything.
+/// Empty when no fork point resolves and no default base stands in, rather than
+/// logging HEAD whole: a branch with no nameable base has no honest answer here,
+/// and the history beside it already shows everything.
 ///
-/// Over-reports after a rebase that replays another branch's commits onto a new
-/// base, since git no longer knows whose were whose — the safe direction, and
-/// the same reading the unpushed-commit count takes.
+/// Two ways it can still be wrong, both toward over-reporting. A branch whose
+/// reflog no longer holds its creation entry — expired, or
+/// `core.logAllRefUpdates` off — falls back to the default base, which is a
+/// moving ref again and which reports a `--from` session's inherited commits as
+/// its own. And after a rebase that replays another branch's commits onto a new
+/// base, git no longer knows whose were whose. Over-reporting is the safe
+/// direction, the same reading the unpushed-commit count takes.
 pub async fn log_branch_commits(cwd: &str, limit: u32, skip: u32) -> Result<Vec<Commit>> {
     let limit = limit.clamp(1, MAX_LOG_PAGE).to_string();
     let skip = format!("--skip={skip}");
 
-    let mut wanted = Vec::new();
     // Hex-checked for [`is_tree_id`]'s reason: this one comes off a reflog
     // line, and a value opening with `-` would parse as a flag.
-    if let Some(base) = fork_point(cwd).await.filter(|sha| is_tree_id(sha)) {
-        wanted.push(base);
-    }
-    if let Some(base) = default_base(cwd).await {
-        wanted.push(base);
-    }
+    let fork = fork_point(cwd).await.filter(|sha| is_tree_id(sha));
 
-    // One exclusion that doesn't resolve makes the whole command fatal, and
+    // The default base only stands in where the reflog named nothing. It is a
+    // moving ref, so it carries the failure described above and is the worse
+    // answer wherever the fork point exists.
+    let wanted = match fork {
+        Some(base) => Some(base),
+        None => default_base(cwd).await,
+    };
+
+    // An exclusion that doesn't resolve makes the whole command fatal, and
     // `git` swallows that into `None` — so the list would read empty with
     // nothing saying why. `default_base` is the live case: it resolves
     // `refs/remotes/origin/HEAD` without checking the target was ever fetched.
-    let mut excludes = Vec::new();
-    for base in wanted {
-        if resolve_commit(cwd, &base).await.is_some() {
-            excludes.push(base);
-        }
-    }
-
-    if excludes.is_empty() {
+    let Some(base) = wanted else {
+        return Ok(Vec::new());
+    };
+    if resolve_commit(cwd, &base).await.is_none() {
         return Ok(Vec::new());
     }
 
-    let mut args = vec!["log", "-z", LOG_FORMAT, "-n", &limit, &skip, "HEAD", "--not"];
-    args.extend(excludes.iter().map(String::as_str));
-    args.push("--");
-
-    let Some(raw) = git(cwd, &args).await else {
+    let Some(raw) = git(
+        cwd,
+        &[
+            "log",
+            "-z",
+            LOG_FORMAT,
+            "--first-parent",
+            "-n",
+            &limit,
+            &skip,
+            "HEAD",
+            "--not",
+            &base,
+            "--",
+        ],
+    )
+    .await
+    else {
         return Ok(Vec::new());
     };
 
@@ -2726,6 +2747,54 @@ mod tests {
         assert!(
             !subjects.iter().any(|s| s == "upstream work"),
             "an upstream commit the fork point predates: {subjects:?}"
+        );
+
+        fs::remove_dir_all(&dir).await.ok();
+        fs::remove_dir_all(&bare).await.ok();
+    }
+
+    /// Work that has landed is still this branch's work. Excluding
+    /// `origin/<default>` as well as the fork point emptied this list the
+    /// moment the session's own commits reached that branch and somebody
+    /// fetched — the list going blank exactly when the work shipped. Only an
+    /// immutable exclusion can be used here, which is why the merge case is
+    /// covered by `--first-parent` instead.
+    #[tokio::test]
+    async fn work_that_has_landed_upstream_is_still_this_branch_s_work() {
+        let dir = scratch_repo().await;
+        let at = dir.to_str().unwrap();
+
+        let bare = std::env::temp_dir().join(format!("dray-origin-{}", Uuid::now_v7()));
+        fs::create_dir_all(&bare).await.unwrap();
+        run(bare.to_str().unwrap(), &["init", "-q", "--bare", "."])
+            .await
+            .unwrap();
+
+        run(at, &["remote", "add", "origin", bare.to_str().unwrap()])
+            .await
+            .unwrap();
+        run(at, &["push", "-q", "origin", "HEAD:refs/heads/main"])
+            .await
+            .unwrap();
+        run(at, &["remote", "set-head", "origin", "main"]).await.unwrap();
+
+        let path = create_worktree(at, "worker", "origin/main").await.unwrap();
+        fs::write(Path::new(&path).join("one.txt"), "1\n").await.unwrap();
+        run(&path, &["add", "-A"]).await.unwrap();
+        run(&path, &["commit", "-qm", "session work"]).await.unwrap();
+
+        // The branch lands on the default branch and the worktree learns about
+        // it, which is what makes `origin/main` contain this session's commit.
+        run(&path, &["push", "-q", "origin", "HEAD:refs/heads/main"])
+            .await
+            .unwrap();
+        run(&path, &["fetch", "-q", "origin"]).await.unwrap();
+
+        let page = log_branch_commits(&path, 50, 0).await.unwrap();
+        assert_eq!(
+            page.iter().map(|c| c.subject.as_str()).collect::<Vec<_>>(),
+            ["session work"],
+            "the list emptied itself once the work landed",
         );
 
         fs::remove_dir_all(&dir).await.ok();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -341,6 +341,16 @@ async fn log_commits(cwd: &str, limit: u32, skip: u32) -> Result<Vec<git::Commit
         .map_err(|e| e.to_string())
 }
 
+/// A page of the commits this branch made on its own, newest first — the same
+/// paging as [`log_commits`], against a range that stops at the fork point.
+/// Empty where no base can be named, which the list draws as its own sentence.
+#[tauri::command]
+async fn log_branch_commits(cwd: &str, limit: u32, skip: u32) -> Result<Vec<git::Commit>, String> {
+    git::log_branch_commits(cwd, limit, skip)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 async fn sync_status(cwd: String) -> git::SyncStatus {
     git::sync_status(&cwd).await
@@ -644,6 +654,7 @@ pub fn run() {
             file_change,
             head_tree,
             log_commits,
+            log_branch_commits,
             sync_status,
             work_status,
             commit_files,

--- a/apps/desktop/src/components/changes/ChangesView.tsx
+++ b/apps/desktop/src/components/changes/ChangesView.tsx
@@ -9,7 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useChanges } from "@/hooks/useChanges";
 import { useHotkey } from "@/hooks/useHotkey";
 import { useCommitLog, useHeadTree } from "@/hooks/useRepo";
-import { commitBase } from "@/lib/commit";
+import { commitBase, defaultSubTab, type SubTab } from "@/lib/commit";
 import { IS_MAC } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import type { ChangedFile, Commit } from "@/types/events";
@@ -19,10 +19,12 @@ const SUB_TABS = [
   // and a tab repeating its parent's name says nothing about what sets it apart
   // from the tab beside it.
   { value: "uncommitted", label: "Uncommitted" },
+  // Between the two, because it is between them in what it answers: this
+  // branch's own commits are narrower than the whole of HEAD's history and
+  // wider than what has not been committed yet.
+  { value: "branch", label: "Branch" },
   { value: "history", label: "History" },
-] as const;
-
-type SubTab = (typeof SUB_TABS)[number]["value"];
+] as const satisfies readonly { value: SubTab; label: string }[];
 
 /// Holds identity for the two lists' `files` when a read hasn't landed, so the
 /// selection below doesn't churn on a fresh array every render.
@@ -52,48 +54,69 @@ export default function ChangesView({
   active: boolean;
   revision: string;
 }) {
-  const [subTab, setSubTab] = useState<SubTab>("uncommitted");
-
-  // ⌘⇧← / ⌘⇧→ step this row, the same shape ⌘⇧↑/↓ steps the session list — the
-  // arrow points at the tab, so a third sub-tab needs no third binding. Not
-  // ⌘1/⌘2, which the view row above already spends, and not ⌘⇧[ /], which
-  // belongs to the right panel and would mean two different rows at once.
-  //
-  // Clamped rather than wrapped: with two entries wrapping makes both chords do
-  // the same thing, so pressing ← twice would land on History.
-  //
-  // Registered only while this view is showing. It stays mounted when it isn't,
-  // and `useHotkey` claims every chord it matches, so leaving it bound would
-  // take ⌘⇧← from the composer, where it selects to the start of the line.
-  const stepSubTab = (delta: number) => {
-    const next = SUB_TABS[SUB_TABS.findIndex((t) => t.value === subTab) + delta];
-    if (next) setSubTab(next.value);
-  };
-  useHotkey("ArrowLeft", () => stepSubTab(-1), { shift: true, enabled: active });
-  useHotkey("ArrowRight", () => stepSubTab(1), { shift: true, enabled: active });
+  // `null` is "the reader never picked", the rule `panelTab` reads by: a hand
+  // pick wins from there on, and until there is one the derived default stands.
+  // Storing `"uncommitted"` as the initial value would make a fresh arrival
+  // indistinguishable from a reader who chose it, so nothing else could ever
+  // lead.
+  const [subTabPick, setSubTabPick] = useState<SubTab | null>(null);
   const [commit, setCommit] = useState<Commit | null>(null);
+  const [branchSha, setBranchSha] = useState<string | null>(null);
   const [workingPath, setWorkingPath] = useState<string | null>(null);
   const [commitPath, setCommitPath] = useState<string | null>(null);
 
   const head = useHeadTree(cwd, revision, active);
-  const log = useCommitLog(cwd, revision, active && subTab === "history");
 
-  // The uncommitted range: HEAD's tree against the working tree as it stands,
+  // Both run on `active` alone rather than on the tab they belong to, because
+  // the default below reads them both: gating them on the tab they choose is
+  // circular, and it flipped the row twice on arrival before it settled. It
+  // also makes the Uncommitted count honest from every tab, which it was not
+  // before — the read behind it only ran while its own tab was showing. The
+  // `active` gate stays on all three reads either way: a hidden view must still
+  // not snapshot the working tree on every event.
+  //
+  // The uncommitted range is HEAD's tree against the working tree as it stands,
   // which `changes_since` snapshots to answer. A commit moves HEAD, so the key
   // rolls onto the new baseline on its own — nothing has to invalidate a cache.
-  const working = useChanges(cwd, head.tree, null, revision, active && subTab === "uncommitted");
+  const working = useChanges(cwd, head.tree, null, revision, active);
+  const branchLog = useCommitLog(cwd, revision, active, "log_branch_commits");
+
+  const workingFiles = working.changes?.files ?? NO_FILES;
+
+  const subTab =
+    subTabPick ??
+    defaultSubTab({
+      hasUncommitted: workingFiles.length > 0,
+      settled: !!working.changes,
+      hasBranchCommits: branchLog.commits.length > 0,
+    });
+
+  // History keeps its gate. It is the expensive read — the whole of HEAD's
+  // history behind it, however long that is — and nothing in the rule above
+  // asks it anything.
+  const log = useCommitLog(cwd, revision, active && subTab === "history", "log_commits");
+
+  // Derived from a sha the way `pick` derives the file below, so a commit that
+  // pages out from under the list cannot leave the pane pointing at nothing.
+  // Falling back to the newest is what opens this tab on a diff rather than on
+  // an empty frame.
+  const branchCommit =
+    branchLog.commits.find((c) => c.sha === branchSha) ?? branchLog.commits[0] ?? null;
+
+  // One commit is open in the pane at a time, whichever tab opened it, so its
+  // read and its file selection are shared rather than written out twice.
+  const openCommit = subTab === "branch" ? branchCommit : subTab === "history" ? commit : null;
 
   // A commit's own range is two fixed ids, so this is read once and cached
   // forever — reopening one costs nothing after the first time.
   const commitChanges = useChanges(
     cwd,
-    commit ? commitBase(commit) : null,
-    commit?.sha ?? null,
+    openCommit ? commitBase(openCommit) : null,
+    openCommit?.sha ?? null,
     "",
-    active && subTab === "history" && !!commit,
+    active && !!openCommit,
   );
 
-  const workingFiles = working.changes?.files ?? NO_FILES;
   const commitFiles = commitChanges.changes?.files ?? NO_FILES;
 
   // Derived rather than stored, so a file that stops being changed cannot leave
@@ -108,6 +131,24 @@ export default function ChangesView({
 
   const showing = subTab === "uncommitted" ? working : commitChanges;
   const selectedFile = subTab === "uncommitted" ? selectedWorking : selectedCommitFile;
+
+  // ⌘⇧← / ⌘⇧→ step this row, the same shape ⌘⇧↑/↓ steps the session list — the
+  // arrow points at the tab, so a fourth sub-tab would need no fourth binding.
+  // Not ⌘1/⌘2, which the view row above already spends, and not ⌘⇧[ /], which
+  // belongs to the right panel and would mean two different rows at once.
+  //
+  // Clamped rather than wrapped: wrapping would make ← from the first tab land
+  // on the last, which is the long way round a row this short.
+  //
+  // Registered only while this view is showing. It stays mounted when it isn't,
+  // and `useHotkey` claims every chord it matches, so leaving it bound would
+  // take ⌘⇧← from the composer, where it selects to the start of the line.
+  const stepSubTab = (delta: number) => {
+    const next = SUB_TABS[SUB_TABS.findIndex((t) => t.value === subTab) + delta];
+    if (next) setSubTabPick(next.value);
+  };
+  useHotkey("ArrowLeft", () => stepSubTab(-1), { shift: true, enabled: active });
+  useHotkey("ArrowRight", () => stepSubTab(1), { shift: true, enabled: active });
 
   // A directory that isn't a repository has nothing to diff. Said plainly
   // rather than drawn as an empty change list, which would read as a clean
@@ -139,7 +180,7 @@ export default function ChangesView({
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  onClick={() => setSubTab(value)}
+                  onClick={() => setSubTabPick(value)}
                   className={cn(
                     "rounded-md px-2 py-1 text-ui transition-colors",
                     subTab === value
@@ -154,12 +195,15 @@ export default function ChangesView({
                 </button>
               </TooltipTrigger>
               {/* Keycaps alone, like the view row above: the name is already on
-                  the button, and the arrow is which side of the row it sits on. */}
+                  the button, and the arrow is which side of the row it sits on.
+                  A tab with a neighbour on each side is reached from either, so
+                  it says both in one cap rather than growing a second — one
+                  `KbdGroup` whatever the row's length. */}
               <TooltipContent side="bottom" className="px-1.5">
                 <KbdGroup>
                   <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
                   <Kbd>⇧</Kbd>
-                  <Kbd>{i === 0 ? "←" : "→"}</Kbd>
+                  <Kbd>{i === 0 ? "←" : i === SUB_TABS.length - 1 ? "→" : "←→"}</Kbd>
                 </KbdGroup>
               </TooltipContent>
             </Tooltip>
@@ -179,6 +223,26 @@ export default function ChangesView({
               className="min-h-0 flex-1 overflow-y-auto"
             />
           )
+        ) : subTab === "branch" ? (
+          <HistoryList
+            commits={branchLog.commits}
+            selected={branchCommit?.sha ?? null}
+            // No closing here, unlike History. Something is always open on this
+            // tab, because closing it is exactly the empty pane the tab exists
+            // to replace.
+            onToggle={(next) => {
+              setBranchSha(next.sha);
+              setCommitPath(null);
+            }}
+            files={commitFiles}
+            selectedFile={selectedCommitFile?.path ?? null}
+            onSelectFile={setCommitPath}
+            hasMore={branchLog.hasMore}
+            onLoadMore={branchLog.loadMore}
+            loading={branchLog.loading}
+            error={branchLog.error}
+            empty="This branch has no commits of its own yet."
+          />
         ) : (
           <HistoryList
             commits={log.commits}
@@ -202,8 +266,10 @@ export default function ChangesView({
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         {/* Keyed on the sha so opening another commit arrives collapsed: the
-            expanded state belongs to the message being read, not to the pane. */}
-        {subTab === "history" && commit && <CommitMessage key={commit.sha} commit={commit} />}
+            expanded state belongs to the message being read, not to the pane.
+            The message belongs to whichever commit is open, whichever of the
+            two tabs opened it. */}
+        {openCommit && <CommitMessage key={openCommit.sha} commit={openCommit} />}
 
         <DiffPane
           cwd={cwd}
@@ -213,7 +279,9 @@ export default function ChangesView({
           empty={
             subTab === "history" && !commit
               ? "Open a commit to see what it changed."
-              : "Select a file to see what changed."
+              : subTab === "branch" && !branchCommit
+                ? "This branch has no commits of its own yet."
+                : "Select a file to see what changed."
           }
         />
       </div>

--- a/apps/desktop/src/components/changes/ChangesView.tsx
+++ b/apps/desktop/src/components/changes/ChangesView.tsx
@@ -63,7 +63,13 @@ export default function ChangesView({
   const [commit, setCommit] = useState<Commit | null>(null);
   const [branchSha, setBranchSha] = useState<string | null>(null);
   const [workingPath, setWorkingPath] = useState<string | null>(null);
+  // A path each, not one shared between the two commit tabs. Switching tabs by
+  // the row moves the open commit without either list's `onToggle` running, so
+  // a single path followed the reader across and opened a file of the same name
+  // in the other tab's commit — which is the auto-selection rule quietly not
+  // happening.
   const [commitPath, setCommitPath] = useState<string | null>(null);
+  const [branchPath, setBranchPath] = useState<string | null>(null);
 
   const head = useHeadTree(cwd, revision, active);
 
@@ -83,13 +89,29 @@ export default function ChangesView({
 
   const workingFiles = working.changes?.files ?? NO_FILES;
 
-  const subTab =
-    subTabPick ??
-    defaultSubTab({
-      hasUncommitted: workingFiles.length > 0,
-      settled: !!working.changes,
-      hasBranchCommits: branchLog.commits.length > 0,
-    });
+  const derived = defaultSubTab({
+    hasUncommitted: workingFiles.length > 0,
+    settled: !!working.changes,
+    hasBranchCommits: branchLog.commits.length > 0,
+  });
+
+  // Taken **once**, when both reads have first answered, and held from there.
+  // The rule picks where the row opens, not where it lives: left deriving on
+  // every render it moves under the reader whenever the answer changes — the
+  // agent writing a file mid-turn would step them off the diff they were
+  // reading and onto Uncommitted. Both reads have to have landed before it can
+  // be taken at all, or whichever answers first decides on the other's behalf.
+  if (subTabPick === null && working.changes && branchLog.settled) setSubTabPick(derived);
+
+  const subTab = subTabPick ?? derived;
+
+  // A different directory is a different repository, so the tab taken for the
+  // old one says nothing about this one.
+  const [seeded, setSeeded] = useState(cwd);
+  if (seeded !== cwd) {
+    setSeeded(cwd);
+    setSubTabPick(null);
+  }
 
   // History keeps its gate. It is the expensive read — the whole of HEAD's
   // history behind it, however long that is — and nothing in the rule above
@@ -127,7 +149,7 @@ export default function ChangesView({
     files.find((f) => f.path === path) ?? files[0] ?? null;
 
   const selectedWorking = pick(workingFiles, workingPath);
-  const selectedCommitFile = pick(commitFiles, commitPath);
+  const selectedCommitFile = pick(commitFiles, subTab === "branch" ? branchPath : commitPath);
 
   const showing = subTab === "uncommitted" ? working : commitChanges;
   const selectedFile = subTab === "uncommitted" ? selectedWorking : selectedCommitFile;
@@ -232,11 +254,11 @@ export default function ChangesView({
             // to replace.
             onToggle={(next) => {
               setBranchSha(next.sha);
-              setCommitPath(null);
+              setBranchPath(null);
             }}
             files={commitFiles}
             selectedFile={selectedCommitFile?.path ?? null}
-            onSelectFile={setCommitPath}
+            onSelectFile={setBranchPath}
             hasMore={branchLog.hasMore}
             onLoadMore={branchLog.loadMore}
             loading={branchLog.loading}

--- a/apps/desktop/src/components/changes/HistoryList.tsx
+++ b/apps/desktop/src/components/changes/HistoryList.tsx
@@ -11,13 +11,17 @@ import type { ChangedFile, Commit } from "@/types/events";
 /// In place rather than as a second column or a drill-in. A column would leave
 /// the diff the narrowest of three panes, and replacing the list would hide the
 /// history behind whichever commit was open. Opening in place keeps both on
-/// screen — and it is why **nothing is selected on arrival**: a first commit
-/// touching thirty files would push the rest of the history off screen before
-/// the reader had picked anything.
+/// screen — which is what lets the history tab arrive with nothing selected: a
+/// first commit touching thirty files would push the rest of the history off
+/// screen before the reader had picked anything.
 ///
-/// No chevron. The row is the control, its highlight says which is open, and a
-/// second click closes it — an arrow would only label what the row already
-/// demonstrates.
+/// Whether anything is open on arrival is the caller's, though, not this
+/// component's. The branch tab opens its newest commit, because there the
+/// alternative is a pane with nothing in it rather than a history worth
+/// scrolling.
+///
+/// No chevron. The row is the control and its highlight says which is open —
+/// an arrow would only label what the row already demonstrates.
 export default function HistoryList({
   commits,
   selected,
@@ -29,6 +33,7 @@ export default function HistoryList({
   onLoadMore,
   loading,
   error,
+  empty = "No commits yet.",
 }: {
   commits: readonly Commit[];
   /// The open commit, or null when the list is closed up.
@@ -42,12 +47,16 @@ export default function HistoryList({
   onLoadMore: () => void;
   loading: boolean;
   error: string | null;
+  /// What an empty list says. The caller's, because "no commits" and "none on
+  /// this branch" are two different facts and only the caller knows which list
+  /// it asked for.
+  empty?: string;
 }) {
   if (error) return <p className="px-3 py-6 text-ui text-destructive">{error}</p>;
   if (!commits.length) {
     return (
       <p className="px-3 py-6 text-ui text-muted-foreground">
-        {loading ? "Reading the history…" : "No commits yet."}
+        {loading ? "Reading the history…" : empty}
       </p>
     );
   }

--- a/apps/desktop/src/hooks/useRepo.ts
+++ b/apps/desktop/src/hooks/useRepo.ts
@@ -97,6 +97,11 @@ export type CommitLog = {
   commits: readonly Commit[];
   error: string | null;
   loading: boolean;
+  /// Whether a read has ever come back for this directory. Carried for
+  /// [useHeadTree]'s reason: until one has, an empty list says "not asked yet"
+  /// rather than "no commits", and a caller that folds the two decides on an
+  /// answer nobody gave it.
+  settled: boolean;
   /// The last page came back full, so there is probably another behind it.
   hasMore: boolean;
   loadMore: () => void;
@@ -120,6 +125,7 @@ export function useCommitLog(
   const [commits, setCommits] = useState<readonly Commit[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [settled, setSettled] = useState(false);
   const [hasMore, setHasMore] = useState(false);
 
   // Read by `loadMore`, which must not close over a stale length: it is called
@@ -141,7 +147,11 @@ export function useCommitLog(
         setError(null);
       })
       .catch((e) => issued.current === token && setError(String(e)))
-      .finally(() => issued.current === token && setLoading(false));
+      .finally(() => {
+        if (issued.current !== token) return;
+        setLoading(false);
+        setSettled(true);
+      });
   }, [cwd, command]);
 
   const loadMore = useCallback(() => {
@@ -177,12 +187,13 @@ export function useCommitLog(
     setSeeded(cwd);
     setCommits([]);
     setError(null);
+    setSettled(false);
     setHasMore(false);
   }
 
   usePolledRead(cwd, revision, active, read);
 
-  return { commits, error, loading, hasMore, loadMore, refresh: read };
+  return { commits, error, loading, settled, hasMore, loadMore, refresh: read };
 }
 
 /// Where the branch stands against its upstream, for the push button.

--- a/apps/desktop/src/hooks/useRepo.ts
+++ b/apps/desktop/src/hooks/useRepo.ts
@@ -103,8 +103,20 @@ export type CommitLog = {
   refresh: () => void;
 };
 
-/// The branch's history, a page at a time.
-export function useCommitLog(cwd: string, revision: string, active: boolean): CommitLog {
+/// A commit list, a page at a time.
+///
+/// Which list is the caller's, because two tabs read two different ones — the
+/// whole of HEAD's history, and just the commits this branch made since it
+/// forked — and both want the same paging, the same race token and the same
+/// `reconcileLog` behind them. Every call site names its command rather than
+/// one of them inheriting a default: a default is how the second reader
+/// quietly gets the first reader's list.
+export function useCommitLog(
+  cwd: string,
+  revision: string,
+  active: boolean,
+  command: string,
+): CommitLog {
   const [commits, setCommits] = useState<readonly Commit[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -121,7 +133,7 @@ export function useCommitLog(cwd: string, revision: string, active: boolean): Co
   const read = useCallback(() => {
     const token = ++issued.current;
     setLoading(true);
-    void invoke<Commit[]>("log_commits", { cwd, limit: LOG_PAGE, skip: 0 })
+    void invoke<Commit[]>(command, { cwd, limit: LOG_PAGE, skip: 0 })
       .then((page) => {
         if (issued.current !== token) return;
         setCommits((prev) => reconcileLog(prev, page));
@@ -130,14 +142,14 @@ export function useCommitLog(cwd: string, revision: string, active: boolean): Co
       })
       .catch((e) => issued.current === token && setError(String(e)))
       .finally(() => issued.current === token && setLoading(false));
-  }, [cwd]);
+  }, [cwd, command]);
 
   const loadMore = useCallback(() => {
     if (paging.current) return;
     paging.current = true;
 
     const token = issued.current;
-    void invoke<Commit[]>("log_commits", {
+    void invoke<Commit[]>(command, {
       cwd,
       limit: LOG_PAGE,
       skip: commitsRef.current.length,
@@ -158,7 +170,7 @@ export function useCommitLog(cwd: string, revision: string, active: boolean): Co
       .finally(() => {
         paging.current = false;
       });
-  }, [cwd]);
+  }, [cwd, command]);
 
   const [seeded, setSeeded] = useState(cwd);
   if (seeded !== cwd) {

--- a/apps/desktop/src/lib/commit.test.ts
+++ b/apps/desktop/src/lib/commit.test.ts
@@ -4,6 +4,7 @@ import {
   checkedCount,
   commitBase,
   commitPaths,
+  defaultSubTab,
   EMPTY_TREE,
   reconcileLog,
   reconcileUnchecked,
@@ -116,5 +117,34 @@ describe("reconcileLog", () => {
     const page = [commit({ sha: "c1" })];
 
     expect(reconcileLog([], page)).toBe(page);
+  });
+});
+
+describe("defaultSubTab", () => {
+  it("opens on work still being written", () => {
+    expect(
+      defaultSubTab({ hasUncommitted: true, settled: true, hasBranchCommits: true }),
+    ).toBe("uncommitted");
+  });
+
+  it("opens on the branch when the tree is clean and the branch has commits", () => {
+    expect(
+      defaultSubTab({ hasUncommitted: false, settled: true, hasBranchCommits: true }),
+    ).toBe("branch");
+  });
+
+  // The view paints before the first read lands, and there an empty list is
+  // "not asked yet" rather than "nothing changed" — read as clean, it opens
+  // the branch tab for a frame and steps off it when the read replies.
+  it("waits for the working tree to answer before leaving Uncommitted", () => {
+    expect(
+      defaultSubTab({ hasUncommitted: false, settled: false, hasBranchCommits: true }),
+    ).toBe("uncommitted");
+  });
+
+  it("stays put when the branch has nothing of its own either", () => {
+    expect(
+      defaultSubTab({ hasUncommitted: false, settled: true, hasBranchCommits: false }),
+    ).toBe("uncommitted");
   });
 });

--- a/apps/desktop/src/lib/commit.ts
+++ b/apps/desktop/src/lib/commit.ts
@@ -83,3 +83,35 @@ export function reconcileLog(
   if (firstPage.length > 0 && firstPage[0].sha === prev[0].sha) return prev;
   return firstPage;
 }
+
+/// Which list the repo view's sub-tab row is showing.
+///
+/// Named here rather than beside the row it labels, so the rule below can
+/// answer in it without this file reaching up into a component.
+export type SubTab = "uncommitted" | "branch" | "history";
+
+/// Where that row lands before the reader has picked a tab.
+///
+/// Uncommitted leads, because it is the one list still being written and every
+/// other tab is a record. A clean tree makes it the emptiest thing on screen
+/// though, so with nothing to commit the branch's own commits are what the
+/// session has to show for itself and the view opens on those instead.
+///
+/// `settled` is what stops that from flipping under the reader. The view
+/// paints before the first read lands, and until it does an empty list says
+/// "not asked yet" rather than "nothing changed" — the same two meanings
+/// `useHeadTree` carries its own `settled` to tell apart. Read as clean, an
+/// unanswered read opens the branch tab for a frame and steps off it the moment
+/// the working tree replies.
+export function defaultSubTab({
+  hasUncommitted,
+  settled,
+  hasBranchCommits,
+}: {
+  hasUncommitted: boolean;
+  /// Whether the working-tree read has ever come back for this directory.
+  settled: boolean;
+  hasBranchCommits: boolean;
+}): SubTab {
+  return !hasUncommitted && settled && hasBranchCommits ? "branch" : "uncommitted";
+}


### PR DESCRIPTION
## TLDR for human

- New **Branch** sub-tab in the Changes view, between Uncommitted and History, listing only the commits this session made.
- Its base comes from the branch's **reflog**, not `origin/<default>` — that matters for `dray new --from`, where the naive range reports the *other* session's commits as this one's.
- The tab auto-opens its newest commit and first file, so it shows a diff rather than an empty frame.
- The sub-tab row now lands on whichever tab has content, until the reader picks one by hand.
- Fixed a tooltip that silently assumed exactly two sub-tabs.

---

History logs `HEAD` whole, so a session's own commits sit buried under everything that came before them.

### Working out the honest base

A worktree's base is not always `origin/<default>`, so I probed git rather than assumed. `git worktree add --no-track -B` — what both `claude -w` and `dray new --from` use — writes `branch: Created from <base>` into the branch's reflog, and that entry's own `%H` **is** the base commit, because the branch starts life pointing at it. An ordinary `git checkout -b` writes the same entry, so plain sessions are covered too.

Measured, on a repo where session B was forked from session A's branch:

```
origin/main..HEAD          → B1, B2, A1, A2   ← reports A's work as B's
HEAD --not <fork> origin/main  → B1, B2
```

Newest matching entry wins, not oldest: `-B` on a pre-existing branch resets it, and older entries name a base this session never had. Pinned by `a_reset_branch_forks_from_the_base_it_was_reset_to`.

`default_base` is excluded **alongside** the fork point, not instead of it. A session that merges `origin/main` in mid-flight pulls upstream commits into HEAD that the fork point predates, and those are not its work. Dropping either exclusion fails a test.

Every exclusion is resolved with `rev-parse --verify` before any argv is built. One bad rev is fatal to the whole `git log`, and `git()` swallows a failure into `None` — so an `origin/HEAD` symref pointing at a never-fetched ref would have left the tab silently empty. `default_base` is the live case: it resolves that symref without checking the target exists.

Where **no** exclusion resolves, the answer is empty rather than the whole of HEAD. A branch with no nameable base has no honest answer, and History already draws everything.

**Known limit:** after a rebase that replays another branch's commits onto a new base, git no longer knows whose were whose, so this over-reports. That is the safe direction, and the same reading the unpushed-commit count already takes.

### Auto-selection

The open commit is derived from a stored sha (`find(sha) ?? commits[0] ?? null`), never stored outright — the rule already in this file. Falling back to the newest is what opens the tab on a diff. Deliberately no toggle-to-close here, unlike History: closing it is exactly the empty pane the tab exists to replace.

### Default sub-tab

`defaultSubTab` is a pure function over three named booleans, tested. `settled` is the load-bearing one: the view paints before the first read lands, and an unanswered read read as "clean" would flip the row for a frame and step off it again. The reader's pick is `SubTab | null`, `null` meaning never picked, exactly how `App.tsx` treats `panelTab`.

This needed the uncommitted and branch reads to run on `active` alone rather than on the tab they decide — gating them on the tab they choose is circular. Side benefit: the Uncommitted count is now honest from every tab, which it was not before. History's paged read stays gated, being the expensive one. Cost is one extra snapshot per event while sitting on History, bounded by the existing `active` gate and the 300ms debounce.

### On the Shift+←/→ comment

The claim half-holds. `stepSubTab` indexes the array and clamps on `undefined`, so the **chord** genuinely needed no third binding. The **tooltip** beside it did not survive a third tab: it rendered `i === 0 ? "←" : "→"`, so the middle tab would have claimed `→` and History would have claimed `→` when `←` is what reaches it. Now first shows `←`, last shows `→`, and any middle tab shows `←→` in one keycap, so it stays one `KbdGroup` at any row length.

### Verification

- `cargo test` — 431 passed, run five times clean (a flake reported during development did not reproduce; it traced to two concurrent `cargo test` runs both regenerating the shared `events.ts`).
- `pnpm test` — 373 passed.
- `pnpm build` — clean, and `events.ts` came back byte-identical, as it must, since this adds no exported type.

### Worth flagging

An empty answer means "no base could be named" and "this branch has made no commits" identically on the wire, and the empty state claims the second. Worth a hedge if the first case turns out to be common.

Fixes DRA-105