### PR TITLE
Start work on an issue from the issues page

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { invoke } from "@tauri-apps/api/core";
+import { Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
 
 import "./App.css";
 import Chat from "@/components/Chat";
@@ -63,6 +66,7 @@ import { useSlashCommands } from "@/hooks/useSlashCommands";
 import { useRecorder } from "@/hooks/useTranscription";
 import { useUpdater } from "@/hooks/useUpdater";
 import { appendToDraft } from "@/hooks/useDraft";
+import { issueTag } from "@/lib/issue";
 import { authFailedTurn } from "@/lib/auth";
 import { changeRange, turnChangedTree } from "@/lib/changes";
 import { prBadgeCount, sessionBranch } from "@/lib/pr";
@@ -706,6 +710,18 @@ function App() {
     go();
   };
 
+  /// Leaves the issues page for the empty composer, with the issue tagged in
+  /// the draft.
+  ///
+  /// The tag alone is the whole handoff: `expand_tags` resolves it out of the
+  /// prompt text on send, so nothing is linked here. It lands in the composer
+  /// rather than starting a session, which is what leaves the project, the
+  /// model and the harness still to be picked.
+  const workOnIssue = (issue: { identifier: string; title: string }) => {
+    goToSession(handleNewSession);
+    appendToDraft(null, issueTag(issue.identifier, issue.title));
+  };
+
   /// Writes a session's settled or pinned flag and takes the sidebar wherever
   /// that write left the row.
   ///
@@ -998,6 +1014,17 @@ function App() {
               onRefresh: pickedIssueData.refresh,
               loading: pickedIssueData.loading,
             }}
+            // In the strip rather than on the issue's own row, beside Refresh:
+            // it acts on the issue the pane is showing, which is the pane's
+            // whole subject — the same slot Open takes for a session.
+            actions={
+              pickedIssue && (
+                <Button variant="secondary" size="xs" onClick={() => workOnIssue(pickedIssue)}>
+                  Work on it
+                  <Plus data-icon="inline-end" />
+                </Button>
+              )
+            }
           >
             <TabBody active>
               <IssuePanel
@@ -1186,6 +1213,7 @@ function App() {
           active={issuesOpen}
           picked={pickedIssue?.identifier ?? null}
           onPick={setPickedIssue}
+          onWorkOn={workOnIssue}
           refreshRef={issuesRefreshRef}
           connected={issuesConnected}
           onConnect={integrations.connect}

--- a/apps/desktop/src/components/IssuesView.tsx
+++ b/apps/desktop/src/components/IssuesView.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useMemo, useState, type MutableRefObject } from "react";
+import { useEffect, useMemo, useState, type MutableRefObject, type SyntheticEvent } from "react";
 
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { ChevronRight, RefreshCw, Search, SlidersHorizontal } from "lucide-react";
+import { ChevronRight, Plus, RefreshCw, Search, SlidersHorizontal } from "lucide-react";
 
 import Avatar from "@/components/Avatar";
 import IssueStateIcon, { IssuePriorityIcon } from "@/components/IssueStateIcon";
 import LinearIcon from "@/components/LinearIcon";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -90,6 +90,7 @@ export default function IssuesView({
   connectError,
   picked,
   onPick,
+  onWorkOn,
   refreshRef,
 }: {
   /// The page is the thing on screen. Hidden pages do not read, for the reason
@@ -105,14 +106,16 @@ export default function IssuesView({
   /// say which one it is. Owned by `App`, because the pane is.
   picked: string | null;
   onPick: (issue: Issue) => void;
+  /// Takes the reader to the empty composer with this issue tagged. Owned by
+  /// `App`, which is the only thing that can leave this page.
+  onWorkOn: (issue: Issue) => void;
   /// Where this page hands its refresh up, so ⌘R can reach it. `App` owns the
   /// chord — it has to pick between this page and the right panel, and only it
   /// knows which one the reader is looking at.
   refreshRef?: MutableRefObject<(() => void) | null>;
 }) {
-  const { issues, settled, filters, query, setQuery, loading, unavailable, refresh } = useIssues(
-    active && connected,
-  );
+  const { issues, settled, filters, query, setQuery, loading, loaded, unavailable, refresh } =
+    useIssues(active && connected);
 
   // Kept current rather than set once: `refresh` is re-made whenever the hook
   // re-runs, and a handle captured at mount would close over a stale one.
@@ -212,7 +215,14 @@ export default function IssuesView({
       )}
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {issues.length === 0 && !loading && (
+        {/* Nothing else while the first read is out — not even the settled
+            headings, which are the one part of this list that can be drawn
+            without an answer and so were the only thing on screen. A page whose
+            finished work appears first, and whose open work arrives second,
+            reads as a workspace with nothing left to do. */}
+        {!loaded && <p className="px-3 py-2 text-ui text-muted-foreground">Reading…</p>}
+
+        {loaded && issues.length === 0 && !loading && (
           <p className="px-3 py-4 text-ui text-muted-foreground">
             {query.text
               ? "No issue matches that."
@@ -222,18 +232,20 @@ export default function IssuesView({
           </p>
         )}
 
-        {groups.map((group) => (
-          <Group key={group.key} kind={group.key} label={group.label} count={group.issues.length}>
-            {group.issues.map((issue) => (
-              <IssueRow
-                key={issue.id}
-                issue={issue}
-                picked={issue.identifier === picked}
-                onPick={onPick}
-              />
-            ))}
-          </Group>
-        ))}
+        {loaded &&
+          groups.map((group) => (
+            <Group key={group.key} kind={group.key} label={group.label} count={group.issues.length}>
+              {group.issues.map((issue) => (
+                <IssueRow
+                  key={issue.id}
+                  issue={issue}
+                  picked={issue.identifier === picked}
+                  onPick={onPick}
+                  onWorkOn={onWorkOn}
+                />
+              ))}
+            </Group>
+          ))}
 
         {/* Done and Cancelled are always here and always start closed. Finished
             work is most of a workspace and almost never what the page was
@@ -241,35 +253,37 @@ export default function IssuesView({
             a filter they have to find first is worse than a heading they can
             see. Nothing is fetched until one is opened: the headings cost a
             round trip only when somebody asks a question of them. */}
-        {SETTLED_KINDS.map(({ key, label }) => {
-          const group = settledGroups.find((g) => g.key === key);
+        {loaded &&
+          SETTLED_KINDS.map(({ key, label }) => {
+            const group = settledGroups.find((g) => g.key === key);
 
-          return (
-            <Group
-              key={key}
-              kind={key}
-              label={label}
-              count={settled.loaded ? (group?.issues.length ?? 0) : null}
-              collapsedByDefault
-              onFirstOpen={settled.request}
-            >
-              {settled.loading && !settled.loaded ? (
-                <p className="px-3 py-2 text-ui text-muted-foreground">Reading…</p>
-              ) : group ? (
-                group.issues.map((issue) => (
-                  <IssueRow
-                    key={issue.id}
-                    issue={issue}
-                    picked={issue.identifier === picked}
-                    onPick={onPick}
-                  />
-                ))
-              ) : (
-                <p className="px-3 py-2 text-ui text-muted-foreground">Nothing here.</p>
-              )}
-            </Group>
-          );
-        })}
+            return (
+              <Group
+                key={key}
+                kind={key}
+                label={label}
+                count={settled.loaded ? (group?.issues.length ?? 0) : null}
+                collapsedByDefault
+                onFirstOpen={settled.request}
+              >
+                {settled.loading && !settled.loaded ? (
+                  <p className="px-3 py-2 text-ui text-muted-foreground">Reading…</p>
+                ) : group ? (
+                  group.issues.map((issue) => (
+                    <IssueRow
+                      key={issue.id}
+                      issue={issue}
+                      picked={issue.identifier === picked}
+                      onPick={onPick}
+                      onWorkOn={onWorkOn}
+                    />
+                  ))
+                ) : (
+                  <p className="px-3 py-2 text-ui text-muted-foreground">Nothing here.</p>
+                )}
+              </Group>
+            );
+          })}
       </div>
     </div>
   );
@@ -519,20 +533,27 @@ function FilterMenu({
 /// with. Linear is still one click away — the pane's own row carries the
 /// button — but it is the second thing offered rather than the first.
 ///
-/// No start button. It would have to name a project, and this page is
-/// workspace-wide — so the button either guesses which repo the work belongs in
-/// or grows a picker of its own beside every row. Tagging a session with `#` in
-/// the composer already starts work against an issue, from a place that knows
-/// which project it is in.
+/// "Work on it" starts nothing. It cannot: this page is workspace-wide, so a
+/// button that spawned a session would have to guess which repo the work belongs
+/// in. It hands the reader to the empty composer with the issue already tagged
+/// instead — which is the one place that *does* know how to ask, since the
+/// project, the model and the harness are all still sitting there unpicked.
 function IssueRow({
   issue,
   picked,
   onPick,
+  onWorkOn,
 }: {
   issue: Issue;
   picked: boolean;
   onPick: (issue: Issue) => void;
+  onWorkOn: (issue: Issue) => void;
 }) {
+  const workOn = (e: SyntheticEvent) => {
+    e.stopPropagation();
+    onWorkOn(issue);
+  };
+
   return (
     <button
       type="button"
@@ -561,6 +582,34 @@ function IssueRow({
           {issue.project}
         </span>
       )}
+
+      {/* A span carrying `buttonVariants` rather than a `Button`, because the
+          row itself is a button and a nested one is invalid markup — the click
+          would open the pane instead. Same bargain `FileLink` makes, and
+          `stopPropagation` on the key as well as the click is what keeps them
+          apart.
+
+          Its slot is reserved whether or not it is drawn: revealed by adding
+          width, the whole row would shift under the cursor that revealed it.
+          Hidden by opacity rather than `display`, or it could not be reached by
+          keyboard at all. */}
+      <span
+        role="button"
+        tabIndex={0}
+        onClick={workOn}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter" && e.key !== " ") return;
+          e.preventDefault();
+          workOn(e);
+        }}
+        className={cn(
+          buttonVariants({ variant: "ghost", size: "xs" }),
+          "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100",
+        )}
+      >
+        Work on it
+        <Plus data-icon="inline-end" />
+      </span>
 
       {/* Who has it. Unassigned draws nothing rather than a placeholder head:
           the question is "whose is this", and a row with no answer should read

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -205,6 +205,10 @@ type RightPanelProps = {
   /// Absent on the issues page, which is showing somebody else's issue and has
   /// no working directory of its own.
   cwd?: string | null;
+  /// Drawn at the far end of the top strip, ahead of Open and Refresh. For an
+  /// action belonging to whatever the pane is showing rather than to one tab —
+  /// the issues page's "Work on it" is the only one today.
+  actions?: React.ReactNode;
   /// A word in the top strip in place of the tab row.
   ///
   /// For a pane with one thing in it and no second thing to switch to. A row of
@@ -254,6 +258,7 @@ export default function RightPanel({
   issue = false,
   refresh,
   cwd,
+  actions,
   heading,
   children,
 }: RightPanelProps) {
@@ -348,6 +353,8 @@ export default function RightPanel({
             Refresh is gone on Subagents and the Open button is gone off a
             session, so whichever survives has to hold the same edge. */}
         <div className="ml-auto flex shrink-0 items-center gap-1">
+          {actions}
+
           {/* Ahead of Refresh, and outside the tab row's own logic: it acts on
               the session rather than on whatever tab is open, so unlike Refresh
               it does not change meaning from one tab to the next. */}

--- a/apps/desktop/src/components/composer/ProjectSelector.tsx
+++ b/apps/desktop/src/components/composer/ProjectSelector.tsx
@@ -1,4 +1,4 @@
-import { FolderPlus } from "lucide-react";
+import { Folder, FolderPlus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -47,8 +47,13 @@ export default function ProjectSelector({
           type="button"
           variant="ghost"
           size="sm"
-          className="max-w-40 px-1.5 text-ui text-muted-foreground"
+          className="max-w-40 gap-1.5 px-1.5 text-ui text-muted-foreground"
         >
+          {/* Same slot and same size as the branch picker's glyph beside it —
+              the row reads as one set of controls or as three unrelated ones.
+              Filled, since lucide draws a folder as an outline and at 14px the
+              open shape reads as a shard rather than a folder. */}
+          <Folder className="size-3.5 shrink-0 fill-current" />
           <span className="truncate">
             {value ? basename(value) : "Attach project"}
           </span>

--- a/apps/desktop/src/hooks/useIssues.ts
+++ b/apps/desktop/src/hooks/useIssues.ts
@@ -295,6 +295,10 @@ export function useIssues(active: boolean) {
     query,
     setQuery,
     loading: open.loading || settled.loading,
+    /// Whether the open list has ever answered. `issues.length` cannot say it:
+    /// an empty workspace and a first read still in flight both read as zero
+    /// rows, and the page draws them differently.
+    loaded: open.loaded,
     // The open half's failure is the one worth a banner: it is the list the
     // page is *for*, and a settled group that could not be read says so by
     // staying empty under a header the reader opened.


### PR DESCRIPTION
## TLDR for human

- **Work on it** on the issues page — list row and detail pane — takes you to the empty composer with the issue tagged, so project, model and harness are still yours to pick.
- The list now waits on its first read instead of showing Done and Cancelled alone for a beat.
- The composer's project picker gains a filled folder glyph.

---

The button starts nothing, and cannot: the issues page is workspace-wide, so anything spawning a session would have to guess which repo the work belongs in. It lands in the composer instead — the one place that already knows how to ask.

The tag is the whole handoff. `expand_tags` resolves `#DRA-129 …` out of the prompt text on send, so nothing is linked here and no new wire surface was needed.

Two placements, two shapes:

- **List row** — ghost, `+` trailing, revealed on hover and on keyboard focus, in a slot reserved at rest so the row cannot shift under the cursor that revealed it. A `span` carrying `buttonVariants` rather than a `Button`, since the row itself is a button.
- **Detail pane** — secondary, in the top strip beside Refresh, through a new `actions` slot on `RightPanel`. It acts on the pane's whole subject, which is the slot Open takes for a session.

The loading state is the other half. `useIssues` now exposes `loaded` — `issues.length` cannot tell an empty workspace from a read still in flight — and the page draws one "Reading…" line until it answers. The settled headings are gated on it too: they were the only part of the list that could draw without an answer, so a page opening on nothing but *Done* and *Cancelled* read as a workspace with nothing left to do.

Fixes DRA-129
