### PR TITLE
Sidebar: drop the heading's path tooltip, unselect the filter label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,13 @@ File give Claude Code (claude.ai/code) guidance for work with code in this repo.
 
 **PR nobody need review carry `no-review` label.** Copy tweak, doc, prompt wording, config — label keep review bot off diff with nothing to find. Add at open (`gh pr create --label no-review`), since review fire on open. Anything touching behaviour = no label.
 
-**Open PR as draft, then spawn Codex reviewer.** `dray new --harness codex --effort medium --from <this session's id>`, briefed with issue, change and PR url — push first, since `--from` carry committed work only. It report through `dray send`; you fix and push until nothing left, then mark ready. `no-review` PR skip both.
+**Default road = work → draft PR → Codex reviewer → talk to it till nothing left → mark ready.** Reaching work you judge done, take that road without being told. Open draft, then `dray new --harness codex --effort medium --from <this session's id>`, briefed with issue, change and PR url — push first, since `--from` carry committed work only. It report through `dray send`; you answer on same channel, fix and push, until it find nothing. Then ready.
+
+**Reader saying "open a PR" = ready PR, no reviewer.** Their word for it mean work already good to go in their judgement, so `gh pr create` with no `--draft` and nobody spawned. That the one instruction outranking road above.
+
+**Draft = the ask for review, so the two never part.** Draft with no reviewer leave PR sitting unready for nothing; reviewer on ready PR review work already declared done. Never one without other.
+
+**Be smart about which change earn that road.** Two-line copy fix, a class removed, a tooltip dropped — review there cost reader a session to read and delete and find nothing worth the turn. Real change, anything touching behaviour or spanning files, take it. Wrong call fixable either way: unasked reviewer = noise, missed one = they ask.
 
 **One team, `Dray`. Prefix `DRA-`. Assign every issue to `yogesh`.**
 

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -746,9 +746,6 @@ export default function Sidebar({
               <Fragment key={group.kind === "pinned" ? "pinned" : group.projectPath}>
                 {heading !== null ? (
                   <div
-                    // Full path on hover, since two projects can share a folder
-                    // name. Pinned has no one path to name.
-                    title={group.kind === "project" ? group.projectPath : undefined}
                     className={cn(
                       "flex min-h-6 items-center truncate pr-2 pl-2 text-ui text-muted-foreground/70",
                       // The first heading sits under the filter's own row, which
@@ -1002,8 +999,10 @@ function ProjectFilter({
       // The negative margin gives the band height without moving anything:
       // `items-center` keeps the column itself where it was. No focus ring: the
       // band is a strip of empty space, so a box drawn around it reads as a
-      // stray frame rather than as the label being focused.
-      className="group/projects -my-1 flex min-w-0 flex-1 cursor-pointer flex-col items-start py-1 pl-1 focus-visible:outline-none"
+      // stray frame rather than as the label being focused. Unselectable
+      // because the label is the target's face, not prose — a double-click
+      // aimed at the band highlighting it is only ever an accident.
+      className="group/projects -my-1 flex min-w-0 flex-1 cursor-pointer flex-col items-start py-1 pl-1 select-none focus-visible:outline-none"
     >
       {/* Hugs its own contents, so the dots stay centred under the label rather
           than under the band. */}


### PR DESCRIPTION
Two small sidebar fixes, plus a CLAUDE.md correction the review of them produced.

**The project heading's `title`.** It held the full path. DESIGN.md reserves that slot for text the app is *truncating* — a shortened path, a clipped name — where the tooltip restores what the layout removed rather than adding a fact the reader did not ask for. The heading names a project already picked, so the system tooltip drifting in was noise over a surface people only scan.

**The picker entry's `title` stays.** It is the same shape and a different question: two projects can share a folder name, and the picker is where that ambiguity is resolved, at the moment of choosing. A Radix menu item cannot hold a real tooltip, so the alternative is losing the disambiguation, not relocating it. That one is data at the point of decision, not a hint on passive chrome.

**The filter is a bare `div` with `role="button"`**, so it never picked up the `select-none` every `Button` in that row already carries. A double-click aimed at the band highlighted its own label. Added.

Nothing else in that row has the problem — the settled/active toggle is a `Button`, and `DevBadge`'s `title` is a genuine truncation restore.

**CLAUDE.md: draft PR and reviewer are one road, and it is judged.** The rule read "open PR as draft, then spawn Codex reviewer" flatly, and this change is exactly the kind that does not earn it. It now says the road is taken on the agent's own read that work is done; that a reader saying "open a PR" in their own words outranks it and means a ready PR with no reviewer; and that draft and reviewer never part.

`pnpm test` 404 passing, `tsc --noEmit` clean.

Fixes DRA-116

🤖 Generated with [Claude Code](https://claude.com/claude-code)