### PR TITLE
Drop the composer's focus border

### DIFF
--- a/apps/desktop/src/components/ChatInput.tsx
+++ b/apps/desktop/src/components/ChatInput.tsx
@@ -676,13 +676,8 @@ export default function ChatInput({
               // shadow: a shadow under a dark card falls on something already
               // darker than itself, and the card is glass there, so being lighter
               // than the page does not draw the box on its own.
-              //
-              // The focus hairline is not part of that trade and stays in both:
-              // a shadow can say "above" and cannot say "focused". The resting
-              // border keeps its width in light and spends only its colour, so
-              // focus swaps a value and reflows nothing.
               !isNewTask &&
-                "border border-edge-surface bg-composer shadow-(--shadow-surface) backdrop-blur-xl focus-within:border-hairline-strong",
+                "border border-edge-surface bg-composer shadow-(--shadow-surface) backdrop-blur-xl",
             )}
           >
             {/* Covers the card rather than replacing anything, so the text and


### PR DESCRIPTION
The composer card gained a `focus-within` hairline on top of its resting border. Removed, along with the comment arguing for it — resting border and shadow are unchanged, focus now draws nothing extra.