### PR TITLE
Chat markdown tables scroll instead of squeezing, with a hover copy control

### DIFF
--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -726,6 +726,25 @@
   opacity: 1;
 }
 
+/* MarkdownTable's scroll box, horizontal-only. `overflow-y: auto` here feeds
+   itself under classic scrollbars: the horizontal bar eats interior height,
+   the table no longer fits, and a vertical bar appears for exactly one
+   scrollbar's worth of scroll. The box has no max-height, so there is never
+   anything real to scroll vertically — hidden costs nothing and ends the
+   loop. Same overlay treatment as the sidebar: thin, invisible until the
+   cursor is over the table. */
+.md-table-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.md-table-scroll:hover {
+  scrollbar-color: color-mix(in oklab, var(--color-muted-foreground) 35%, transparent)
+    transparent;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/apps/desktop/src/components/chat/Markdown.tsx
+++ b/apps/desktop/src/components/chat/Markdown.tsx
@@ -3,6 +3,7 @@ import { Streamdown, type Components, type LinkSafetyConfig, type ThemeInput } f
 
 import FileLink from "@/components/chat/FileLink";
 import LinkDialog from "@/components/chat/LinkDialog";
+import { MarkdownTable } from "@/components/chat/MarkdownTable";
 import { useCodeTheme } from "@/hooks/useCodeTheme";
 import { createSharedCodePlugin } from "@/lib/codePlugin";
 import type { CodeThemePair } from "@/lib/codeTheme";
@@ -50,8 +51,11 @@ function codePlugin(pair: CodeThemePair) {
   return plugin;
 }
 
-// Copy is the only control worth keeping. Table actions and code download are
-// off entirely rather than hidden with CSS, so they can't be tabbed to either.
+// Copy is the only control worth keeping, and code's is the only one of
+// Streamdown's used: the table's copy control is ours ([MarkdownTable]), whose
+// format menu opens on hover where Streamdown's needs a click. Download and
+// fullscreen are off entirely rather than hidden with CSS, so they can't be
+// tabbed to either.
 const CONTROLS = { table: false, code: { copy: true, download: false } };
 
 // Streamdown's own confirm is kept on — a link in agent output is worth a
@@ -80,10 +84,14 @@ function MarkdownImpl({
   );
   const plugins = useMemo(() => ({ code: codePlugin(pair) }), [pair]);
 
-  // The caller's own overrides win, so a surface needing its own `span` is not
-  // quietly handed this one instead.
+  // The caller's own overrides win, so a surface needing its own `span` or
+  // `table` is not quietly handed this one instead.
   const overrides = useMemo(
-    () => (linkFilePaths ? { span: FilePathSpan, ...components } : components),
+    () => ({
+      table: MarkdownTable,
+      ...(linkFilePaths ? { span: FilePathSpan } : null),
+      ...components,
+    }),
     [linkFilePaths, components],
   );
 
@@ -147,30 +155,26 @@ function MarkdownImpl({
         // The copy control's reveal-on-hover lives in App.css too — it keys off
         // the code block itself, not this whole message.
 
-        // Table: no enclosing box. The outline lives on an unnamed div between
-        // the wrapper and the table, so all three layers have to be cleared —
-        // including that div's own `bg-background`, which cost nothing to leave
-        // while the page was that exact colour and became a slab behind every
-        // table the moment the page was glass.
-        "[&_[data-streamdown=table-wrapper]]:border-0 [&_[data-streamdown=table-wrapper]]:bg-transparent [&_[data-streamdown=table-wrapper]]:p-0",
-        "[&_[data-streamdown=table-wrapper]]:rounded-none",
-        "[&_[data-streamdown=table-wrapper]>div]:rounded-none [&_[data-streamdown=table-wrapper]>div]:border-0",
-        "[&_[data-streamdown=table-wrapper]>div]:bg-transparent",
+        // Table: no enclosing box. The wrapper and scroll box are ours
+        // ([MarkdownTable]) and carry no chrome of their own; only what
+        // Streamdown still renders inside them needs clearing — the header's
+        // fill, and cells with no structure of their own, so rows get the
+        // rules instead.
         "[&_[data-streamdown=table-header]]:bg-transparent",
-        "[&_table]:rounded-none [&_table]:border-0",
-        // Cells carry no rules of their own, so removing the outline would leave
-        // the table with no structure at all — put it back on the rows.
         "[&_th]:border-b [&_th]:border-border/60",
         "[&_tbody_tr]:border-b [&_tbody_tr]:border-border/30",
-        // A cell that cannot break sets the table's width: one file path in a
-        // bot's summary table pushed every other column out of the PR panel and
-        // left the reader scrolling sideways to read a sentence. Anywhere rather
-        // than break-word, because only `anywhere` shrinks the cell's min-content
-        // width, which is what the auto layout measures. The wrapper keeps its
-        // own scroll for a table that is genuinely wide.
-        // The header cell needs its `whitespace-nowrap` lifted first, or the
-        // wrap rule is dead on it — nowrap outranks overflow-wrap.
-        "[&_th]:whitespace-normal [&_th]:wrap-anywhere [&_td]:wrap-anywhere",
+        // Each column is still capped, or one long-prose cell runs its whole
+        // paragraph out on a single line and the reader scrolls a paragraph's
+        // width to finish a sentence. The cap rides the block
+        // `rehypeTableCells` puts inside every cell (see markdownPlugins for
+        // why the `td` itself cannot carry it), spelled here so all table
+        // styling reads in one place. Break-word rather than anywhere: only a
+        // word wider than the whole cap breaks — a file path in a cell — so a
+        // column can never collapse below its longest ordinary word.
+        "[&_.dray-table-cell]:max-w-md [&_.dray-table-cell]:wrap-break-word",
+        // The header cell's `whitespace-nowrap` has to lift, or a capped
+        // header column overflows instead of wrapping.
+        "[&_th]:whitespace-normal",
         // With cells now several lines tall, a middle-aligned short cell floats
         // opposite the middle of a paragraph beside it.
         "[&_td]:align-top",

--- a/apps/desktop/src/components/chat/MarkdownTable.tsx
+++ b/apps/desktop/src/components/chat/MarkdownTable.tsx
@@ -1,0 +1,98 @@
+import { Check, Copy } from "lucide-react";
+import { memo, useRef, useState, type ComponentProps } from "react";
+
+import { Button } from "@/components/ui/button";
+import { serializeTable, type TableFormat } from "@/lib/markdownTable";
+
+/// The copy control's formats, in menu order. Markdown first because it is
+/// also what the trigger itself copies.
+const FORMATS: { format: TableFormat; label: string }[] = [
+  { format: "markdown", label: "Markdown" },
+  { format: "csv", label: "CSV" },
+  { format: "tsv", label: "TSV" },
+];
+
+/// Reads the rendered table rather than re-parsing markdown — the DOM is the
+/// one place the rows already sit resolved, whatever plugins rewrote them.
+function cells(table: HTMLTableElement): string[][] {
+  return Array.from(table.rows, (row) =>
+    Array.from(row.cells, (cell) => (cell.textContent ?? "").trim().replace(/\s+/g, " ")),
+  );
+}
+
+/// The table renderer, replacing Streamdown's wrapper whole. Ours for two
+/// reasons: the scroll box is horizontal-only with its width story in one
+/// place, and the copy control opens its format menu on hover — Streamdown's
+/// holds the menu behind React state only a click reaches.
+function MarkdownTableImpl({ children, ...props }: ComponentProps<"table"> & { node?: unknown }) {
+  const table = useRef<HTMLTableElement>(null);
+  const [copied, setCopied] = useState<TableFormat | null>(null);
+  const timer = useRef(0);
+  const { node: _node, ...rest } = props;
+
+  const copy = async (format: TableFormat) => {
+    if (!table.current) return;
+    // A failed write shows no check mark and nothing else — a transcript row
+    // has nowhere to put an error sentence.
+    try {
+      await navigator.clipboard.writeText(serializeTable(cells(table.current), format));
+      setCopied(format);
+      window.clearTimeout(timer.current);
+      timer.current = window.setTimeout(() => setCopied(null), 2000);
+    } catch {}
+  };
+
+  return (
+    <div className="group/table relative my-4">
+      {/* `w-max` lets a wide table keep its measured width, with the excess
+          scrolling here rather than squeezing the columns; `min-w-full` keeps
+          a narrow one filling the line. Cell width bounds ride the blocks
+          `rehypeTableCells` puts inside every cell, styled in Markdown. */}
+      <div className="md-table-scroll">
+        <table ref={table} className="w-max min-w-full border-collapse" {...rest}>
+          {children}
+        </table>
+      </div>
+      <div className="absolute top-0 right-0 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover/table:opacity-100">
+        <div className="group/copy relative">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Copy table"
+            onClick={() => void copy("markdown")}
+          >
+            {copied ? <Check /> : <Copy />}
+          </Button>
+          {/* Hover opens it — the trigger already costs a hover to appear, and
+              a click on top of that to see the formats made three gestures of
+              one copy. Padding, not margin, bridges the gap to the trigger so
+              the hover never breaks crossing it. */}
+          {/* The surface matches DropdownMenuContent: `--popover` is glass, so
+              `backdrop-blur-xl` is what keeps it readable over the table's
+              text, and the edge is a ring like every other menu's. */}
+          <div className="absolute top-full right-0 z-10 hidden pt-1 group-focus-within/copy:block group-hover/copy:block">
+            <div className="min-w-36 rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 backdrop-blur-xl">
+              {FORMATS.map(({ format, label }) => (
+                <button
+                  key={format}
+                  type="button"
+                  className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                  onClick={() => void copy(format)}
+                >
+                  {copied === format ? (
+                    <Check className="size-3.5" />
+                  ) : (
+                    <Copy className="size-3.5 opacity-60" />
+                  )}
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const MarkdownTable = memo(MarkdownTableImpl);

--- a/apps/desktop/src/lib/markdownPlugins.test.ts
+++ b/apps/desktop/src/lib/markdownPlugins.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { FILE_LINK_CLASS, FILE_PATH_CLASS, REHYPE_PLUGINS, walk } from "./markdownPlugins";
+import {
+  FILE_LINK_CLASS,
+  FILE_PATH_CLASS,
+  REHYPE_PLUGINS,
+  TABLE_CELL_CLASS,
+  walk,
+  wrapCells,
+} from "./markdownPlugins";
 
 type Hast = {
   type: string;
@@ -243,5 +250,47 @@ describe("rehypeFilePaths", () => {
     walk(tree);
 
     expect(tree.children![0].children).toBe(before);
+  });
+});
+
+describe("rehypeTableCells", () => {
+  function cell(tagName: "th" | "td", value: string): Hast {
+    return { type: "element", tagName, properties: {}, children: [{ type: "text", value }] };
+  }
+
+  it("wraps each cell's content in one block carrying the width hook", () => {
+    const row: Hast = {
+      type: "element",
+      tagName: "tr",
+      properties: {},
+      children: [cell("th", "Theme"), cell("td", "Rosé Pine")],
+    };
+    const tree: Hast = {
+      type: "root",
+      children: [{ type: "element", tagName: "table", properties: {}, children: [row] }],
+    };
+    wrapCells(tree);
+
+    for (const c of row.children!) {
+      expect(c.children).toHaveLength(1);
+      expect(c.children![0]).toMatchObject({
+        tagName: "div",
+        properties: { className: [TABLE_CELL_CLASS] },
+      });
+    }
+    expect(text(row.children![1])).toBe("Rosé Pine");
+  });
+
+  it("touches nothing outside a cell", () => {
+    const prose: Hast = {
+      type: "element",
+      tagName: "p",
+      properties: {},
+      children: [{ type: "text", value: "no table here" }],
+    };
+    const tree: Hast = { type: "root", children: [prose] };
+    wrapCells(tree);
+
+    expect(prose.children).toEqual([{ type: "text", value: "no table here" }]);
   });
 });

--- a/apps/desktop/src/lib/markdownPlugins.ts
+++ b/apps/desktop/src/lib/markdownPlugins.ts
@@ -26,11 +26,48 @@ const HARDEN = [
   { ...hardenDefaults, linkBlockPolicy: "text-only", imageBlockPolicy: "text-only" },
 ];
 
+/// The block `rehypeTableCells` puts inside every table cell, and the hook
+/// `Markdown` hangs the cell's width cap on. The name is spelled again in
+/// `Markdown`'s class list — Tailwind only reads literal class strings, so the
+/// two cannot share the constant.
+export const TABLE_CELL_CLASS = "dray-table-cell";
+
+/// Wraps each table cell's content in one block, so a width cap has an element
+/// it actually works on. A wide table is meant to scroll in its wrapper, not
+/// squeeze — but with no cap at all, one long-prose cell runs its whole
+/// paragraph out on a single line. The cap cannot sit on the cell: min/max
+/// width on a `td` is undefined in auto table layout and WebKit ignores it,
+/// where a block child is ordinary block layout, whose `max-width` clamps the
+/// column the cell measures out to.
+function rehypeTableCells() {
+  return (tree: HastNode) => wrapCells(tree);
+}
+
+export function wrapCells(node: HastNode) {
+  if (node.tagName === "th" || node.tagName === "td") {
+    node.children = [
+      {
+        type: "element",
+        tagName: "div",
+        properties: { className: [TABLE_CELL_CLASS] },
+        children: node.children ?? [],
+      },
+    ];
+    return;
+  }
+  for (const child of node.children ?? []) {
+    if (child.type === "element") wrapCells(child);
+  }
+}
+
 /// Streamdown's own rehype pipeline, with harden told to block a link by
-/// unwrapping it rather than by annotating the text around it.
+/// unwrapping it rather than by annotating the text around it, and every table
+/// cell given the block its width cap rides on. Cell wrapping sits after
+/// sanitize, which would otherwise strip the block it adds; harden stays last.
 export const REHYPE_PLUGINS = [
   defaultRehypePlugins.raw,
   defaultRehypePlugins.sanitize,
+  rehypeTableCells,
   HARDEN,
 ] as StreamdownProps["rehypePlugins"];
 
@@ -184,6 +221,7 @@ export function walk(node: HastNode) {
 export const REHYPE_PLUGINS_WITH_FILE_PATHS = [
   defaultRehypePlugins.raw,
   defaultRehypePlugins.sanitize,
+  rehypeTableCells,
   rehypeFilePaths,
   HARDEN,
 ] as StreamdownProps["rehypePlugins"];

--- a/apps/desktop/src/lib/markdownTable.test.ts
+++ b/apps/desktop/src/lib/markdownTable.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeTable } from "./markdownTable";
+
+const ROWS = [
+  ["Theme", "Note"],
+  ["Rosé Pine", "Muted, low-chroma"],
+];
+
+describe("serializeTable", () => {
+  it("writes markdown with a delimiter row", () => {
+    expect(serializeTable(ROWS, "markdown")).toBe(
+      "| Theme | Note |\n| --- | --- |\n| Rosé Pine | Muted, low-chroma |",
+    );
+  });
+
+  it("escapes a pipe in a markdown cell", () => {
+    expect(serializeTable([["a|b"]], "markdown")).toBe("| a\\|b |\n| --- |");
+  });
+
+  it("quotes a csv field holding the delimiter, and doubles quotes", () => {
+    expect(serializeTable([["a,b", 'say "hi"', "plain"]], "csv")).toBe(
+      '"a,b","say ""hi""",plain',
+    );
+  });
+
+  it("joins tsv with tabs", () => {
+    expect(serializeTable(ROWS, "tsv")).toBe("Theme\tNote\nRosé Pine\tMuted, low-chroma");
+  });
+
+  it("answers empty for no rows", () => {
+    expect(serializeTable([], "markdown")).toBe("");
+  });
+});

--- a/apps/desktop/src/lib/markdownTable.ts
+++ b/apps/desktop/src/lib/markdownTable.ts
@@ -1,0 +1,27 @@
+/// Serializes a rendered table's rows for the copy control in
+/// [MarkdownTable](../components/chat/MarkdownTable.tsx). Pure and here rather
+/// than in the component because a wrong escape is invisible on screen — it
+/// only shows when the paste lands somewhere that parses it.
+
+export type TableFormat = "markdown" | "csv" | "tsv";
+
+function toMarkdown(rows: string[][]): string {
+  const line = (r: string[]) => `| ${r.map((c) => c.replaceAll("|", "\\|")).join(" | ")} |`;
+  const [head, ...body] = rows;
+  return [line(head), line(head.map(() => "---")), ...body.map(line)].join("\n");
+}
+
+/// A field is quoted only when it holds its own format's delimiter, a quote
+/// or a newline — a comma is ordinary text in TSV and quoting it there wraps
+/// most prose cells for nothing.
+function toDelimited(rows: string[][], sep: string): string {
+  const needsQuote = new RegExp(`["\n${sep}]`);
+  const field = (c: string) => (needsQuote.test(c) ? `"${c.replaceAll('"', '""')}"` : c);
+  return rows.map((r) => r.map(field).join(sep)).join("\n");
+}
+
+export function serializeTable(rows: string[][], format: TableFormat): string {
+  if (rows.length === 0) return "";
+  if (format === "markdown") return toMarkdown(rows);
+  return toDelimited(rows, format === "csv" ? "," : "\t");
+}


### PR DESCRIPTION
Fixes DRA-120

## What

- A markdown table wider than the transcript column keeps its measured width and scrolls horizontally in its wrapper, instead of `wrap-anywhere` collapsing every column to a letter a line.
- Columns are capped (~28rem) so a long prose cell wraps at word boundaries; only a token wider than the whole cap (a long path) breaks mid-word. The cap rides a block `rehypeTableCells` puts inside every cell — min/max-width on a `td` is undefined in auto table layout and WebKit ignores it.
- The scroll box is horizontal-only with a thin overlay scrollbar; `overflow-y: auto` fed a phantom vertical scrollbar under classic scrollbars.
- Hovering a table reveals a copy control; hovering it auto-opens the format menu (Markdown / CSV / TSV), and clicking the trigger copies Markdown outright. Streamdown's own control needs a click to open its menu, which is why the table wrapper is now ours (`MarkdownTable`).

## Verified

- Rendered at 860/420/640px panes in a real browser: columns hold, narrow pane scrolls (`scrollWidth=834, clientWidth=402`), paragraph cell wraps at the cap, unbreakable path breaks at the cap.
- Menu opens on hover; click shows the check, so the clipboard write resolved.
- `pnpm test` 412 pass; serialization (pipe escaping, per-format quoting) pinned in `markdownTable.test.ts`; cell wrapping pinned in `markdownPlugins.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)