### PR TITLE
fix(composer): draw the card's edge in dark mode

### DIFF
--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -265,6 +265,13 @@
      that needs this, where every surface is within a few percent of white and a
      shadow is the only thing left that can say "above". */
   --shadow-surface: none;
+  /* The edge of that same floating surface, and the exact twin of the shadow
+     above: the two say "above" in the two modes, and never both at once. A
+     hairline here because dark's floating surface is glass — `--veil-float` is
+     62% of a colour a few percent off the page — so being lighter than the
+     transcript is not on its own enough to draw the box. Light takes the shadow
+     and no edge; see the note there. */
+  --edge-surface: var(--hairline);
   /* The same idea one step down, for a surface that sits *in* the page rather
      than floating over it — the user's own message bubble, and whatever else
      wants separating from the transcript without claiming to hover above it. The
@@ -444,6 +451,12 @@
      that says how far above the transcript the card sits. */
   --shadow-surface:
     0 1px 1px oklch(0 0 1 / 8%), 0 1px 1px oklch(0 0 0 / 10%), 0 1px 4px oklch(0 0 0 / 8%);
+  /* Transparent, where dark carries a hairline. The shadow above already draws
+     the lip, and a border under it is a second line saying the same thing — read
+     together they double the edge and the crispness the shadow was tuned for is
+     what makes that show. Transparent rather than absent so the border-width
+     stays 1px in both modes: focus swaps the colour in and nothing reflows. */
+  --edge-surface: transparent;
   /* Lighter and a shade softer than the one above, and both halves are needed:
      the composer's shadow read as an edge cut under the bubble, because a bubble
      is not lifted off the page the way a bar at the window's edge is. So the
@@ -632,6 +645,7 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-hairline: var(--hairline);
+  --color-edge-surface: var(--edge-surface);
   --color-hairline-strong: var(--hairline-strong);
   --color-veil-strong: var(--veil-strong);
   --color-destructive: var(--destructive);

--- a/apps/desktop/src/components/ChatInput.tsx
+++ b/apps/desktop/src/components/ChatInput.tsx
@@ -669,13 +669,20 @@ export default function ChatInput({
             ref={cardRef}
             className={cn(
               "relative rounded-2xl transition-colors",
-              // `--shadow-surface` is `none` in dark, where the card already reads
-              // as raised by being lighter than the transcript behind it. In light
-              // every surface sits within a few percent of white, so the shadow is
-              // the only thing left that says the composer floats over the page it
-              // scrolls under.
+              // `--edge-surface` and `--shadow-surface` are one pair, and exactly
+              // one of them is drawn per mode. Light gets the shadow and a
+              // transparent edge — under a shadow tuned this crisp, a border is a
+              // second line saying the same thing. Dark gets the edge and no
+              // shadow: a shadow under a dark card falls on something already
+              // darker than itself, and the card is glass there, so being lighter
+              // than the page does not draw the box on its own.
+              //
+              // The focus hairline is not part of that trade and stays in both:
+              // a shadow can say "above" and cannot say "focused". The resting
+              // border keeps its width in light and spends only its colour, so
+              // focus swaps a value and reflows nothing.
               !isNewTask &&
-                "bg-composer shadow-(--shadow-surface) backdrop-blur-xl focus-within:border-hairline-strong",
+                "border border-edge-surface bg-composer shadow-(--shadow-surface) backdrop-blur-xl focus-within:border-hairline-strong",
             )}
           >
             {/* Covers the card rather than replacing anything, so the text and


### PR DESCRIPTION
The chat input was barely visible on the Default theme in dark mode.

`4ed26eea` traded the composer card's `border border-hairline` for `shadow-(--shadow-surface)`. That shadow is what light mode needs, and it is `none` in dark — so the card was left with neither an edge nor a shadow. What remained was `bg-composer`, which under transparency is `--veil-float`: 62% of `--surface-card` over a backdrop a few percent darker, and nothing drawing the boundary.

`--edge-surface` is the shadow's twin, declared beside it in both ramps: a hairline in dark, transparent in light. Exactly one of the two is drawn per mode, so the shadow keeps carrying light on its own and no border doubles the lip it draws.

The focus hairline is not part of that trade and stays in both modes — a shadow can say "above" and cannot say "focused". The resting border keeps its width in light and spends only its colour, so focus swaps a value and reflows nothing.

`focus-within:border-hairline-strong` had also been dead since that commit: a border colour with no width behind it. It works again.

Fixes DRA-115