### PR TITLE
Composer: ⌘⇧A reaches pi, and pi's remembered model survives a session visit

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -39,6 +39,7 @@ import ComposerToolbar from "@/components/composer/ComposerToolbar";
 import AppShell from "@/components/layout/AppShell";
 import SessionHeader from "@/components/layout/SessionHeader";
 import { nextEffort } from "@/components/composer/ModelSelector";
+import { nextHarness } from "@/lib/model";
 import ViewTabs, { type ViewTab } from "@/components/layout/ViewTabs";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { pickAttachments } from "@/hooks/useAttachments";
@@ -790,11 +791,12 @@ function App() {
   // ⌘⇧T is reopen-closed-tab in a webview: left bound on a session that cannot
   // use it, it would eat the key and do nothing.
   const composingNewSession = !selectedSessionId && !issuesOpen;
-  useHotkey(
-    "a",
-    () => setHarness(harness === "codex" ? "claude_code" : "codex"),
-    { shift: true, enabled: composingNewSession },
-  );
+  // Steps the picker's own row in its own order, rather than toggling between
+  // two — a toggle written when there were two silently never reached pi.
+  useHotkey("a", () => setHarness(nextHarness(harness)), {
+    shift: true,
+    enabled: composingNewSession,
+  });
   useHotkey("t", () => setUseWorktree((v) => !v), {
     shift: true,
     // A worktree has nothing to fork from until a project is picked, which is

--- a/apps/desktop/src/components/composer/ModelSelector.tsx
+++ b/apps/desktop/src/components/composer/ModelSelector.tsx
@@ -26,7 +26,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { isUnsetModel } from "@/lib/model";
+import { HARNESS_ORDER, isUnsetModel } from "@/lib/model";
 import type { Effort, Harness, Model, ModelId } from "@/types/events";
 
 const EFFORT_LABELS: Record<Effort, string> = {
@@ -41,11 +41,12 @@ const EFFORT_LABELS: Record<Effort, string> = {
 /// the screen reader's alone — the row is marks, since two of them side by side
 /// say "pick one" in less space than two words do, and a tooltip repeating the
 /// name is longer than the row it hangs off.
-const AGENTS: { id: Harness; label: string }[] = [
-  { id: "claude_code", label: "Claude Code" },
-  { id: "codex", label: "Codex" },
-  { id: "pi", label: "pi" },
-];
+const AGENT_LABELS: Record<Harness, string> = {
+  claude_code: "Claude Code",
+  codex: "Codex",
+  pi: "pi",
+};
+const AGENTS = HARNESS_ORDER.map((id) => ({ id, label: AGENT_LABELS[id] }));
 
 /// Next effort level for `model`, wrapping — what ⌘⇧E lands on. `null`
 /// where the model offers nothing to cycle, so the chord no-ops rather than

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -99,6 +99,11 @@ export function useSessions() {
     // archived is the exception view, so every launch starts on the active list.
     const [showArchived, setShowArchived] = useState(false);
     const [models, setModels] = useState<Model[]>([]);
+    // Which harness `models` was read for. The list lands a beat after the
+    // harness moves, so it can still be the *other* harness's — and a pick
+    // repaired against that list is replaced by whatever led it, which is how a
+    // remembered pi model came back as one the reader never starred.
+    const [modelsHarness, setModelsHarness] = useState<Harness | null>(null);
     // pi's list is a read, not a table, so it can be in flight. `0` is the
     // resting value and every refresh bumps it, which is what re-arms the
     // effect below without a second copy of the read beside it.
@@ -682,8 +687,16 @@ const handleNewSession = () => {
   // other harness would come back here untouched every time — and the harness
   // is stored too, so the two can disagree from the moment one is picked
   // without the other.
+  //
+  // But only where that list is the preferred harness's own. Coming back from a
+  // session on another agent, `models` is still that agent's list, and
+  // repairing a pi pick against Claude's models threw it away for Claude's
+  // first model — which the pi fetch then threw away again for pi's first.
+  // An empty list is the "not landed yet" answer, and the fetch the harness
+  // change fires repairs the pick against the right list a beat later.
+  const ownList = modelsHarness === prefs.harness ? models : [];
   setModelId(
-    usableModel(models, rememberedModel(prefs.modelByHarness, prefs.harness), prefs.harness),
+    usableModel(ownList, rememberedModel(prefs.modelByHarness, prefs.harness), prefs.harness),
   );
   setEffortByModel(prefs.effortByModel);
   setPermissionModeState(prefs.permissionMode);
@@ -1130,6 +1143,7 @@ useEffect(() => {
       // land on the second harness's picker.
       if (cancelled) return;
       setModels(list);
+      setModelsHarness(harness);
       // A model belongs to exactly one harness, so switching harness leaves the
       // pick naming something the new one cannot run. Repaired here, where the
       // real list has just landed, rather than guessed at when the toggle moved.

--- a/apps/desktop/src/lib/model.test.ts
+++ b/apps/desktop/src/lib/model.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_MODEL_FOR, isUnsetModel, rememberedModel, UNSET_MODEL, usableModel } from "./model";
+import {
+  DEFAULT_MODEL_FOR,
+  HARNESS_ORDER,
+  isUnsetModel,
+  nextHarness,
+  rememberedModel,
+  UNSET_MODEL,
+  usableModel,
+} from "./model";
 import type { Model } from "@/types/events";
 
 const model = (id: string): Model =>
@@ -89,5 +97,28 @@ describe("the unset model", () => {
   /// that discovers its list lands.
   it("stands while the list is empty", () => {
     expect(usableModel([], UNSET_MODEL, "pi")).toBe(UNSET_MODEL);
+  });
+
+  /// A pick pi cannot run falls to "let pi decide", never to the head of the
+  /// list. The head is a model the reader never starred, and it reached the
+  /// spawn as a `--model` nobody asked for — with nothing on screen saying the
+  /// remembered pick had been replaced.
+  it("is where a pick pi cannot run falls, not the head of the list", () => {
+    expect(usableModel(CLAUDE, "gpt55" as never, "pi")).toBe(UNSET_MODEL);
+  });
+});
+
+describe("nextHarness", () => {
+  /// Toggling between two was written when there were two, and silently never
+  /// reached the third. The chord steps the picker's own row instead.
+  it("steps through every harness in the picker's order and wraps", () => {
+    expect(HARNESS_ORDER).toEqual(["claude_code", "codex", "pi"]);
+    expect(nextHarness("claude_code")).toBe("codex");
+    expect(nextHarness("codex")).toBe("pi");
+    expect(nextHarness("pi")).toBe("claude_code");
+  });
+
+  it("parks an unknown harness on the first", () => {
+    expect(nextHarness("other" as never)).toBe("claude_code");
   });
 });

--- a/apps/desktop/src/lib/model.ts
+++ b/apps/desktop/src/lib/model.ts
@@ -67,11 +67,25 @@ export function usableModel(models: Model[], picked: ModelId, harness: Harness):
 
   const fallback = DEFAULT_MODEL_FOR[harness];
 
-  // Unset is a real answer where the harness names no default: pi picks for
-  // itself, and the spawn omits the flag. Without this the repair below reads
-  // it as a pick to replace and lands on whichever model leads the list —
-  // overriding a choice the reader made in pi's own settings.
-  if (isUnsetModel(picked) && isUnsetModel(fallback)) return picked;
+  // A harness naming no default answers the sentinel, never the head of the
+  // list: pi picks for itself, and the spawn omits the flag. A pick this list
+  // cannot run — the other harness's model, or one whose provider was logged
+  // out — falls to "let pi decide", where landing on the list's first model
+  // put a session on a model the reader never chose, with nothing on screen
+  // saying so. Same answer for the unset pick.
+  if (isUnsetModel(fallback)) return UNSET_MODEL;
 
   return models.some((m) => m.id === fallback) ? fallback : models[0].id;
+}
+
+/// The agents in the order the picker draws them, which is also the order ⌘⇧A
+/// steps through. One list: a chord visiting a harness the row cannot show, or
+/// skipping one it can, reads as the chord being broken.
+export const HARNESS_ORDER: Harness[] = ["claude_code", "codex", "pi"];
+
+/// Where ⌘⇧A lands from `current`, wrapping. An unknown current steps onto the
+/// first, the same place the picker parks its thumb.
+export function nextHarness(current: Harness): Harness {
+  const i = HARNESS_ORDER.indexOf(current);
+  return HARNESS_ORDER[(i + 1) % HARNESS_ORDER.length];
 }


### PR DESCRIPTION
Fixes DRA-124

## What
- **⌘⇧A** toggled `codex ↔ claude_code` only, so pi was unreachable by keyboard. It now steps the picker's own row in order (`HARNESS_ORDER` / `nextHarness` in `model.ts`), one list shared by the picker and the chord.
- **pi's model reset after visiting a session.** The pick was stored fine; `handleNewSession` repaired it against whichever `models` list was loaded — the list of the session just visited. A pi pick vs Claude's list fell to Claude's first model, then pi's fetch repaired *that* to pi's first, one nobody starred. The loaded list is now tagged with its harness (`modelsHarness`) and only the preferred harness's own list repairs the pick.
- `usableModel` under a harness with no default (pi) falls to the unset sentinel — "let pi decide" — never to the head of the list.

## Tests
- `pnpm test`: 437 passing, new cases for `nextHarness` and the pi fallback.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)