### PR TITLE
docs(prompts): define parent session and harness names

### DIFF
--- a/apps/desktop/src-tauri/src/harness/claude_code/claude_code.rs
+++ b/apps/desktop/src-tauri/src/harness/claude_code/claude_code.rs
@@ -365,3 +365,36 @@ async fn read_stderr(stderr: ChildStderr) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::APPEND_SYSTEM_PROMPT;
+
+    /// Same undefined word Codex read as a git parent. Claude has not been seen
+    /// to get it wrong, which is not the same as the prompt saying what it means.
+    #[test]
+    fn the_prompt_defines_a_parent_session() {
+        // Prose, so match on the words rather than on where a line wraps.
+        let prose = APPEND_SYSTEM_PROMPT
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(prose.contains("parent session is the Dray session that spawned this one"));
+        assert!(prose.contains("never a git parent"));
+        assert!(prose.contains("`parentSessionId`"));
+    }
+
+    /// "Review this with codex" names a harness, and an agent reading it as the
+    /// vendor's CLI shells out to a second agent nothing in the app can see.
+    #[test]
+    fn the_prompt_reads_an_agent_name_as_a_harness() {
+        let prose = APPEND_SYSTEM_PROMPT
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(prose.contains("`dray new --harness <name>`"));
+        assert!(prose.contains("never the vendor's own CLI or app"));
+    }
+}

--- a/apps/desktop/src-tauri/src/harness/claude_code/system_prompt.md
+++ b/apps/desktop/src-tauri/src/harness/claude_code/system_prompt.md
@@ -35,6 +35,8 @@ Independent pieces of work run as separate Dray sessions, each on its own branch
 
 Task, session, chat, agent, worker, tab — all one thing: a Dray session.
 
+Your parent session is the Dray session that spawned this one, never a git parent. `dray ls --json` names it `parentSessionId`, and `dray send <id>` reaches it.
+
 Reach for `dray new` on:
 
 - "spin up a session", "start a session", "open a new task"
@@ -42,6 +44,9 @@ Reach for `dray new` on:
 - "run these in parallel", "in another session"
 - "fan this out", "spawn agents", "swarm of agents"
 - "have another agent review this" → `dray new --from <this session's id>`
+- "code review with codex", "get claude to look at this" → `dray new --harness <name>`
+
+Naming an agent names the harness a Dray session runs, never the vendor's own CLI or app. Never shell out to one.
 
 A count means that many sessions, one each. Own branch and PR = own session; steps of one job stay in one.
 

--- a/apps/desktop/src-tauri/src/harness/codex/codex.rs
+++ b/apps/desktop/src-tauri/src/harness/codex/codex.rs
@@ -788,6 +788,34 @@ mod tests {
         assert!(prose.contains(r#"only "Dray isn't running" says that"#));
     }
 
+    /// Told to report back to its parent, an agent with no definition of the
+    /// word reads it as a git parent and goes looking at commits. The prompt
+    /// has to say which parent it means; the skill carries the mechanism.
+    #[test]
+    fn the_developer_instructions_define_a_parent_session() {
+        let prose = DEVELOPER_INSTRUCTIONS
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(prose.contains("parent session is the Dray session that spawned this one"));
+        assert!(prose.contains("never a git parent"));
+        assert!(prose.contains("`parentSessionId`"));
+    }
+
+    /// "Review this with codex" names a harness, and an agent reading it as the
+    /// vendor's CLI shells out to a second agent nothing in the app can see.
+    #[test]
+    fn the_developer_instructions_read_an_agent_name_as_a_harness() {
+        let prose = DEVELOPER_INSTRUCTIONS
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(prose.contains("`dray new --harness <name>`"));
+        assert!(prose.contains("never the vendor's own CLI or app"));
+    }
+
     /// Replays a real capture through the parser and the mapper.
     ///
     /// The point is not the assertions below so much as the parse itself: these

--- a/apps/desktop/src-tauri/src/harness/codex/developer_instructions.md
+++ b/apps/desktop/src-tauri/src/harness/codex/developer_instructions.md
@@ -33,6 +33,8 @@ Independent pieces of work run as separate Dray sessions, each on its own branch
 
 Task, session, chat, agent, worker, tab — all one thing: a Dray session.
 
+Your parent session is the Dray session that spawned this one, never a git parent. `dray ls --json` names it `parentSessionId`, and `dray send <id>` reaches it.
+
 Reach for `dray new` on:
 
 - "spin up a session", "start a session", "open a new task"
@@ -40,6 +42,9 @@ Reach for `dray new` on:
 - "run these in parallel", "in another session"
 - "fan this out", "spawn agents", "swarm of agents"
 - "have another agent review this" → `dray new --from <this session's id>`
+- "code review with codex", "get claude to look at this" → `dray new --harness <name>`
+
+Naming an agent names the harness a Dray session runs, never the vendor's own CLI or app. Never shell out to one.
 
 A count means that many sessions, one each. Own branch and PR = own session; steps of one job stay in one.
 


### PR DESCRIPTION
Both harness prompts use "parent" and name agents without ever defining either word.

- **Parent session.** Told to report back to its parent, Codex read the word as a git parent and went looking at commits. One line now says what it is: the Dray session that spawned this one, `parentSessionId` in `dray ls --json`, reached with `dray send <id>`.
- **Agent names.** "Code review with codex" reads as shelling out to the vendor CLI. One line now says it names the harness a Dray session runs, `dray new --harness <name>`.

Vocabulary only — the `dray` skill already carries the mechanism, so neither line restates it. The two prompts stay separate files; each keeps its own wording elsewhere.

Four tests pin the definitions, two per prompt. `claude_code.rs` had no test module for its prompt at all, so this adds one.

Fixes DRA-110

🤖 Generated with [Claude Code](https://claude.com/claude-code)