### PR TITLE
Fill the context ring for pi sessions

### DIFF
--- a/apps/desktop/PI-PLAN.md
+++ b/apps/desktop/PI-PLAN.md
@@ -1479,10 +1479,24 @@ The denominator is `get_state`'s `model.contextWindow`, taken at the handshake
 that already runs, held in an `AtomicU64` the mapper reads at `agent_settled`.
 The window is re-read on `model_changed`, since Dray respawns for a model
 change but a pi extension calling `setModel` does not — and dropped to `0` the
-moment that event lands, rather than left standing until the answer does. A
-turn settling in the gap draws no ring, where one drawn against the model that
-left is wrong in the direction that reassures: a switch onto a smaller window
-understates occupancy and the gauge says there is room where there is none.
+moment that event lands, rather than left standing until the answer does. That
+stops the *mixed* pair, which is the one nothing else could catch: a fresh
+occupancy measured against the window of the model that left, which after a
+switch onto a smaller one says there is room where there is none.
+
+**It does not make the gauge wait, and cannot.** The reader folds backwards to
+the newest event carrying a figure, so a turn with no window falls through to
+the previous turn's pair — the same reading, a turn older, and internally
+consistent because both halves came from one model. The window Dray no longer
+knows is therefore a stale gauge for as long as it takes `get_state` to answer,
+which is a local round trip against a turn that runs for seconds, and for the
+life of the child where that request fails.
+
+Making it go dark instead needs the fold to know that readings before a point
+are void — a persisted model-change event, which is a variant on the shared
+vocabulary and a fold rule to go with it. Not built: nothing Dray does reaches
+this, since it respawns for a model change, and the path exists only for a pi
+extension calling `setModel` mid-session.
 
 Three states carry no reading rather than a wrong one, and the last two are
 what pi's own `getContextUsage` does: a window Dray never learned, a turn that

--- a/apps/desktop/PI-PLAN.md
+++ b/apps/desktop/PI-PLAN.md
@@ -1477,9 +1477,17 @@ and it agrees with pi's own figure exactly: 2139 in `live_turn.jsonl`, 2840 in
 `no_approvals.jsonl`, against the `get_session_stats` answer captured in each.
 The denominator is `get_state`'s `model.contextWindow`, taken at the handshake
 that already runs, held in an `AtomicU64` the mapper reads at `agent_settled`.
-One reading stands for the child's life, since pi respawns for a model change.
-Cost: nothing per turn, and a window Dray never learns draws no ring rather
-than a wrong one. Pinned by `the_turn_carries_pis_own_occupancy_figure`, which
+The window is re-read on `model_changed`, since Dray respawns for a model
+change but a pi extension calling `setModel` does not.
+
+Three states carry no reading rather than a wrong one, and the last two are
+what pi's own `getContextUsage` does: a window Dray never learned, a turn that
+**failed or was aborted** — its message describes a call that did not land —
+and a turn closing **after a compaction**, whose held total describes the
+context that compaction just threw away. The ring settles on the newest event
+carrying a figure, so a stale total there lands after `context_compacted`'s own
+count and jumps the ring back up for the rest of the session. In all three the
+previous reading stands, which is the safe direction. Pinned by `the_turn_carries_pis_own_occupancy_figure`, which
 reads both numbers out of the captures rather than restating them.
 
 Two edges the docs name and a capture should confirm: `contextUsage` is

--- a/apps/desktop/PI-PLAN.md
+++ b/apps/desktop/PI-PLAN.md
@@ -1109,8 +1109,9 @@ compiler names every one, and ts-rs emits `string` either way.
 **Two things come off `Model` that the first draft added.** `provider`
 duplicates the id — pi's `set_model` takes the halves separately, so the split
 belongs at the call site, on the **first** `/` (OpenRouter ids carry more than
-one). `context_window` has no reader: the ring takes occupancy from
-`get_session_stats`, not from the model table.
+one). `context_window` has no reader on `Model`: the ring takes its
+denominator from the handshake's own `get_state` answer, not from the model
+table — one number, read where it is already being asked for.
 
 **Two.** `Model` grows what a discovered entry knows and a static one can leave
 empty:
@@ -1461,6 +1462,26 @@ before the event is emitted. One round trip per turn, no model call, and the
 number is exact rather than derived — no summing of four disjoint counts, no
 per-model window table.
 
+**That is not what shipped, and the reason is the reader.** A request is
+settled by a line off stdout, and the read loop is what reads them — so
+awaiting `get_session_stats` from inside it waits on itself and gives up
+thirty seconds later, every turn. Asking from a spawned task escapes the
+deadlock and loses the ordering: `TurnCompleted` is emitted and logged before
+the answer lands, and there is no second event carrying occupancy for the
+ring to read.
+
+So the fallback below is the implementation. `message_end.message.usage`
+carries `totalTokens`, which **is** the occupancy — one model call's prompt
+plus its answer, so the turn's last call describes what the turn left behind —
+and it agrees with pi's own figure exactly: 2139 in `live_turn.jsonl`, 2840 in
+`no_approvals.jsonl`, against the `get_session_stats` answer captured in each.
+The denominator is `get_state`'s `model.contextWindow`, taken at the handshake
+that already runs, held in an `AtomicU64` the mapper reads at `agent_settled`.
+One reading stands for the child's life, since pi respawns for a model change.
+Cost: nothing per turn, and a window Dray never learns draws no ring rather
+than a wrong one. Pinned by `the_turn_carries_pis_own_occupancy_figure`, which
+reads both numbers out of the captures rather than restating them.
+
 Two edges the docs name and a capture should confirm: `contextUsage` is
 **omitted** when no model or window is available, and its `tokens`/`percent`
 are **null** immediately after a compaction until a fresh assistant response
@@ -1478,10 +1499,10 @@ would read zero on a real session and show an empty gauge with nothing saying
 why.
 
 So the per-message `usage` feeds `UsageUpdate` (emitted, never persisted) and
-nothing else, and `message_end.message.usage` — which *is* populated — is the
-fallback if `get_session_stats` ever proves too slow to ask on every turn. Its
-`cost` field has no home in Dray at all and is dropped: pi is the first harness
-to report money, and a surface for it is a product decision, not a mapping one.
+`TurnCompleted`, where `message_end.message.usage` — which *is* populated — is
+what the ring reads, for the reason above. Its `cost` field has no home in Dray
+at all and is dropped: pi is the first harness to report money, and a surface
+for it is a product decision, not a mapping one.
 
 ### Gaps, both directions
 

--- a/apps/desktop/PI-PLAN.md
+++ b/apps/desktop/PI-PLAN.md
@@ -1478,16 +1478,27 @@ and it agrees with pi's own figure exactly: 2139 in `live_turn.jsonl`, 2840 in
 The denominator is `get_state`'s `model.contextWindow`, taken at the handshake
 that already runs, held in an `AtomicU64` the mapper reads at `agent_settled`.
 The window is re-read on `model_changed`, since Dray respawns for a model
-change but a pi extension calling `setModel` does not.
+change but a pi extension calling `setModel` does not — and dropped to `0` the
+moment that event lands, rather than left standing until the answer does. A
+turn settling in the gap draws no ring, where one drawn against the model that
+left is wrong in the direction that reassures: a switch onto a smaller window
+understates occupancy and the gauge says there is room where there is none.
 
 Three states carry no reading rather than a wrong one, and the last two are
 what pi's own `getContextUsage` does: a window Dray never learned, a turn that
 **failed or was aborted** — its message describes a call that did not land —
-and a turn closing **after a compaction**, whose held total describes the
-context that compaction just threw away. The ring settles on the newest event
-carrying a figure, so a stale total there lands after `context_compacted`'s own
-count and jumps the ring back up for the rest of the session. In all three the
-previous reading stands, which is the safe direction. Pinned by `the_turn_carries_pis_own_occupancy_figure`, which
+and a turn closing **after a compaction that landed**, whose held total
+describes the context that compaction just threw away. The ring settles on the
+newest event carrying a figure, so a stale total there lands after
+`context_compacted`'s own count and jumps the ring back up for the rest of the
+session. In all three the previous reading stands, which is the safe direction.
+
+A compaction that **aborted** is deliberately not among them, and the asymmetry
+is the reader's own rule: `context_compacted` lands either way and settles
+`used` on whatever count it carries, which for an aborted one is `None`. So
+withholding the turn's window there does not leave the gauge on its last figure
+— it blanks it. Nothing left the window anyway, so the held total is still the
+truth. Pinned by `the_turn_carries_pis_own_occupancy_figure`, which
 reads both numbers out of the captures rather than restating them.
 
 Two edges the docs name and a capture should confirm: `contextUsage` is

--- a/apps/desktop/src-tauri/src/harness/pi/fixtures/README.md
+++ b/apps/desktop/src-tauri/src/harness/pi/fixtures/README.md
@@ -54,7 +54,9 @@ been believed:
 - **`usage` on `message_update` is all zeros for the whole stream** on xAI. The
   stub populated it. pi's docs warn that it "may remain zero until completion"
   and that is what a real provider does — which is why the context ring reads
-  `get_session_stats` rather than deriving from deltas.
+  the *committed* message's `usage.totalTokens` rather than deriving from
+  deltas. `get_session_stats` is captured beside it in both live files, and the
+  two agree: that is what pins the reading.
 - **`toolcall_delta` fired once per call, carrying the whole argument JSON.**
   The stub split it into twelve-character fragments. So the streaming-preview
   split — header from the stream, body from the committed event — *works*, but

--- a/apps/desktop/src-tauri/src/harness/pi/mapper.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/mapper.rs
@@ -100,6 +100,11 @@ pub struct Mapper {
     ///
     /// Cleared by the next committed message, whose total is post-compaction
     /// and honest again.
+    ///
+    /// Never armed by a compaction that *aborted*: nothing left the window, so
+    /// the held total still describes it — and withholding a window there
+    /// leaves the reader settling on that compaction's own absent count, which
+    /// blanks the gauge outright.
     compacted_since_usage: bool,
 }
 
@@ -309,17 +314,23 @@ impl Mapper {
                 result,
                 aborted,
             } => {
-                // Whatever the mapper is holding describes the context this
-                // compaction has just replaced, so it must not close the turn
-                // as an occupancy reading. Armed even where the compaction
-                // aborted: it reports no saving either, and the ring is better
-                // left on its last known figure than moved by a guess.
-                self.compacted_since_usage = true;
-
                 // Dropped where the compaction did not finish: the numbers
                 // describe a context that was kept, and reporting a saving for
                 // one that was thrown away is worse than reporting none.
                 let saved = result.filter(|_| !aborted);
+
+                // Whatever the mapper is holding describes the context a
+                // compaction that *landed* has just replaced, so it must not
+                // close the turn as an occupancy reading.
+                //
+                // Only where one landed, and the difference is the ring going
+                // blank: an aborted compaction still publishes
+                // `context_compacted`, whose `post_tokens` is `None`, and the
+                // reader settles `used` on the newest event carrying a figure
+                // — so a turn withholding its window leaves that `None` as the
+                // answer and the gauge draws nothing. Nothing left the window
+                // in that case anyway, so the held total is still the truth.
+                self.compacted_since_usage = saved.is_some();
 
                 vec![self.event(AgentEventPayload::ContextCompacted {
                     trigger: reason,
@@ -920,6 +931,42 @@ mod tests {
             settled_usage(&settled).context_window.is_none(),
             "the ring would jump back to the context the compaction threw away"
         );
+    }
+
+    /// A compaction that *aborted* changed nothing, so the turn closing after
+    /// one keeps its reading.
+    ///
+    /// Withholding it there does not leave the ring on its last figure — it
+    /// blanks it. `context_compacted` still lands, carrying no count, and the
+    /// reader settles `used` on the newest event that carries one either way,
+    /// so an absent window on the turn above it makes that `None` the answer.
+    #[test]
+    fn an_aborted_compaction_leaves_the_reading_alone() {
+        let mut mapper = Mapper::new(
+            "s".into(),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(500_000)),
+        );
+
+        feed(&mut mapper, r#"{"type":"agent_start"}"#);
+        feed(
+            &mut mapper,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[],
+                "usage":{"input":180000,"output":16,"cacheRead":0,"cacheWrite":0,
+                         "reasoning":0,"totalTokens":180016}}}"#,
+        );
+        feed(
+            &mut mapper,
+            r#"{"type":"compaction_end","reason":"threshold","aborted":true,
+                "errorMessage":"Nothing to compact (session too small)"}"#,
+        );
+        let settled = feed(&mut mapper, r#"{"type":"agent_settled"}"#);
+
+        let window = settled_usage(&settled)
+            .context_window
+            .expect("the gauge would draw nothing at all");
+
+        assert_eq!(window.used_tokens, 180016);
     }
 
     /// A failed or aborted turn describes a call that did not land, so it

--- a/apps/desktop/src-tauri/src/harness/pi/mapper.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/mapper.rs
@@ -84,10 +84,23 @@ pub struct Mapper {
     /// Shared rather than passed because the reader is running *before* the
     /// handshake it settles the answer for — nothing but a line off stdout
     /// resolves a request, so the mapper exists a moment before its window
-    /// does. One reading stands for the child's life: pi respawns for a model
-    /// change (`applies_model_in_place: false`), so nothing can move the window
-    /// under a session that is running.
+    /// does. Shared for a second reason too: Dray respawns for a model change
+    /// (`applies_model_in_place: false`) but a pi extension calling `setModel`
+    /// does not, so [`super::pi`] re-reads this on `model_changed`.
     context_window: Arc<AtomicU64>,
+    /// Whether a compaction has landed since the reading in `usage` was taken.
+    ///
+    /// A compaction *lowers* occupancy and publishes what it kept on
+    /// `context_compacted`, so a turn closing after one must not re-attach the
+    /// message total from before it — the ring is settled by the newest event
+    /// carrying a figure, and a stale one there jumps it back to its
+    /// pre-compaction level and keeps it there for the rest of the session.
+    /// Claude Code's mapper clears its own tracked reading at a boundary for
+    /// exactly this.
+    ///
+    /// Cleared by the next committed message, whose total is post-compaction
+    /// and honest again.
+    compacted_since_usage: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -106,7 +119,15 @@ impl Mapper {
             outcome: None,
             usage: None,
             context_window,
+            compacted_since_usage: false,
         }
+    }
+
+    /// The slot holding the ring's denominator, for the one caller that has to
+    /// write it: a model changing under a running child leaves the window
+    /// describing the model that left.
+    pub fn context_window(&self) -> Arc<AtomicU64> {
+        self.context_window.clone()
     }
 
     /// Puts the ring's pair on a turn's usage: the committed message's
@@ -122,8 +143,20 @@ impl Mapper {
     /// count of `0` is a turn that reached no model at all — an auth failure
     /// reports zeros where pi's own reading is the system prompt alone, and a
     /// ring drawn empty there claims a fresh context rather than an unknown one.
-    fn with_occupancy(&self, mut usage: Usage) -> Usage {
+    ///
+    /// Two turns carry no reading at all rather than a wrong one, both matching
+    /// what pi's own `getContextUsage` does: one that **failed or was aborted**,
+    /// whose message describes a call that did not land, and one closing
+    /// **after a compaction** the message predates. In both the previous
+    /// reading stands, which is the safe direction — under-reporting occupancy
+    /// costs nothing where over-reporting claims a context that was thrown
+    /// away.
+    fn with_occupancy(&self, mut usage: Usage, status: TurnStatus) -> Usage {
         let max = self.context_window.load(Relaxed);
+
+        if self.compacted_since_usage || !matches!(status, TurnStatus::Success) {
+            return usage;
+        }
 
         if let Some(used) = usage.total_tokens.filter(|used| *used > 0 && max > 0) {
             usage.context_window = Some(ContextWindow {
@@ -152,7 +185,6 @@ impl Mapper {
 
             PiEvent::AgentSettled => {
                 let outcome = self.outcome.take();
-                let usage = self.usage.take().map(|u| self.with_occupancy(u));
 
                 let (status, stop_reason, final_text) = match outcome {
                     Some(o) if o.stop_reason.as_deref() == Some("error") => {
@@ -160,6 +192,10 @@ impl Mapper {
                     }
                     other => (TurnStatus::Success, other.and_then(|o| o.stop_reason), None),
                 };
+
+                // Read after the verdict, since a failed turn's counts describe
+                // a model call that did not land.
+                let usage = self.usage.take().map(|u| self.with_occupancy(u, status));
 
                 vec![self.event(AgentEventPayload::TurnCompleted {
                     status,
@@ -273,6 +309,13 @@ impl Mapper {
                 result,
                 aborted,
             } => {
+                // Whatever the mapper is holding describes the context this
+                // compaction has just replaced, so it must not close the turn
+                // as an occupancy reading. Armed even where the compaction
+                // aborted: it reports no saving either, and the ring is better
+                // left on its last known figure than moved by a guess.
+                self.compacted_since_usage = true;
+
                 // Dropped where the compaction did not finish: the numbers
                 // describe a context that was kept, and reporting a saving for
                 // one that was thrown away is worse than reporting none.
@@ -345,6 +388,9 @@ impl Mapper {
             error_message,
         });
         if let Some(u) = usage {
+            // This reading is newer than any compaction before it, so the
+            // suppression that one armed is spent.
+            self.compacted_since_usage = false;
             self.usage = Some(Usage {
                 input_tokens: Some(u.input),
                 output_tokens: Some(u.output),
@@ -839,6 +885,83 @@ mod tests {
         }
     }
 
+    /// A compaction lowers occupancy, so the message total from before it must
+    /// not close the turn as a reading.
+    ///
+    /// The ring settles on the newest event carrying a figure. Left attached,
+    /// the stale total lands *after* `context_compacted`'s own count and jumps
+    /// the ring back to its pre-compaction level — where it then stays, since
+    /// nothing later contradicts it. The next committed message clears the
+    /// suppression, which is the ordinary case: a compaction exists to make
+    /// room for a call that follows it.
+    #[test]
+    fn a_turn_closing_after_a_compaction_carries_no_stale_reading() {
+        let mut mapper = Mapper::new(
+            "s".into(),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(500_000)),
+        );
+
+        feed(&mut mapper, r#"{"type":"agent_start"}"#);
+        feed(
+            &mut mapper,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[],
+                "usage":{"input":180000,"output":16,"cacheRead":0,"cacheWrite":0,
+                         "reasoning":0,"totalTokens":180016}}}"#,
+        );
+        feed(
+            &mut mapper,
+            r#"{"type":"compaction_end","reason":"threshold","aborted":false,
+                "result":{"tokensBefore":180016,"estimatedTokensAfter":20000}}"#,
+        );
+        let settled = feed(&mut mapper, r#"{"type":"agent_settled"}"#);
+
+        assert!(
+            settled_usage(&settled).context_window.is_none(),
+            "the ring would jump back to the context the compaction threw away"
+        );
+    }
+
+    /// A failed or aborted turn describes a call that did not land, so it
+    /// carries no reading either — pi's own `getContextUsage` skips those
+    /// messages for the same reason, and the previous reading standing is the
+    /// safe direction.
+    #[test]
+    fn a_failed_turn_carries_no_reading() {
+        let mut mapper = Mapper::new(
+            "s".into(),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(500_000)),
+        );
+
+        feed(&mut mapper, r#"{"type":"agent_start"}"#);
+        feed(
+            &mut mapper,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[],
+                "stopReason":"error","errorMessage":"the provider gave up",
+                "usage":{"input":2000,"output":8,"cacheRead":0,"cacheWrite":0,
+                         "reasoning":0,"totalTokens":2008}}}"#,
+        );
+        let settled = feed(&mut mapper, r#"{"type":"agent_settled"}"#);
+
+        assert!(settled_usage(&settled).context_window.is_none());
+    }
+
+    fn feed(mapper: &mut Mapper, line: &str) -> Vec<AgentEvent> {
+        mapper.map(super::super::parser::parse_line(line).expect("parses"))
+    }
+
+    /// The usage riding a turn that just closed, so a test asserting about the
+    /// ring cannot pass on a turn that never closed at all.
+    fn settled_usage(events: &[AgentEvent]) -> Usage {
+        match &events[0].payload {
+            AgentEventPayload::TurnCompleted { usage, .. } => {
+                usage.clone().expect("the counts still ride the turn")
+            }
+            other => panic!("the turn did not close: {other:?}"),
+        }
+    }
+
     /// `get_state` is what fills the denominator, and it is already the
     /// handshake — so the ring costs no round trip. Pinned because the field
     /// sits on the model rather than beside it, and reading the wrong level
@@ -871,22 +994,25 @@ mod tests {
         };
 
         assert!(mapper(0)
-            .with_occupancy(counted.clone())
+            .with_occupancy(counted.clone(), TurnStatus::Success)
             .context_window
             .is_none());
         assert!(mapper(500_000)
-            .with_occupancy(Usage {
-                total_tokens: Some(0),
-                ..Usage::default()
-            })
+            .with_occupancy(
+                Usage {
+                    total_tokens: Some(0),
+                    ..Usage::default()
+                },
+                TurnStatus::Success,
+            )
             .context_window
             .is_none());
         assert!(mapper(500_000)
-            .with_occupancy(Usage::default())
+            .with_occupancy(Usage::default(), TurnStatus::Success)
             .context_window
             .is_none());
         assert!(mapper(500_000)
-            .with_occupancy(counted)
+            .with_occupancy(counted, TurnStatus::Success)
             .context_window
             .is_some());
     }

--- a/apps/desktop/src-tauri/src/harness/pi/mapper.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/mapper.rs
@@ -20,8 +20,8 @@
 //! `0`.
 
 use crate::events::{
-    AgentEvent, AgentEventPayload, BlockRef, BlockType, DeltaEvent, ErrorSource, SessionInfo,
-    ToolResult, ToolType, TurnStatus, Usage,
+    usage::ContextWindow, AgentEvent, AgentEventPayload, BlockRef, BlockType, DeltaEvent,
+    ErrorSource, SessionInfo, ToolResult, ToolType, TurnStatus, Usage,
 };
 use crate::harness::Harness;
 use serde_json::Value;
@@ -77,6 +77,17 @@ pub struct Mapper {
     /// `message_update` and is **all zeros on a real provider** for the whole
     /// run. Reading those would draw a ring that never fills.
     usage: Option<Usage>,
+    /// The running model's context window, the ring's denominator. `0` until
+    /// the handshake fills it, and forever on a pi that answered `get_state`
+    /// with no window on its model.
+    ///
+    /// Shared rather than passed because the reader is running *before* the
+    /// handshake it settles the answer for — nothing but a line off stdout
+    /// resolves a request, so the mapper exists a moment before its window
+    /// does. One reading stands for the child's life: pi respawns for a model
+    /// change (`applies_model_in_place: false`), so nothing can move the window
+    /// under a session that is running.
+    context_window: Arc<AtomicU64>,
 }
 
 #[derive(Debug, Clone)]
@@ -86,7 +97,7 @@ struct Outcome {
 }
 
 impl Mapper {
-    pub fn new(session_id: String, seq: Arc<AtomicU64>) -> Self {
+    pub fn new(session_id: String, seq: Arc<AtomicU64>, context_window: Arc<AtomicU64>) -> Self {
         Self {
             session_id,
             seq,
@@ -94,7 +105,34 @@ impl Mapper {
             open_calls: std::collections::HashMap::new(),
             outcome: None,
             usage: None,
+            context_window,
         }
+    }
+
+    /// Puts the ring's pair on a turn's usage: the committed message's
+    /// `totalTokens` against the model's window.
+    ///
+    /// `totalTokens` **is** the occupancy, not a per-turn sum — it is one model
+    /// call's prompt plus its answer, so the last call of a turn describes the
+    /// context that turn left behind. Pinned against pi's own arithmetic in
+    /// `the_turn_carries_pis_own_occupancy_figure`, which reads the
+    /// `get_session_stats` answer captured beside it.
+    ///
+    /// Both halves must be real. A window of `0` is a pi that never said, and a
+    /// count of `0` is a turn that reached no model at all — an auth failure
+    /// reports zeros where pi's own reading is the system prompt alone, and a
+    /// ring drawn empty there claims a fresh context rather than an unknown one.
+    fn with_occupancy(&self, mut usage: Usage) -> Usage {
+        let max = self.context_window.load(Relaxed);
+
+        if let Some(used) = usage.total_tokens.filter(|used| *used > 0 && max > 0) {
+            usage.context_window = Some(ContextWindow {
+                used_tokens: used,
+                max_tokens: max,
+            });
+        }
+
+        usage
     }
 
     pub fn map(&mut self, event: PiEvent) -> Vec<AgentEvent> {
@@ -114,7 +152,7 @@ impl Mapper {
 
             PiEvent::AgentSettled => {
                 let outcome = self.outcome.take();
-                let usage = self.usage.take();
+                let usage = self.usage.take().map(|u| self.with_occupancy(u));
 
                 let (status, stop_reason, final_text) = match outcome {
                     Some(o) if o.stop_reason.as_deref() == Some("error") => {
@@ -487,7 +525,17 @@ mod tests {
     }
 
     fn mapped(fixture: &str) -> Vec<AgentEvent> {
-        let mut mapper = Mapper::new("s".into(), Arc::new(AtomicU64::new(0)));
+        mapped_within(fixture, 0)
+    }
+
+    /// The same, on a session that learned its model's context window at the
+    /// handshake — which is where the ring's denominator comes from.
+    fn mapped_within(fixture: &str, context_window: u64) -> Vec<AgentEvent> {
+        let mut mapper = Mapper::new(
+            "s".into(),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(context_window)),
+        );
 
         fixture
             .lines()
@@ -499,10 +547,25 @@ mod tests {
             .collect()
     }
 
+    /// What a captured command answered, so a test can check this build's
+    /// arithmetic against pi's own rather than against a number typed here.
+    fn answered(fixture: &str, command: &str) -> Value {
+        fixture
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str::<Record>(l).expect("fixture record"))
+            .filter(|r| r.dir == "out")
+            .filter_map(|r| serde_json::from_str::<Value>(&r.line).ok())
+            .find(|v| v["type"] == "response" && v["command"] == command)
+            .map(|v| v["data"].clone())
+            .unwrap_or_else(|| panic!("the capture has no {command} answer in it"))
+    }
+
     const LIVE_TURN: &str = include_str!("fixtures/live_turn.jsonl");
     const EXTENSION_TOOL: &str = include_str!("fixtures/extension_tool_and_dialogs.jsonl");
     const ABORT: &str = include_str!("fixtures/abort_and_queue.jsonl");
     const FAILED: &str = include_str!("fixtures/failed_turn_live.jsonl");
+    const NO_APPROVALS: &str = include_str!("fixtures/no_approvals.jsonl");
 
     /// One prompt is one turn, however many model calls pi makes inside it.
     ///
@@ -739,6 +802,95 @@ mod tests {
         );
     }
 
+    /// The committed message's `totalTokens` **is** pi's own occupancy reading,
+    /// which is the whole reason the ring needs no round trip of its own.
+    ///
+    /// Checked against the `get_session_stats` answer captured in the same
+    /// session rather than a number written here: `contextUsage.tokens` is what
+    /// pi's own UI draws, so agreeing with it is the claim being made. Two
+    /// captures, one live and one stubbed, since a single-message turn would
+    /// hide a sum where these each close after three model calls.
+    #[test]
+    fn the_turn_carries_pis_own_occupancy_figure() {
+        for fixture in [LIVE_TURN, NO_APPROVALS] {
+            let stats = answered(fixture, "get_session_stats");
+            let occupancy = stats["contextUsage"]["tokens"]
+                .as_u64()
+                .expect("the capture answered with an occupancy");
+            let max = stats["contextUsage"]["contextWindow"]
+                .as_u64()
+                .expect("the capture answered with a window");
+
+            let window = mapped_within(fixture, max)
+                .iter()
+                .find_map(|e| match &e.payload {
+                    AgentEventPayload::TurnCompleted { usage, .. } => {
+                        usage.as_ref().and_then(|u| u.context_window)
+                    }
+                    _ => None,
+                })
+                .expect("the turn closed with a window on it");
+
+            assert_eq!(
+                window.used_tokens, occupancy,
+                "the ring disagrees with pi's own arithmetic"
+            );
+            assert_eq!(window.max_tokens, max);
+        }
+    }
+
+    /// `get_state` is what fills the denominator, and it is already the
+    /// handshake — so the ring costs no round trip. Pinned because the field
+    /// sits on the model rather than beside it, and reading the wrong level
+    /// leaves a window of `0`, which draws as no ring at all.
+    #[test]
+    fn the_handshake_answer_carries_the_window() {
+        let state = answered(NO_APPROVALS, "get_state");
+
+        assert!(state["model"]["contextWindow"]
+            .as_u64()
+            .is_some_and(|w| w > 0));
+    }
+
+    /// Neither half may be guessed at. A window of `0` is a pi that never said;
+    /// a count of `0` is a turn that reached no model — an auth failure reports
+    /// zeros where the real occupancy is the system prompt — and a ring drawn
+    /// there claims a fresh context rather than an unknown one.
+    #[test]
+    fn a_missing_half_draws_no_ring() {
+        let counted = Usage {
+            total_tokens: Some(2139),
+            ..Usage::default()
+        };
+        let mapper = |window: u64| {
+            Mapper::new(
+                "s".into(),
+                Arc::new(AtomicU64::new(0)),
+                Arc::new(AtomicU64::new(window)),
+            )
+        };
+
+        assert!(mapper(0)
+            .with_occupancy(counted.clone())
+            .context_window
+            .is_none());
+        assert!(mapper(500_000)
+            .with_occupancy(Usage {
+                total_tokens: Some(0),
+                ..Usage::default()
+            })
+            .context_window
+            .is_none());
+        assert!(mapper(500_000)
+            .with_occupancy(Usage::default())
+            .context_window
+            .is_none());
+        assert!(mapper(500_000)
+            .with_occupancy(counted)
+            .context_window
+            .is_some());
+    }
+
     /// An abort is a user's own Stop, and pi reports it as `stopReason: "error"`
     /// — the docs say `"aborted"` and it does not. Mapping it as a failure is
     /// honest here: the sentence pi gives is the one to draw.
@@ -773,7 +925,11 @@ mod tests {
     }
 
     fn map_one(line: &str) -> Vec<AgentEvent> {
-        let mut mapper = Mapper::new("s".into(), Arc::new(AtomicU64::new(0)));
+        let mut mapper = Mapper::new(
+            "s".into(),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+        );
         mapper.map(super::super::parser::parse_line(line).expect("parses"))
     }
 

--- a/apps/desktop/src-tauri/src/harness/pi/pi.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/pi.rs
@@ -566,12 +566,16 @@ async fn read_stdout(
         //
         // Spawned, never awaited: a request is settled by a line off stdout and
         // this loop is what reads them, so awaiting one here waits on itself.
-        // Ordering does not matter the way it does for occupancy — a window is
-        // a standing fact, so the worst a late answer costs is one turn drawn
-        // against the previous model's.
+        //
+        // So the old window is dropped *here*, synchronously, rather than left
+        // standing until the answer lands. A turn settling in that gap draws no
+        // ring, where one drawn against the model that left is wrong in the
+        // direction that reassures — a switch onto a smaller window understates
+        // occupancy, and the gauge says there is room where there is none.
         if matches!(event, parser::PiEvent::ModelChanged { .. }) {
             let client = client.clone();
             let context_window = mapper.context_window();
+            context_window.store(0, Relaxed);
             tokio::spawn(async move {
                 match client.request("get_state", Value::Null).await {
                     Ok(state) => {

--- a/apps/desktop/src-tauri/src/harness/pi/pi.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/pi.rs
@@ -559,6 +559,31 @@ async fn read_stdout(
             continue;
         }
 
+        // The model moved under a running child, which Dray itself never does
+        // — it respawns — but a pi extension calling `setModel` does, and pi
+        // reports it here whoever asked. The ring's denominator belongs to the
+        // model, so it is re-read rather than left describing the old one.
+        //
+        // Spawned, never awaited: a request is settled by a line off stdout and
+        // this loop is what reads them, so awaiting one here waits on itself.
+        // Ordering does not matter the way it does for occupancy — a window is
+        // a standing fact, so the worst a late answer costs is one turn drawn
+        // against the previous model's.
+        if matches!(event, parser::PiEvent::ModelChanged { .. }) {
+            let client = client.clone();
+            let context_window = mapper.context_window();
+            tokio::spawn(async move {
+                match client.request("get_state", Value::Null).await {
+                    Ok(state) => {
+                        if let Some(window) = state["model"]["contextWindow"].as_u64() {
+                            context_window.store(window, Relaxed);
+                        }
+                    }
+                    Err(error) => eprintln!("[pi] could not re-read the context window: {error:#}"),
+                }
+            });
+        }
+
         // An extension asking the reader something. Answered from here and
         // never merely ignored: pi blocks the tool call until an
         // `extension_ui_response` carrying this id comes back, and

--- a/apps/desktop/src-tauri/src/harness/pi/pi.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/pi.rs
@@ -33,7 +33,7 @@ use crate::store::{self, next_seq_by_session_id};
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::process::Stdio;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 use std::time::Duration;
@@ -195,6 +195,13 @@ pub async fn init(
     // through the session.
     let desk_token = desk::open(session_id, client.clone(), pending.clone(), seq.clone());
 
+    // The ring's denominator, filled by the handshake below and read by the
+    // mapper at every turn's end. Minted here because the reader has to start
+    // *before* that handshake — nothing settles a request except a line off
+    // stdout — so the mapper exists a moment before its window does. `0` until
+    // then, which draws no ring rather than a wrong one.
+    let context_window = Arc::new(AtomicU64::new(0));
+
     // The reader has to be running before the handshake: `get_state` is a
     // request, and nothing settles a pending request except a line off stdout.
     tokio::spawn({
@@ -207,11 +214,22 @@ pub async fn init(
         let queued = queued.clone();
         let seq = seq.clone();
         let pending = pending.clone();
+        let context_window = context_window.clone();
         let desk_id = session_id.clone();
         let teardown_app = app.clone();
         async move {
             if let Err(error) = read_stdout(
-                stdout, client, session_id, session_cwd, events, status, queued, pending, seq, app,
+                stdout,
+                client,
+                session_id,
+                session_cwd,
+                events,
+                status,
+                queued,
+                pending,
+                seq,
+                context_window,
+                app,
             )
             .await
             {
@@ -243,26 +261,40 @@ pub async fn init(
     // bound, tighter than an ordinary command's: silence here is
     // indistinguishable from a slow start, and thirty seconds of a blank
     // composer reads as broken.
-    if let Err(error) = client
+    let state = client
         .request_within("get_state", Value::Null, HANDSHAKE_TIMEOUT)
-        .await
-    {
-        // Everything above is post-spawn, so the child is running with nobody
-        // left to talk to it. Killed rather than dropped: a `Child` is not
-        // reaped on drop, so every failed start would leave a pi alive for the
-        // life of the app.
-        //
-        // Asked whether it is still there first, because the two failures want
-        // different cures and read identically without this: a child that
-        // *exited* took its reason with it to stderr, where one still running
-        // and silent is pi not answering a command this build sends.
-        let died = child.try_wait().ok().flatten();
-        shutdown(&mut child, &client).await;
+        .await;
 
-        return Err(error).with_context(|| match died {
-            Some(status) => format!("pi exited during the handshake ({status})"),
-            None => "pi did not answer the handshake".to_string(),
-        });
+    let state = match state {
+        Ok(state) => state,
+        Err(error) => {
+            // Everything above is post-spawn, so the child is running with
+            // nobody left to talk to it. Killed rather than dropped: a `Child`
+            // is not reaped on drop, so every failed start would leave a pi
+            // alive for the life of the app.
+            //
+            // Asked whether it is still there first, because the two failures
+            // want different cures and read identically without this: a child
+            // that *exited* took its reason with it to stderr, where one still
+            // running and silent is pi not answering a command this build
+            // sends.
+            let died = child.try_wait().ok().flatten();
+            shutdown(&mut child, &client).await;
+
+            return Err(error).with_context(|| match died {
+                Some(status) => format!("pi exited during the handshake ({status})"),
+                None => "pi did not answer the handshake".to_string(),
+            });
+        }
+    };
+
+    // The one number the ring cannot derive. Read off the handshake rather than
+    // asked for per turn, which the reader could not do anyway: a request is
+    // settled by a line off stdout, so awaiting one inside the read loop waits
+    // on itself. Sound for the child's life — pi respawns for a model change,
+    // so nothing moves the window under a running session.
+    if let Some(window) = state["model"]["contextWindow"].as_u64() {
+        context_window.store(window, Relaxed);
     }
 
     Ok(Session {
@@ -473,6 +505,7 @@ async fn read_stdout(
     queued: QueuedMessages,
     pending: PendingPermissions,
     seq: Arc<AtomicU64>,
+    context_window: Arc<AtomicU64>,
     app: AppHandle,
 ) -> Result<()> {
     let reader = BufReader::new(stdout);
@@ -480,7 +513,7 @@ async fn read_stdout(
     // `U+2029` are legal inside JSON strings, so a reader treating them as line
     // breaks would corrupt any record containing one.
     let mut lines = reader.lines();
-    let mut mapper = mapper::Mapper::new(session_id.clone(), seq.clone());
+    let mut mapper = mapper::Mapper::new(session_id.clone(), seq.clone(), context_window);
     let transport = Transport::Pi(client.clone());
 
     while let Some(line) = lines.next_line().await? {

--- a/apps/desktop/src-tauri/src/harness/pi/pi.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/pi.rs
@@ -568,10 +568,16 @@ async fn read_stdout(
         // this loop is what reads them, so awaiting one here waits on itself.
         //
         // So the old window is dropped *here*, synchronously, rather than left
-        // standing until the answer lands. A turn settling in that gap draws no
-        // ring, where one drawn against the model that left is wrong in the
-        // direction that reassures — a switch onto a smaller window understates
-        // occupancy, and the gauge says there is room where there is none.
+        // standing until the answer lands. That is about the *mixed* pair: a
+        // fresh occupancy measured against the window of the model that left
+        // reads as room where there is none, once the switch is onto a smaller
+        // one.
+        //
+        // It does not make the gauge wait. A turn carrying no window falls
+        // through to the previous turn's pair, which is a reading one turn old
+        // with both halves from one model. Going dark instead would need the
+        // fold to know that readings before this point are void — see
+        // PI-PLAN.md.
         if matches!(event, parser::PiEvent::ModelChanged { .. }) {
             let client = client.clone();
             let context_window = mapper.context_window();


### PR DESCRIPTION
The composer's context meter was blank on every pi session: `contextUsage` needs `turn_completed.usage.contextWindow`, and pi's mapper never set `context_window`.

Both numbers were already on the wire, so this costs no round trip per turn.

- **used** — the committed assistant message's `usage.totalTokens` *is* pi's own occupancy figure: one model call's prompt plus its answer, so the turn's last call describes what the turn left behind. It agrees with the `get_session_stats` answer captured in the same session exactly — 2139 in `live_turn.jsonl`, 2840 in `no_approvals.jsonl` — and the test reads both numbers out of the captures rather than restating them.
- **max** — `get_state`'s `model.contextWindow`, read off the handshake that already runs, held in an `AtomicU64` the mapper reads at `agent_settled`. One reading stands for the child's life, since pi respawns for a model change.

`get_session_stats` was the planned route and cannot serve it: a pi request is settled by a line off stdout and the read loop is what reads them, so awaiting one inside it waits on itself for thirty seconds. Asking from a spawned task escapes the deadlock and lands after `TurnCompleted` is already emitted and logged. PI-PLAN.md now records that.

A window of `0` or a turn reporting no tokens draws no ring, rather than an empty one claiming a fresh context.

No frontend change — the ring already reads the pair off `turn_completed`.

Fixes DRA-127

🤖 Generated with [Claude Code](https://claude.com/claude-code)