### PR TITLE
Stop the abort on quit

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -821,6 +821,13 @@ pub fn run() {
             // kill still gets past this — see `Known issues`.
             if matches!(event, tauri::RunEvent::Exit) {
                 transcription::audio::restore_other_audio();
+                // Tao ends the process with `process::exit`, which runs the C
+                // atexit chain — and ggml-metal's global device registry frees
+                // its Metal residency sets there, after the Metal runtime is
+                // already down, and `ggml_abort`s. So every quit filed a crash
+                // report. `process::exit` skips every Rust destructor anyway,
+                // so skipping the C half too costs nothing we still rely on.
+                unsafe { libc::_exit(0) }
             }
         });
 }


### PR DESCRIPTION
Quitting filed a crash report every time once transcription had loaded a model:

```
abort → ggml_abort → ggml_metal_rsets_free → ggml_metal_device_free
     → ~vector<unique_ptr<ggml_metal_device>> → __cxa_finalize_ranges
     → exit → std::process::exit → tao EventLoop::run
```

Tao ends the process with `process::exit`, which runs the C atexit chain. ggml-metal's global device registry frees its Metal residency sets there, after the Metal runtime is already down, and `ggml_abort`s.

`RunEvent::Exit` now ends the process with `libc::_exit(0)` after restoring muted audio. `process::exit` already skips every Rust destructor, so skipping the C half costs nothing we still rely on.

Verified against a debug bundle: launch, dictate, quit — no new report in `~/Library/Logs/DiagnosticReports`.

Fixes DRA-135