### PR TITLE
fix(notices): shorten Deleted confirmation to 800ms

### DIFF
--- a/apps/desktop/src/components/NoticeStack.tsx
+++ b/apps/desktop/src/components/NoticeStack.tsx
@@ -78,7 +78,7 @@ const BAR: Record<NoticeKind, string> = {
 
 /// How long the card lingers after its work is done, to say so. Long enough to
 /// read one word, short enough that nobody waits on it.
-const CONFIRM_MS = 1400;
+const CONFIRM_MS = 800;
 
 /// Wraps a button in the tooltip that carries its accelerator, and only where
 /// there is one to carry.


### PR DESCRIPTION
`CONFIRM_MS` 1400 → 800. It is the duration of the notice card's progress-bar
animation once `phase` flips to `done`, and that bar's `animationend` is what
dismisses the card — so it is the whole of the delay after Delete is clicked.
1400ms read as a stall.

The doc comment above it stands: 800ms is still long enough to read one word.

## The sibling constant is now deliberately different

`COPIED_MS` in `apps/desktop/src/components/layout/SessionHeader.tsx` is also
1400 and is **left alone** — only the delete card was too slow.

Its doc comment reads *"How long the button holds its confirmation, matching the
notice stack's own."* That sentence is now stale: the two no longer match. The
divergence is intended, not drift. Anything re-syncing them should change the
comment, not the value.