### PR TITLE
Deleting a worktree no longer holds the dialog open

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -223,9 +223,15 @@ Dialog get **no** such confirmation: it close, and enough else on screen already
 
 **Neither route wait on git.** Unlock, remove, `branch -D` = three command over directory that can be large, and both surface used to sit through them — dialog unchanged, card spinning "Deleting…". Press now start work and answer straight away: dialog close, card go to its **Deleted** state. Reversal deliberate. Spinner said "still going" and nothing else, and dialog holding still through it read as click that missed.
 
-**Cost = failure land after reader been told it worked, so second card take it back.** `worktree-failed`, raised whatever window doing (like `pr`, opposite reason — reader already seen wrong answer). Label = news not verb (`Worktree not deleted`), subject = task title like offer's, detail = **git's own sentence**, only thing naming why — tree another session hold lock on, removal git refuse. Button = `View`, and it lead somewhere real: refusal leave index entry alone, so settled bar still carry its Delete worktree button. Reason on card, cure at end of button. Bar take destructive colour offer wore — same deletion, and only place reader learn tree still there.
+**"Deleted" therefore optimistic, and card exist to take it back.** `worktree-failed`, raised whatever window doing (like `pr`, opposite reason — reader already seen wrong answer). Detail = backend's own sentence, only thing saying which step stopped.
 
-Error banner cannot carry this and that not preference: banner draw above **composer**, settled session draw settled bar instead, so one state this reachable from = one state banner not on screen in.
+**Label name operation, never outcome** — `Worktree cleanup failed`, not "not deleted". Removal = run of step and any can answer: git refusing leave directory, but index write come **last**, so failure there = tree already gone and session simply never moved off it. Which step reached not reported, so copy claiming state of disk wrong roughly half the time.
+
+Button = `View`, and it lead somewhere real for same reason: last step = one clearing index entry, so cleanup that stop anywhere leave settled bar still carrying its Delete worktree button. Reason on card, rest of run at end of button. Bar take destructive colour offer wore — same deletion, only place reader learn it stopped part way.
+
+**Card only where reader been told something.** Tidy-up pass over worktree already gone raise none: nothing drawn, nothing promised, and session pointed at missing directory before it ran, so card there = state reader never seen and cannot act on.
+
+Error banner cannot carry any of this and that not preference: banner draw above **composer**, settled session draw settled bar instead, so one state this reachable from = one state banner not on screen in.
 
 Failure inside session **delete** stay quiet, deliberately: card keyed to session about to stop existing, whose button lead nowhere. Naming orphaned path with no session behind it = channel of its own.
 

--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -221,7 +221,15 @@ It only card with **two** button. Skip = answer card give itself when bar run ou
 
 Dialog get **no** such confirmation: it close, and enough else on screen already say so.
 
-Card also only one naming its subject, breaking `NoticeStack`'s own "verb and nothing else" rule on purpose — several card can stack, and "Settled" alone say nothing about which settle it answer for. Detail line say "its worktree", which reach directory through thing that own it. Title run to 60 char and card `w-fit`, so it capped and truncated with `title` attribute restoring rest. Dialog keep worktree name instead: it open from settled bar, where title already two inches away in header.
+**Neither route wait on git.** Unlock, remove, `branch -D` = three command over directory that can be large, and both surface used to sit through them — dialog unchanged, card spinning "Deleting…". Press now start work and answer straight away: dialog close, card go to its **Deleted** state. Reversal deliberate. Spinner said "still going" and nothing else, and dialog holding still through it read as click that missed.
+
+**Cost = failure land after reader been told it worked, so second card take it back.** `worktree-failed`, raised whatever window doing (like `pr`, opposite reason — reader already seen wrong answer). Label = news not verb (`Worktree not deleted`), subject = task title like offer's, detail = **git's own sentence**, only thing naming why — tree another session hold lock on, removal git refuse. Button = `View`, and it lead somewhere real: refusal leave index entry alone, so settled bar still carry its Delete worktree button. Reason on card, cure at end of button. Bar take destructive colour offer wore — same deletion, and only place reader learn tree still there.
+
+Error banner cannot carry this and that not preference: banner draw above **composer**, settled session draw settled bar instead, so one state this reachable from = one state banner not on screen in.
+
+Failure inside session **delete** stay quiet, deliberately: card keyed to session about to stop existing, whose button lead nowhere. Naming orphaned path with no session behind it = channel of its own.
+
+Card name its subject — it and `worktree-failed` the only two that do — breaking `NoticeStack`'s own "verb and nothing else" rule on purpose — several card can stack, and "Settled" alone say nothing about which settle it answer for. Detail line say "its worktree", which reach directory through thing that own it. Title run to 60 char and card `w-fit`, so it capped and truncated with `title` attribute restoring rest. Dialog keep worktree name instead: it open from settled bar, where title already two inches away in header.
 
 **Counts _are_ warning, so dialog one step not two.** Sidebar's delete and PR panel's merge take second confirm precisely because they carry no such detail; adding one here make reader confirm sentence they already read. Destructive fill only where something actually lost — on clean tree this tidying up, and red make safe answer look like dangerous one.
 

--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -229,7 +229,7 @@ Dialog get **no** such confirmation: it close, and enough else on screen already
 
 Button = `View`, and it lead somewhere real for same reason: last step = one clearing index entry, so cleanup that stop anywhere leave settled bar still carrying its Delete worktree button. Reason on card, rest of run at end of button. Bar take destructive colour offer wore — same deletion, only place reader learn it stopped part way.
 
-**Card only where reader been told something.** Tidy-up pass over worktree already gone raise none: nothing drawn, nothing promised, and session pointed at missing directory before it ran, so card there = state reader never seen and cannot act on.
+**Card follow who asked, not what happened.** Worktree already gone skip question either way — nothing left to weigh — but settle's own pass raise nothing on failure (nothing drawn, nothing promised, session pointed at missing directory before it ran) where **button press still report**: reader watched that dialog close, so silence there = click with nothing to show for it, which whole thing this section exist to remove.
 
 Error banner cannot carry any of this and that not preference: banner draw above **composer**, settled session draw settled bar instead, so one state this reachable from = one state banner not on screen in.
 

--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -1057,6 +1057,15 @@ impl SessionManager {
         // go. `git worktree remove` by hand is the recovery. Failing the
         // delete instead would be worse — the session the user asked to be rid
         // of would still be there.
+        //
+        // Deliberately *not* covered by the card [`remove_worktree`] above
+        // raises on a refusal. That card corrects a "Deleted" the reader was
+        // shown and sends them back to the session to try again; here they were
+        // shown nothing to correct, and the session it would be keyed to is the
+        // one being deleted — so it would be a card about a row that is gone,
+        // whose button leads nowhere. Saying this properly means naming the
+        // orphaned path with no session behind it, which is a channel of its
+        // own and not this one.
         if let Some(item) = get_session_index_item(session_id).await? {
             if let Err(e) = remove_session_worktree(&item).await {
                 eprintln!("could not remove worktree for {session_id}: {e}");

--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -1058,14 +1058,14 @@ impl SessionManager {
         // delete instead would be worse — the session the user asked to be rid
         // of would still be there.
         //
-        // Deliberately *not* covered by the card [`remove_worktree`] above
-        // raises on a refusal. That card corrects a "Deleted" the reader was
-        // shown and sends them back to the session to try again; here they were
-        // shown nothing to correct, and the session it would be keyed to is the
-        // one being deleted — so it would be a card about a row that is gone,
-        // whose button leads nowhere. Saying this properly means naming the
-        // orphaned path with no session behind it, which is a channel of its
-        // own and not this one.
+        // Deliberately *not* covered by the card the frontend raises when
+        // [`remove_worktree`] above is refused. That card corrects a "Deleted"
+        // the reader was shown and sends them back to the session to try again;
+        // here they were shown nothing to correct, and the session it would be
+        // keyed to is the one being deleted — so it would be a card about a row
+        // that is gone, whose button leads nowhere. Saying this properly means
+        // naming the orphaned path with no session behind it, which is a
+        // channel of its own and not this one.
         if let Some(item) = get_session_index_item(session_id).await? {
             if let Err(e) = remove_session_worktree(&item).await {
                 eprintln!("could not remove worktree for {session_id}: {e}");

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -279,7 +279,7 @@ function App() {
     }
 
     if (!disposition.exists) {
-      removeWorktree(sessionId);
+      removeWorktree(sessionId, "tidy");
       return;
     }
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -279,7 +279,7 @@ function App() {
     }
 
     if (!disposition.exists) {
-      void removeWorktree(sessionId);
+      removeWorktree(sessionId);
       return;
     }
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -254,8 +254,9 @@ function App() {
 
   // Reads what the removal would cost *before* deciding whether to ask, so a
   // worktree that isn't there any more — deleted by hand, or by a `claude` run
-  // that had an exit prompt of its own — is tidied up silently. Asking about a
-  // directory the reader can no longer see is a question with one answer.
+  // that had an exit prompt of its own — is tidied up without a question.
+  // Asking about a directory the reader can no longer see is a question with
+  // one answer.
   //
   // `ask` is the whole difference between the two routes in. Settling raises a
   // notice that expires into "keep it", because the reader was doing something
@@ -279,7 +280,13 @@ function App() {
     }
 
     if (!disposition.exists) {
-      removeWorktree(sessionId, "tidy");
+      // Skipping the question is right either way — there is nothing left to
+      // weigh — but *who asked* still decides whether a failure is reported.
+      // The dialog route is a button the reader pressed and watched close, so
+      // a relocation that then fails has to say so, or that press is the click
+      // with nothing to show for it this whole change is about. Settling asked
+      // for nothing and hears nothing.
+      removeWorktree(sessionId, ask === "dialog" ? "asked" : "tidy");
       return;
     }
 

--- a/apps/desktop/src/components/NoticeStack.tsx
+++ b/apps/desktop/src/components/NoticeStack.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { Check, Loader2 } from "lucide-react";
+import { Check } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -28,7 +28,9 @@ type NoticeStackProps = {
   /// its PR tab. Selecting alone would land the reader on a transcript that
   /// says nothing about the pull request the card is about.
   onOpenPr: (sessionId: string) => void;
-  onDeleteWorktree: (sessionId: string) => Promise<boolean>;
+  /// Starts the removal, which answers nothing: git finishes in the background
+  /// and a refusal comes back as a card of its own.
+  onDeleteWorktree: (sessionId: string) => void;
 };
 
 /// What the button promises. Named for what the reader will do there rather
@@ -44,6 +46,10 @@ const ACTION: Record<NoticeKind, string> = {
   // the one irreversible thing in the app reachable by a stray click on a
   // notice nobody asked for.
   pr: "Review",
+  // Where the retry is. The refused removal left the index entry alone, so the
+  // session's settled bar is still carrying its "Delete worktree" button — the
+  // card names the reason and this puts the reader back in front of the cure.
+  "worktree-failed": "View",
 };
 
 /// The bar's colour, matching the rail mark the row will be wearing when the
@@ -63,6 +69,10 @@ const BAR: Record<NoticeKind, string> = {
   // colour to separate them would spend the palette on a distinction the label
   // already makes.
   pr: "bg-accent-add/70",
+  // The colour the offer wore, kept for the card that reports it did not
+  // happen: the two are the same deletion, and this one is the only place the
+  // reader learns the tree is still there.
+  "worktree-failed": "bg-destructive/70",
 };
 
 /// How long the card lingers after its work is done, to say so. Long enough to
@@ -120,9 +130,12 @@ function NoticeCard({
   notice: Notice;
   isNext: boolean;
   onTake: () => void;
-  onDeleteWorktree: () => Promise<boolean>;
+  onDeleteWorktree: () => void;
 }) {
-  const [phase, setPhase] = useState<"idle" | "working" | "done">("idle");
+  // Two states, not three. There was a `working` one holding a spinner while
+  // git ran; the removal no longer waits, so the press goes straight to the
+  // answer and a refusal arrives later as its own card.
+  const [phase, setPhase] = useState<"idle" | "done">("idle");
   const [hovered, setHovered] = useState(false);
   const worktree = notice.kind === "worktree";
 
@@ -159,26 +172,24 @@ function NoticeCard({
     };
   }, [duration, notice.sessionId]);
 
-  // Nothing runs down while the reader is on the card or while the git work is
-  // in flight. `done` deliberately keeps running under the cursor: the reader
-  // just clicked this, and the pause exists to protect a button they are still
-  // reaching for — past that press there is no target left to protect, and a
-  // card waiting for the mouse to leave reads as stuck.
-  const frozen = phase === "working" || (hovered && phase === "idle");
+  // Nothing runs down while the reader is on the card. `done` deliberately
+  // keeps running under the cursor: the reader just clicked this, and the pause
+  // exists to protect a button they are still reaching for — past that press
+  // there is no target left to protect, and a card waiting for the mouse to
+  // leave reads as stuck.
+  const frozen = hovered && phase === "idle";
   useEffect(() => {
     if (frozen) timer.current?.pause();
     else timer.current?.play();
   }, [frozen, duration]);
 
-  const confirm = async () => {
-    setPhase("working");
-    if (await onDeleteWorktree()) {
-      setPhase("done");
-      return;
-    }
-    // The error banner already carries the reason, so the card leaves rather
-    // than sitting there implying the deletion is still going to happen.
-    dismissNotice(notice.sessionId, notice.kind);
+  // Said, not awaited. "Deleted" is the truthful thing to draw here — the
+  // removal is under way and nothing the reader does now changes it — and it
+  // is the one confirmation this deletion gets on either route. A git refusal
+  // lands afterwards on a `worktree-failed` card, which is what takes it back.
+  const confirm = () => {
+    onDeleteWorktree();
+    setPhase("done");
   };
 
   // ⌘D deletes without the trip to a 40px button, which is the whole point of
@@ -190,9 +201,10 @@ function NoticeCard({
   // A key of its own rather than more meaning on ⌘G: one chord that sometimes
   // navigates and sometimes destroys is the shape that burns someone once.
   // Guarded on `isNext` so a stack of cards has exactly one target, the same
-  // one ⌘G has, and on `idle` so a repeat press can't land mid-flight.
+  // one ⌘G has, and on `idle` so a repeat press cannot ask for the removal a
+  // second time while the card sits there saying it already happened.
   useHotkey("d", () => {
-    if (worktree && isNext && phase === "idle") void confirm();
+    if (worktree && isNext && phase === "idle") confirm();
   });
 
   return (
@@ -247,7 +259,6 @@ function NoticeCard({
               variant="ghost"
               size="xs"
               className="text-muted-foreground"
-              disabled={phase === "working"}
               onClick={() => dismissNotice(notice.sessionId, notice.kind)}
             >
               Skip
@@ -269,27 +280,17 @@ function NoticeCard({
             // card the reader did not ask for, it is the difference between a
             // button they read and one they click past.
             worktree && "bg-destructive text-white hover:bg-destructive/90",
-            // Full strength while the git work runs: the spinner and the verb
-            // are the state, and dimming them makes the one live thing on the
-            // card the hardest part of it to read.
-            "disabled:opacity-100",
             // Done is a statement, not a control. It keeps the fill so the card
             // doesn't reflow into a different shape at the moment the eye is on
             // it, and drops the pointer so nothing invites a second press.
             phase === "done" && "pointer-events-none",
           )}
-          disabled={phase === "working"}
-          onClick={worktree ? () => void confirm() : onTake}
+          onClick={worktree ? confirm : onTake}
         >
           {phase === "done" ? (
             <>
               <Check className="size-3.5" />
               Deleted
-            </>
-          ) : phase === "working" ? (
-            <>
-              <Loader2 className="size-3.5 animate-spin" />
-              Deleting…
             </>
           ) : (
             ACTION[notice.kind]
@@ -344,6 +345,10 @@ export default function NoticeStack({
   // Where a card leads, which is the same for the key and for the button. The
   // navigating kinds go somewhere and a worktree card only leaves: its Skip is
   // what this lands on, which is what keeps the key below non-destructive.
+  //
+  // `worktree-failed` navigates like the rest, and has to: it is the one card
+  // whose subject is a session the reader is being sent back to, where the
+  // button that tries the removal again still is.
   const take = (notice: Notice) => {
     dismissNotice(notice.sessionId, notice.kind);
     if (notice.kind === "pr") onOpenPr(notice.sessionId);

--- a/apps/desktop/src/components/NoticeStack.tsx
+++ b/apps/desktop/src/components/NoticeStack.tsx
@@ -46,9 +46,10 @@ const ACTION: Record<NoticeKind, string> = {
   // the one irreversible thing in the app reachable by a stray click on a
   // notice nobody asked for.
   pr: "Review",
-  // Where the retry is. The refused removal left the index entry alone, so the
-  // session's settled bar is still carrying its "Delete worktree" button — the
-  // card names the reason and this puts the reader back in front of the cure.
+  // Where the retry is. The step that clears the index entry is the last one,
+  // so a cleanup that stopped anywhere left the settled bar carrying its
+  // "Delete worktree" button — the card names the reason and this puts the
+  // reader back in front of the control that runs the rest.
   "worktree-failed": "View",
 };
 
@@ -69,9 +70,9 @@ const BAR: Record<NoticeKind, string> = {
   // colour to separate them would spend the palette on a distinction the label
   // already makes.
   pr: "bg-accent-add/70",
-  // The colour the offer wore, kept for the card that reports it did not
-  // happen: the two are the same deletion, and this one is the only place the
-  // reader learns the tree is still there.
+  // The colour the offer wore, kept for the card that reports it did not go
+  // through: the two are the same deletion, and this one is the only place the
+  // reader learns it stopped part way.
   "worktree-failed": "bg-destructive/70",
 };
 
@@ -183,10 +184,13 @@ function NoticeCard({
     else timer.current?.play();
   }, [frozen, duration]);
 
-  // Said, not awaited. "Deleted" is the truthful thing to draw here — the
-  // removal is under way and nothing the reader does now changes it — and it
-  // is the one confirmation this deletion gets on either route. A git refusal
-  // lands afterwards on a `worktree-failed` card, which is what takes it back.
+  // Said, not awaited — and "Deleted" is *optimistic*, deliberately. It reports
+  // a removal that is under way rather than one that has happened, which is the
+  // trade this whole surface now makes: the alternative is a spinner saying
+  // "still going" over three git commands, which is the click that reads as
+  // missed. Nothing the reader does from here changes the outcome, and a
+  // cleanup that fails comes back on a `worktree-failed` card, which exists to
+  // take this word back.
   const confirm = () => {
     onDeleteWorktree();
     setPhase("done");

--- a/apps/desktop/src/components/WorktreeDialog.tsx
+++ b/apps/desktop/src/components/WorktreeDialog.tsx
@@ -1,6 +1,3 @@
-import { useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
-
 import {
   AlertDialog,
   AlertDialogAction,
@@ -39,13 +36,27 @@ export type WorktreePrompt = {
 /// destructive controls — the sidebar's delete, the PR panel's merge — use a
 /// second confirm precisely because they carry no such detail. Adding one here
 /// would make the reader confirm a sentence they had already read.
+///
+/// **And it does not wait for git.** Unlocking the tree, removing it and
+/// deleting its branch is three commands over a directory that can be large,
+/// and this used to stay up through all three behind a spinner — which said
+/// "still going" for a second and a half and nothing else. The press starts the
+/// work and the dialog leaves on it, so there is no `deleting` state here at
+/// all: nothing on this surface outlives the click.
+///
+/// Closing is the whole of the confirmation, and it can be, because the reader
+/// is looking straight at it. What that costs is the one answer that arrives
+/// too late to draw here — a removal git refuses. The notice stack takes it as
+/// a `worktree-failed` card, because by then the reader has been told it worked
+/// and has to be told otherwise.
 export default function WorktreeDialog({
   prompt,
   onConfirm,
   onClose,
 }: {
   prompt: WorktreePrompt | null;
-  onConfirm: (sessionId: string) => Promise<boolean>;
+  /// Starts the removal. It answers nothing, by design — see above.
+  onConfirm: (sessionId: string) => void;
   onClose: () => void;
 }) {
   // Held for the fade: Radix keeps `Content` mounted while it closes, and the
@@ -53,30 +64,8 @@ export default function WorktreeDialog({
   // state for the frame the eye is still on.
   const cost = prompt && worktreeCost(prompt.disposition);
 
-  // The dialog stays up while git works. Unlocking the tree, removing it and
-  // deleting its branch is three commands over a directory that can be large,
-  // and a dialog sitting unchanged through them reads as one the click missed.
-  //
-  // Reset on *open* rather than on close, for the reason `cost` is held:
-  // clearing it as the dialog leaves flips the button back to "Delete anyway"
-  // for the length of the fade.
-  const [deleting, setDeleting] = useState(false);
-  useEffect(() => {
-    if (prompt) setDeleting(false);
-  }, [prompt]);
-
-  // No "Deleted" state to match the notice card's. That card has to keep
-  // saying so because the reader is looking elsewhere by then; this dialog is
-  // the thing they are looking at, and it closing says it. A failure closes it
-  // too — the error banner already carries the reason.
-  const confirm = async (sessionId: string) => {
-    setDeleting(true);
-    await onConfirm(sessionId);
-    onClose();
-  };
-
   return (
-    <AlertDialog open={prompt !== null} onOpenChange={(next) => !next && !deleting && onClose()}>
+    <AlertDialog open={prompt !== null} onOpenChange={(next) => !next && onClose()}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Delete this worktree?</AlertDialogTitle>
@@ -97,28 +86,19 @@ export default function WorktreeDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={deleting}>Keep it</AlertDialogCancel>
+          <AlertDialogCancel>Keep it</AlertDialogCancel>
           {/* Red whether or not anything is lost: this deletes a directory
               either way, and a button that only turns red sometimes teaches
               the reader to read the colour instead of the sentence. What the
               cost changes is the label. */}
           <AlertDialogAction
             destructive
-            // Full strength while disabled: the spinner and the verb are the
-            // state, and dimming them as well makes the one live thing on the
-            // dialog the hardest part of it to read.
-            className="disabled:opacity-100"
-            disabled={deleting}
-            // Radix's `Action` closes the dialog itself, through
-            // `composeEventHandlers` — so `preventDefault` is what holds it up
-            // for the work. Without it the deleting state lasts one frame.
-            onClick={(e) => {
-              e.preventDefault();
-              if (prompt) void confirm(prompt.sessionId);
-            }}
+            // No `preventDefault`. Radix's `Action` closes the dialog itself
+            // through `composeEventHandlers`, which used to be the thing held
+            // up for the git work and is now exactly what is wanted.
+            onClick={() => prompt && onConfirm(prompt.sessionId)}
           >
-            {deleting && <Loader2 className="animate-spin" />}
-            {deleting ? "Deleting…" : cost ? "Delete anyway" : "Delete worktree"}
+            {cost ? "Delete anyway" : "Delete worktree"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/desktop/src/hooks/useNotices.test.ts
+++ b/apps/desktop/src/hooks/useNotices.test.ts
@@ -72,6 +72,16 @@ describe("the notice stack", () => {
     expect(keys()).toEqual(["a:pr"]);
   });
 
+  // A refused removal leaves the index entry alone, so the settled bar is still
+  // carrying the button that tries again — opening the session is what puts
+  // that cure on screen, which is the whole of what this card was asking for.
+  it("counts a refused worktree removal as answered by opening the session", () => {
+    pushNotice(notice("a", "worktree-failed"));
+
+    dismissNotice("a", ANSWERED_BY_OPENING);
+    expect(keys()).toEqual([]);
+  });
+
   // The stack's array identity is what `useSyncExternalStore` subscribes on, so
   // a dismissal that found nothing must not mint a new one — see the early
   // return in `dismissNotice`.

--- a/apps/desktop/src/hooks/useNotices.ts
+++ b/apps/desktop/src/hooks/useNotices.ts
@@ -14,10 +14,9 @@ import { useSyncExternalStore } from "react";
 ///
 /// `worktree-failed` is the correction, and it exists because the deletion no
 /// longer waits: the dialog closes and the card says "Deleted" the moment the
-/// click lands, so a git failure arrives after the reader has been told it
-/// worked. Nothing else can tell them otherwise — the error banner sits above a
-/// composer a settled session does not draw, and the row they would read it
-/// from is the one still carrying the tree.
+/// click lands, so a failure arrives after the reader has been told it worked.
+/// Nothing else can tell them otherwise — the error banner sits above a
+/// composer a settled session does not draw.
 ///
 /// `pr` is the only kind raised by something no session did. A turn ending, a
 /// question asked and a tree settled are all this app's own doing; a pull
@@ -25,7 +24,7 @@ import { useSyncExternalStore } from "react";
 /// one kind that fires whether or not the window has focus — the reader cannot
 /// have seen it happen. `worktree-failed` fires regardless of focus too, for
 /// the opposite reason: they have already seen the wrong answer. See `announce`
-/// in [useSessions](./useSessions.ts) for the split the other three make.
+/// in [useSessions](./useSessions.ts) for the split the first three make.
 export type NoticeKind = "completed" | "asking" | "worktree" | "pr" | "worktree-failed";
 
 /// How long each kind stays on screen. Read by the card to time its own progress
@@ -139,15 +138,16 @@ export function dismissNotice(sessionId: string, kind?: NoticeKind | NoticeKind[
 /// What opening a session answers: the completion is read, and a pending
 /// request is now on screen next to the transcript that explains it.
 ///
-/// `pr` is deliberately absent, because nothing *answers* it. The other three
-/// report something about the session itself, which opening it settles; a pull
+/// `pr` is deliberately absent, because nothing *answers* it. Every other kind
+/// reports something about the session itself, which opening it settles; a pull
 /// request being ready is true whether or not the reader is looking at the
 /// session, and stays true after they look away. That card runs its own
 /// countdown out and goes. See [usePrReady](./usePrReady.ts).
 ///
-/// `worktree-failed` is answered because the cure is in the session: the
-/// removal left the index entry alone, so the settled bar is still carrying the
-/// button that tries again, and opening the session is what puts it on screen.
+/// `worktree-failed` is answered because the nearest thing to a cure is in the
+/// session: the step that clears the index entry is the last one, so a cleanup
+/// that stopped anywhere left the settled bar carrying the button that runs the
+/// rest, and opening the session is what puts it on screen.
 ///
 /// Spelled out rather than written as "everything but `pr`", so a kind added
 /// later has to be placed here on purpose instead of inheriting a default that

--- a/apps/desktop/src/hooks/useNotices.ts
+++ b/apps/desktop/src/hooks/useNotices.ts
@@ -12,13 +12,21 @@ import { useSyncExternalStore } from "react";
 /// the worktree", which is why the card offers no way to say so: the safe
 /// choice is what doing nothing already does.
 ///
+/// `worktree-failed` is the correction, and it exists because the deletion no
+/// longer waits: the dialog closes and the card says "Deleted" the moment the
+/// click lands, so a git failure arrives after the reader has been told it
+/// worked. Nothing else can tell them otherwise — the error banner sits above a
+/// composer a settled session does not draw, and the row they would read it
+/// from is the one still carrying the tree.
+///
 /// `pr` is the only kind raised by something no session did. A turn ending, a
 /// question asked and a tree settled are all this app's own doing; a pull
 /// request turning green is CI reporting somewhere else, which is why it is the
 /// one kind that fires whether or not the window has focus — the reader cannot
-/// have seen it happen. See `announce` in [useSessions](./useSessions.ts) for
-/// the split the other three make.
-export type NoticeKind = "completed" | "asking" | "worktree" | "pr";
+/// have seen it happen. `worktree-failed` fires regardless of focus too, for
+/// the opposite reason: they have already seen the wrong answer. See `announce`
+/// in [useSessions](./useSessions.ts) for the split the other three make.
+export type NoticeKind = "completed" | "asking" | "worktree" | "pr" | "worktree-failed";
 
 /// How long each kind stays on screen. Read by the card to time its own progress
 /// bar, which is also what dismisses it — see [NoticeStack](../components/NoticeStack.tsx).
@@ -33,6 +41,10 @@ export const NOTICE_TTL_MS: Record<NoticeKind, number> = {
   // News that will keep, like a finished turn: the pull request stays ready,
   // and the card is a shortcut to it rather than the only way to find it.
   pr: 10_000,
+  // The long window for `worktree`'s reason once more: this one carries git's
+  // own sentence, which is the only thing naming why the removal was refused,
+  // and a reason nobody had time to read is a reason nobody was given.
+  "worktree-failed": 15_000,
 };
 
 /// One in-app notice — something happened in a session the reader was not
@@ -60,14 +72,15 @@ export type Notice = {
   /// know, and a card whose first line was a task title would make them read to
   /// the end to find out what it wanted.
   label: string;
-  /// A second line, which only the `worktree` card carries. The others are a
-  /// verb the reader acts on immediately; this one is a decision, and the facts
-  /// it turns on have to be on the card rather than a click away.
+  /// A second line, which only the two worktree cards carry. The others are a
+  /// verb the reader acts on immediately; one of these is a decision and the
+  /// other is a refusal, and the facts each turns on have to be on the card
+  /// rather than a click away.
   detail?: string;
   /// What the notice is about, drawn muted beside the label rather than under
   /// it. Two lines of heading for a card this size read as two separate things
   /// to deal with; on one line the eye takes the action first and the subject
-  /// as the qualifier it is. Only the `worktree` card has one.
+  /// as the qualifier it is. Only the two worktree cards have one.
   subject?: string;
 };
 
@@ -132,10 +145,19 @@ export function dismissNotice(sessionId: string, kind?: NoticeKind | NoticeKind[
 /// session, and stays true after they look away. That card runs its own
 /// countdown out and goes. See [usePrReady](./usePrReady.ts).
 ///
+/// `worktree-failed` is answered because the cure is in the session: the
+/// removal left the index entry alone, so the settled bar is still carrying the
+/// button that tries again, and opening the session is what puts it on screen.
+///
 /// Spelled out rather than written as "everything but `pr`", so a kind added
 /// later has to be placed here on purpose instead of inheriting a default that
 /// may not suit it.
-export const ANSWERED_BY_OPENING: NoticeKind[] = ["completed", "asking", "worktree"];
+export const ANSWERED_BY_OPENING: NoticeKind[] = [
+  "completed",
+  "asking",
+  "worktree",
+  "worktree-failed",
+];
 
 function subscribe(listener: () => void) {
   listeners.add(listener);

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -58,10 +58,11 @@ export type StreamingBlock = {
     callId: string | null,
 }
 
-/// Sessions whose worktree removal is out. Module-level rather than a ref
-/// because it guards a write to disk, not a render: nothing draws from it, and
-/// the one thing it has to survive is the composer remounting under a session
-/// switch while git is still working.
+/// Sessions whose worktree removal has been asked for and not refused.
+///
+/// Module-level rather than a ref because it guards a write to disk, not a
+/// render: nothing draws from it, and the one thing it has to survive is the
+/// composer remounting under a session switch while git is still working.
 const removingWorktrees = new Set<string>();
 
 export function useSessions() {
@@ -742,6 +743,13 @@ const unlinkIssue = async (sessionId: string, key: string) => {
 // The half of the removal that can only run once git has answered: the
 // relocated entry, applied to both copies of the session.
 const applyWorktreeRemoval = (sessionId: string, updated: SessionIndexItem) => {
+  // A retry that worked retires the card that reported the first attempt.
+  // Reachable without going through it: the failure leaves the settled bar's
+  // own button on screen, so the reader can press that instead of View, and
+  // the card would sit there for the rest of its fifteen seconds still saying
+  // the cleanup failed.
+  dismissNotice(sessionId, "worktree-failed");
+
   setSessionIndexItems((prev) =>
     prev.map((i) => (i.sessionId === sessionId ? updated : i)),
   );
@@ -777,17 +785,25 @@ const applyWorktreeRemoval = (sessionId: string, updated: SessionIndexItem) => {
 // session draws the settled bar instead — so the one state this can be reached
 // from is the one state the banner is not on screen in.
 //
-// `reason` is git's own sentence and the whole of the detail line. It is the
-// only thing that names the cause — a tree another session still holds a lock
-// on, a removal git refused — and the card's own button is the cure, since the
-// entry was left alone and the settled bar is still offering to try again.
+// **It says the cleanup failed, not that the tree is still there**, and the
+// difference is the whole of the copy. The removal is a run of steps and any of
+// them can be the one that answers: git refusing leaves the directory, but the
+// index write is *last*, so a failure there is a tree already deleted and a
+// session that was never moved off it. Naming the outcome would mean naming
+// which step, which the backend does not report; naming the operation is true
+// of every one of them.
+//
+// `reason` is the backend's own sentence and the whole of the detail line — the
+// only thing that says which step this was. The button is the nearest thing to
+// a cure: the entry is only cleared by that last step, so the settled bar is
+// still carrying the control that runs the rest, whichever end it stopped at.
 const reportWorktreeFailure = (sessionId: string, title: string, reason: string) => {
   pushNotice({
     sessionId,
     kind: "worktree-failed",
     // The news, not an action: there is nothing here for the reader to decide,
     // and a card that opened with a verb would be asking them to.
-    label: "Worktree not deleted",
+    label: "Worktree cleanup failed",
     subject: title,
     detail: reason,
   });
@@ -808,14 +824,29 @@ const reportWorktreeFailure = (sessionId: string, title: string, reason: string)
 // card goes to "Deleted". So this returns as soon as the work is under way,
 // and the two things that can only be known later — the relocated row, and a
 // refusal — arrive on their own.
-const removeWorktree = (sessionId: string) => {
+//
+// `origin` is which of those two callers it was, and all it decides is whether
+// a failure is reported. `"asked"` means the reader pressed something and was
+// told it worked, so a failure has to be taken back. `"tidy"` is the pass over
+// a worktree that had already gone — nothing was drawn, nothing was promised,
+// and the session was pointing at a missing directory before this ran, so a
+// card there would raise a state the reader has never seen and cannot act on.
+const removeWorktree = (sessionId: string, origin: "asked" | "tidy" = "asked") => {
   // A second press cannot be allowed through, and the window this opened is
   // why. The row keeps its "Delete worktree" button until the write lands, so
   // the same tree can be asked for twice — and the second call, arriving after
   // the first relocated the entry, is refused with "that session is not running
-  // in a worktree". That is a deletion that worked, reported to the reader as
+  // in a worktree". That is a cleanup that worked, reported to the reader as
   // one that failed, which is the failure `merge_pr` re-reads the pull request
   // to avoid.
+  //
+  // **Held for good on success, not until the promise settles.** Clearing it
+  // there looks equivalent and is a frame early: React schedules the re-render
+  // that retires the button, so the button outlives the guard by however long
+  // that takes to commit — which is the exact window above, still open. Nothing
+  // is leaked by keeping it, because `worktree_name` is written at creation and
+  // at fork and cleared in one place, so a session that has been relocated can
+  // never want this again.
   if (removingWorktrees.has(sessionId)) return;
   removingWorktrees.add(sessionId);
 
@@ -825,14 +856,19 @@ const removeWorktree = (sessionId: string) => {
 
   void invoke<SessionIndexItem>("remove_session_worktree", { sessionId })
     // Two callbacks rather than `.then(…).catch(…)`, so the failure card can
-    // only ever report git refusing. Chained, a throw out of the write above
-    // would land in the same handler and be described as a removal that did
-    // not happen, when it did.
+    // only ever report the backend refusing. Chained, a throw out of the write
+    // above would land in the same handler and be described as a cleanup that
+    // failed, when it was the one thing here that succeeded.
     .then(
       (updated) => applyWorktreeRemoval(sessionId, updated),
-      (e) => reportWorktreeFailure(sessionId, title, String(e)),
-    )
-    .finally(() => removingWorktrees.delete(sessionId));
+      (e) => {
+        // Cleared only here. A failure is the one outcome that wants pressing
+        // again, and every other path leaves the entry claimed for good — see
+        // above for why that is the right length to hold it.
+        removingWorktrees.delete(sessionId);
+        if (origin === "asked") reportWorktreeFailure(sessionId, title, String(e));
+      },
+    );
 };
 
 // Copies a session onto a new id so it can be carried on in two directions at

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -825,12 +825,14 @@ const reportWorktreeFailure = (sessionId: string, title: string, reason: string)
 // and the two things that can only be known later — the relocated row, and a
 // refusal — arrive on their own.
 //
-// `origin` is which of those two callers it was, and all it decides is whether
-// a failure is reported. `"asked"` means the reader pressed something and was
-// told it worked, so a failure has to be taken back. `"tidy"` is the pass over
-// a worktree that had already gone — nothing was drawn, nothing was promised,
-// and the session was pointing at a missing directory before this ran, so a
-// card there would raise a state the reader has never seen and cannot act on.
+// `origin` is who asked, and all it decides is whether a failure is reported.
+// `"asked"` means the reader pressed something — a button, a card, or one that
+// skipped its confirm because the tree had already gone — so they are owed the
+// answer, whether that is the close they saw or a card taking it back.
+// `"tidy"` is the app's own pass on settle over a worktree that was not there:
+// nothing was drawn and nothing was promised, and the session was pointing at a
+// missing directory before this ran, so a card would raise a state the reader
+// has never seen and cannot act on.
 const removeWorktree = (sessionId: string, origin: "asked" | "tidy" = "asked") => {
   // A second press cannot be allowed through, and the window this opened is
   // why. The row keeps its "Delete worktree" button until the write lands, so

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -58,6 +58,12 @@ export type StreamingBlock = {
     callId: string | null,
 }
 
+/// Sessions whose worktree removal is out. Module-level rather than a ref
+/// because it guards a write to disk, not a render: nothing draws from it, and
+/// the one thing it has to survive is the composer remounting under a session
+/// switch while git is still working.
+const removingWorktrees = new Set<string>();
+
 export function useSessions() {
 
     // The sticky defaults. Live state below seeds from these and writes back on
@@ -733,23 +739,9 @@ const unlinkIssue = async (sessionId: string, key: string) => {
   }
 };
 
-// Deletes the worktree a session was running in, keeping the session. The
-// backend kills the child, removes the tree and its branch, and relocates the
-// index entry to the project root; the row is replaced from what it returns,
-// for the reason `setSessionFlags` above gives.
-//
-// The relocated item no longer carries a `worktreeName`, which is what retires
-// every control that offers this — the button disappears because the thing it
-// acted on is gone, rather than because anything tracks that it was pressed.
-const removeWorktree = async (sessionId: string): Promise<boolean> => {
-  let updated: SessionIndexItem;
-  try {
-    updated = await invoke<SessionIndexItem>("remove_session_worktree", { sessionId });
-  } catch (e) {
-    setError(String(e));
-    return false;
-  }
-
+// The half of the removal that can only run once git has answered: the
+// relocated entry, applied to both copies of the session.
+const applyWorktreeRemoval = (sessionId: string, updated: SessionIndexItem) => {
   setSessionIndexItems((prev) =>
     prev.map((i) => (i.sessionId === sessionId ? updated : i)),
   );
@@ -776,11 +768,71 @@ const removeWorktree = async (sessionId: string): Promise<boolean> => {
   // A killed child leaves no `session_status`, so the sidebar would sit on
   // whatever it last saw — `in_progress` for a session that was mid-turn.
   setStatusBySession((prev) => ({ ...prev, [sessionId]: "idle" }));
+};
 
-  // Reported so the notice card can say "Deleted" and mean it. A failure has
-  // already reached the reader through the error banner, and the card retires
-  // itself rather than claiming something that didn't happen.
-  return true;
+// Takes back the "Deleted" the reader has already been shown.
+//
+// A card rather than the error banner, which is where this used to go and can
+// no longer carry it: that banner is drawn above the composer, and a settled
+// session draws the settled bar instead — so the one state this can be reached
+// from is the one state the banner is not on screen in.
+//
+// `reason` is git's own sentence and the whole of the detail line. It is the
+// only thing that names the cause — a tree another session still holds a lock
+// on, a removal git refused — and the card's own button is the cure, since the
+// entry was left alone and the settled bar is still offering to try again.
+const reportWorktreeFailure = (sessionId: string, title: string, reason: string) => {
+  pushNotice({
+    sessionId,
+    kind: "worktree-failed",
+    // The news, not an action: there is nothing here for the reader to decide,
+    // and a card that opened with a verb would be asking them to.
+    label: "Worktree not deleted",
+    subject: title,
+    detail: reason,
+  });
+};
+
+// Deletes the worktree a session was running in, keeping the session. The
+// backend kills the child, removes the tree and its branch, and relocates the
+// index entry to the project root; the row is replaced from what it returns,
+// for the reason `setSessionFlags` above gives.
+//
+// The relocated item no longer carries a `worktreeName`, which is what retires
+// every control that offers this — the button disappears because the thing it
+// acted on is gone, rather than because anything tracks that it was pressed.
+//
+// **Started, not awaited.** Unlocking the tree, removing it and deleting its
+// branch is three git commands over a directory that can be large, and both
+// callers have something better to say than "wait": the dialog closes and the
+// card goes to "Deleted". So this returns as soon as the work is under way,
+// and the two things that can only be known later — the relocated row, and a
+// refusal — arrive on their own.
+const removeWorktree = (sessionId: string) => {
+  // A second press cannot be allowed through, and the window this opened is
+  // why. The row keeps its "Delete worktree" button until the write lands, so
+  // the same tree can be asked for twice — and the second call, arriving after
+  // the first relocated the entry, is refused with "that session is not running
+  // in a worktree". That is a deletion that worked, reported to the reader as
+  // one that failed, which is the failure `merge_pr` re-reads the pull request
+  // to avoid.
+  if (removingWorktrees.has(sessionId)) return;
+  removingWorktrees.add(sessionId);
+
+  // Read now rather than on the way out: by the time a refusal lands the row
+  // may have moved, and the title is what says which session the card is about.
+  const title = sessionIndexItems.find((i) => i.sessionId === sessionId)?.title ?? "";
+
+  void invoke<SessionIndexItem>("remove_session_worktree", { sessionId })
+    // Two callbacks rather than `.then(…).catch(…)`, so the failure card can
+    // only ever report git refusing. Chained, a throw out of the write above
+    // would land in the same handler and be described as a removal that did
+    // not happen, when it did.
+    .then(
+      (updated) => applyWorktreeRemoval(sessionId, updated),
+      (e) => reportWorktreeFailure(sessionId, title, String(e)),
+    )
+    .finally(() => removingWorktrees.delete(sessionId));
 };
 
 // Copies a session onto a new id so it can be carried on in two directions at


### PR DESCRIPTION
## TLDR for human

- The delete-worktree dialog no longer waits on git — it closes on the press, and the notice card goes straight to "Deleted". Both used to sit through three git commands over a directory that can be large.
- A failure now arrives after the reader has been told it worked, so a new `worktree-failed` notice card takes it back: the backend's own sentence as the detail, and a **View** button landing on the settled bar, where the button that runs the rest still is.
- A second press on the same tree is refused, so a cleanup that worked can't be reported as one that failed.
- Failures inside session *delete* stay quiet, deliberately — reasoning below.
- Reviewed by a Codex session; five findings, four fixed and one answered. See the last two commits.

---

Fixes DRA-117

### What changed

`removeWorktree` starts the removal and returns. The relocated index entry and any failure arrive on their own:

- **`WorktreeDialog`** loses its `deleting` state, spinner, disabled pass and `preventDefault` — Radix's own `Action` close is now what is wanted. Closing is the confirmation, and it can be: the reader is looking straight at it. The comment explaining the old wait is rewritten to explain the trade instead.
- **`NoticeCard`** loses its `working` phase for the same reason. Its existing **Deleted** state is the success confirmation, drawn on the press.

### The failure card

`worktree-failed`, a new `NoticeKind`. Raised whatever the window is doing — like `pr`, for the opposite reason: the reader has already seen the wrong answer.

**It names the operation, not the outcome:** "Worktree cleanup failed", not "not deleted". The removal is a run of steps and any of them can be the one that answers — git refusing leaves the directory, but the index write is *last*, so a failure there is a tree already gone and a session that was simply never moved off it. Which step stopped isn't reported, so copy asserting the state of the disk would be wrong about half the time.

The button is **View**, and it leads somewhere real for the same reason: that last step is the only writer that clears `worktree_name`, so a cleanup stopping anywhere leaves the settled bar carrying its Delete worktree button. That's also why it's in `ANSWERED_BY_OPENING`.

**A card only where the reader asked.** Settle's own pass over an already-missing tree reports nothing — nothing was drawn and nothing promised. A press that skipped its confirm for the same reason still reports, because the reader watched that dialog close.

### Session delete: left quiet

Checked, and deliberately not covered. That card would be keyed to a session about to stop existing, so its subject is a row that's gone and its button leads nowhere. Saying it properly means naming the orphaned path with no session behind it — a channel of its own. The reasoning sits next to the best-effort call in `session.rs`. The reviewer agreed this shouldn't block the issue.

### Review

A Codex session reviewed `dd68e5b3` and raised five things. Fixed in `830dce1b` and `9f43b6c6`:

1. The card overclaimed — it promised the tree survived, which the backend can't. Now named by operation (above).
2. A retry that worked left the failure card up for the rest of its 15s. It's dismissed in `applyWorktreeRemoval`, since the reader can press the settled bar's button rather than View.
3. The in-flight guard cleared when the promise settled, which is a frame early — React *schedules* the re-render that retires the button, so the window it exists to close was still open. Held for good on success now; `worktree_name` is cleared in exactly one place, so a relocated session can never want another removal.
4. The missing-directory branch reported nothing whichever route reached it, so pressing the button on an already-gone tree was silent on failure.
5. Stale comment wording in `session.rs` and `useNotices.ts`.

One suggestion declined: renaming the card's "Deleted" to "Deletion started". The dialog route says nothing at all on close, so hedging the word would make the two routes disagree about the same press — and the hedge is the "still going" this issue asked to remove. Took the alternative instead: the comment calls it optimistic outright rather than claiming it's true.

### Known cost

The failure card is in-app only, so a reader who clicks Delete and switches to another app can miss it inside its 15s. Nothing is lost — the settled bar still offers the removal — but they aren't told twice. Same gap `usePrReady`'s card has.

### Verification

`tsc --noEmit`, `pnpm test` (405 passing, one added for the new kind's place in `ANSWERED_BY_OPENING`), `cargo check`. The Rust change is comment-only. Nobody has driven the running app through the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
