### PR TITLE
Find agent CLIs installed through version managers

### DIFF
--- a/apps/desktop/src-tauri/src/binpath.rs
+++ b/apps/desktop/src-tauri/src/binpath.rs
@@ -223,8 +223,13 @@ pub async fn agent_binary(harness: Harness) -> PathBuf {
 /// we actually have. A binary that cannot be run at all answers `false`, which
 /// puts it behind the next candidate rather than failing the resolution.
 async fn speaks_app_server(bin: &Path) -> bool {
+    // The candidate's own dir goes on `PATH` for the same reason the child's
+    // does: an npm codex is a `node` script, and this probe runs before
+    // anything is cached for `resolved_bin_dirs` to hand back.
+    let extra = bin.parent().map(Path::to_path_buf).into_iter().collect();
     let Ok(output) = Command::new(bin)
         .arg("--help")
+        .env("PATH", child_path(extra))
         .output()
         .await
     else {
@@ -303,8 +308,10 @@ pub fn known_dirs() -> Vec<PathBuf> {
 /// directory a resolver landed in goes back to the child. Only cached answers
 /// are read, and every spawn site resolves its own binary before building the
 /// `PATH`, so the one it needs is always there.
-// ponytail: proto's npm globals sit in tools/node/globals/bin with node one
-// dir over; add ~/.proto/shims here if that ever bites.
+///
+/// A `node` found by the same walk goes with them, since it is not always a
+/// sibling: mise's npm backend puts the CLI under `installs/npm-<pkg>` and
+/// node under `installs/node`, proto puts globals one dir over from its node.
 pub fn resolved_bin_dirs() -> Vec<PathBuf> {
     [CLAUDE_PATH.get(), CODEX_PATH.get(), PI_PATH.get()]
         .into_iter()
@@ -312,7 +319,49 @@ pub fn resolved_bin_dirs() -> Vec<PathBuf> {
         .chain(GH_PATH.get().into_iter().flatten())
         .filter(|path| path.is_absolute())
         .filter_map(|path| path.parent().map(Path::to_path_buf))
+        .chain(node_dir().cloned())
         .collect()
+}
+
+static NODE_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// The `bin` holding a `node`, looked for exactly as the CLIs are but with no
+/// shell probe — a `node` only the shell knows about is one the child would
+/// see anyway if the shell's `PATH` were inherited, and it is not.
+fn node_dir() -> Option<&'static PathBuf> {
+    NODE_DIR
+        .get_or_init(|| {
+            search_path("node")
+                .or_else(|| search_known_dirs("node"))
+                .and_then(|node| node.parent().map(Path::to_path_buf))
+        })
+        .as_ref()
+}
+
+/// The `PATH` for a child this app spawns: the inherited one, then `extra`,
+/// then [`known_dirs`] — each once. `extra` ahead of the fixed list, since a
+/// CLI resolved out of a version manager wants *its* sibling `node`, not
+/// whichever shim `~/.volta/bin` or `~/.n/bin` happens to hold.
+pub fn child_path(extra: Vec<PathBuf>) -> String {
+    let inherited = std::env::var_os("PATH").unwrap_or_default();
+    let mut dirs = extra;
+    dirs.extend(known_dirs());
+    with_dirs(&inherited, dirs)
+}
+
+/// `inherited` with each of `extra` appended once, in order.
+fn with_dirs(inherited: &std::ffi::OsStr, extra: Vec<PathBuf>) -> String {
+    let mut dirs: Vec<PathBuf> = std::env::split_paths(inherited).collect();
+
+    for dir in extra {
+        if !dirs.contains(&dir) {
+            dirs.push(dir);
+        }
+    }
+
+    std::env::join_paths(dirs)
+        .map(|joined| joined.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| inherited.to_string_lossy().into_owned())
 }
 
 /// The directories `claude` actually installs to, checked directly so the
@@ -484,6 +533,53 @@ mod tests {
         assert_eq!(find_versioned(&root.join("nope"), 2, layouts, "pi"), None);
 
         std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// launchd's `PATH` plus a CLI resolved out of a version manager's bin:
+    /// that bin must be on the child's `PATH` — or the script's `env node`
+    /// finds nothing — and ahead of the fixed list, or a `node` shim there
+    /// wins over the sibling the CLI was installed against. Each dir once.
+    #[test]
+    fn a_resolved_bin_dir_comes_after_inherited_and_before_known() {
+        let launchd = std::ffi::OsStr::new("/usr/bin:/bin:/usr/sbin:/sbin");
+        let nvm_bin = PathBuf::from("/home/u/.nvm/versions/node/v25.2.1/bin");
+        let volta = PathBuf::from("/home/u/.volta/bin");
+
+        let path = with_dirs(
+            launchd,
+            vec![PathBuf::from("/bin"), nvm_bin.clone(), nvm_bin, volta],
+        );
+
+        assert_eq!(
+            path,
+            "/usr/bin:/bin:/usr/sbin:/sbin:/home/u/.nvm/versions/node/v25.2.1/bin:/home/u/.volta/bin"
+        );
+    }
+
+    /// An npm codex is a script whose interpreter sits beside it, and the probe
+    /// runs before any cache could put that dir on `PATH`. A fake interpreter
+    /// stands in for `node`; the probe passes only if the candidate's own dir
+    /// was handed to it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_app_server_probe_finds_the_interpreter_beside_the_candidate() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join("dray-binpath-probe-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let script = |name: &str, body: &str| {
+            let path = dir.join(name);
+            std::fs::write(&path, body).unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+            path
+        };
+        script("dray-fake-node", "#!/bin/sh\necho 'codex app-server'\n");
+        let codex = script("codex", "#!/usr/bin/env dray-fake-node\n");
+
+        assert!(speaks_app_server(&codex).await);
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/binpath.rs
+++ b/apps/desktop/src-tauri/src/binpath.rs
@@ -223,10 +223,15 @@ pub async fn agent_binary(harness: Harness) -> PathBuf {
 /// we actually have. A binary that cannot be run at all answers `false`, which
 /// puts it behind the next candidate rather than failing the resolution.
 async fn speaks_app_server(bin: &Path) -> bool {
-    // The candidate's own dir goes on `PATH` for the same reason the child's
-    // does: an npm codex is a `node` script, and this probe runs before
-    // anything is cached for `resolved_bin_dirs` to hand back.
-    let extra = bin.parent().map(Path::to_path_buf).into_iter().collect();
+    // The candidate's own dir and a `node` go on `PATH` for the same reason
+    // the child's do: an npm codex is a `node` script, and this probe runs
+    // before anything is cached for `resolved_bin_dirs` to hand back.
+    let extra = bin
+        .parent()
+        .map(Path::to_path_buf)
+        .into_iter()
+        .chain(node_dir().cloned())
+        .collect();
     let Ok(output) = Command::new(bin)
         .arg("--help")
         .env("PATH", child_path(extra))

--- a/apps/desktop/src-tauri/src/binpath.rs
+++ b/apps/desktop/src-tauri/src/binpath.rs
@@ -159,6 +159,9 @@ mod pi_resolution_tests {
     #[ignore]
     async fn where_pi_resolves_to() {
         println!("pi -> {}", super::pi().await.display());
+        // The mise branch alone, since any earlier hit hides it above.
+        let mise = dirs::home_dir().unwrap().join(".local/share/mise/installs");
+        println!("mise pi -> {:?}", super::find_versioned(&mise, 2, &["bin", "", "pi"], "pi"));
     }
 }
 
@@ -272,6 +275,20 @@ pub fn known_dirs() -> Vec<PathBuf> {
         home.join(".claude/local"),
         home.join(".bun/bin"),
         home.join(".npm-global/bin"),
+        // Managers whose shims run on their own, found by absolute path. asdf's
+        // and mise's do not — one is a script calling `asdf`, the other refuses
+        // a tool pinned in no config — so those are globbed by install below.
+        home.join(".volta/bin"),
+        home.join("Library/pnpm"),
+        home.join(".local/share/pnpm"),
+        home.join(".yarn/bin"),
+        home.join(".n/bin"),
+        // Nix keeps binaries in the store; these profile links are how they
+        // reach a PATH. The second is home-manager's per-user profile.
+        home.join(".nix-profile/bin"),
+        PathBuf::from("/etc/profiles/per-user")
+            .join(home.file_name().unwrap_or_default())
+            .join("bin"),
         PathBuf::from("/opt/homebrew/bin"),
         PathBuf::from("/usr/local/bin"),
     ]
@@ -292,14 +309,63 @@ fn search_known_dirs(bin: &str) -> Option<PathBuf> {
         return Some(found);
     }
 
-    // nvm keeps one bin directory per installed Node version, so the path
-    // depends on which version is current — glob the versions rather than
-    // guessing one.
-    let versions = std::fs::read_dir(home.join(".nvm/versions/node")).ok()?;
-    versions
-        .flatten()
-        .map(|entry| entry.path().join("bin").join(bin))
-        .find(|candidate| is_executable(candidate))
+    // Version managers keep one directory per installed version, so the path
+    // depends on which is current — glob the versions rather than guess one.
+    // Each row: the root, how many directory levels sit between it and a
+    // version, and where the binary lives relative to that version.
+    let versioned: [(PathBuf, usize, &[&str]); 7] = [
+        (home.join(".nvm/versions/node"), 1, &["bin"]),
+        (home.join(".nodenv/versions"), 1, &["bin"]),
+        (
+            home.join("Library/Application Support/fnm/node-versions"),
+            1,
+            &["installation/bin"],
+        ),
+        (home.join(".local/share/fnm/node-versions"), 1, &["installation/bin"]),
+        // installs/<tool>/<version>/bin — `<tool>` is `nodejs` for an `npm -g`
+        // under an asdf node, or the plugin's own name.
+        (home.join(".asdf/installs"), 2, &["bin"]),
+        // tools/<tool>/<version>/bin; an `npm -g` under a proto node lands in
+        // tools/node/globals/bin, which the same walk reaches.
+        (home.join(".proto/tools"), 2, &["bin"]),
+        // Same shape, but mise unpacks a release as it ships, so the binary
+        // sits wherever the archive put it: `bin`, the version root, or one
+        // level in under the tool's name (`installs/pi/latest/pi/pi`). Globbed
+        // across every tool rather than `installs/<bin>`, since a CLI lands
+        // under `node` (npm -g), its registry name (`claude`, `claude-code`,
+        // `codex`) or `npm-<package>` depending on how it was asked for.
+        (home.join(".local/share/mise/installs"), 2, &["bin", "", bin]),
+    ];
+    versioned
+        .iter()
+        .find_map(|(root, depth, layouts)| find_versioned(root, *depth, layouts, bin))
+}
+
+/// Looks for `bin` under every directory `depth` levels below `root`, trying
+/// each layout as a path relative to it. A missing `root` is ordinary rather
+/// than an error — most machines have at most one of these managers.
+///
+/// Walked in reverse lexical order so `latest` (mise's symlink) outranks any
+/// numbered directory.
+// ponytail: lexical, so 0.9 beats 0.10 — a semver sort if that ever bites.
+fn find_versioned(root: &Path, depth: usize, layouts: &[&str], bin: &str) -> Option<PathBuf> {
+    let mut dirs = vec![root.to_path_buf()];
+    for _ in 0..depth {
+        dirs = dirs
+            .iter()
+            .filter_map(|dir| std::fs::read_dir(dir).ok())
+            .flatten()
+            .flatten()
+            .map(|entry| entry.path())
+            .collect();
+    }
+    dirs.sort();
+    dirs.into_iter().rev().find_map(|version| {
+        layouts
+            .iter()
+            .map(|layout| version.join(layout).join(bin))
+            .find(|candidate| is_executable(candidate))
+    })
 }
 
 /// Asks the user's login shell where `bin` is, which is the only way to see a
@@ -367,6 +433,36 @@ mod tests {
     #[tokio::test]
     async fn a_missing_binary_resolves_to_none() {
         assert!(resolve("dray-definitely-not-a-real-binary").await.is_none());
+    }
+
+    /// mise's nesting is the layout that went missing: `installs/<tool>/<v>/`
+    /// with the binary one level further in under the tool's own name.
+    #[test]
+    fn finds_a_binary_nested_under_a_version_dir() {
+        let root = std::env::temp_dir().join("dray-binpath-versioned-test");
+        let _ = std::fs::remove_dir_all(&root);
+        let place = |rel: &str| {
+            let bin = root.join(rel);
+            std::fs::create_dir_all(bin.parent().unwrap()).unwrap();
+            std::fs::write(&bin, "").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+            bin
+        };
+        let _numbered = place("pi/0.84.4/pi/pi");
+        let latest = place("pi/latest/pi/pi");
+        let under_node = place("node/22.0.0/bin/claude");
+
+        let layouts: &[&str] = &["bin", "", "pi"];
+        assert_eq!(find_versioned(&root, 2, layouts, "pi"), Some(latest));
+        assert_eq!(find_versioned(&root, 2, &["bin"], "claude"), Some(under_node));
+        assert_eq!(find_versioned(&root, 2, &["bin"], "pi"), None);
+        assert_eq!(find_versioned(&root.join("nope"), 2, layouts, "pi"), None);
+
+        std::fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/binpath.rs
+++ b/apps/desktop/src-tauri/src/binpath.rs
@@ -294,6 +294,27 @@ pub fn known_dirs() -> Vec<PathBuf> {
     ]
 }
 
+/// The directory each resolved CLI sits in, for the child's `PATH`.
+///
+/// An npm-installed CLI is a `#!/usr/bin/env node` script, and under a version
+/// manager `node` lives beside it in a per-version `bin` that [`known_dirs`]
+/// cannot name. Resolving the script and spawning it under launchd's `PATH`
+/// then fails with `env: node: No such file or directory` — so whatever
+/// directory a resolver landed in goes back to the child. Only cached answers
+/// are read, and every spawn site resolves its own binary before building the
+/// `PATH`, so the one it needs is always there.
+// ponytail: proto's npm globals sit in tools/node/globals/bin with node one
+// dir over; add ~/.proto/shims here if that ever bites.
+pub fn resolved_bin_dirs() -> Vec<PathBuf> {
+    [CLAUDE_PATH.get(), CODEX_PATH.get(), PI_PATH.get()]
+        .into_iter()
+        .flatten()
+        .chain(GH_PATH.get().into_iter().flatten())
+        .filter(|path| path.is_absolute())
+        .filter_map(|path| path.parent().map(Path::to_path_buf))
+        .collect()
+}
+
 /// The directories `claude` actually installs to, checked directly so the
 /// common bundle launch never pays for a shell spawn. Not exhaustive by design
 /// — [`login_shell_which`] is the general answer, this is the fast path.

--- a/apps/desktop/src-tauri/src/harness/claude_code/claude_code.rs
+++ b/apps/desktop/src-tauri/src/harness/claude_code/claude_code.rs
@@ -124,7 +124,8 @@ pub async fn init(
 
     // Resolved rather than spawned by bare name: a bundled `.app` launched from
     // Finder inherits launchd's `PATH`, which holds no `claude`.
-    let mut command = Command::new(crate::binpath::claude().await);
+    let bin = crate::binpath::claude().await;
+    let mut command = Command::new(&bin);
 
     // Which app the agent's own `dray` calls reach. Set because dev and release
     // builds listen on different sockets and the CLI's default names the
@@ -140,7 +141,7 @@ pub async fn init(
         // How the CLI knows which session is calling it, which is what links a
         // spawned session to its parent and what the depth cap reads.
         .env("DRAY_SESSION_ID", session_id)
-        .env("PATH", crate::harness::agent_path())
+        .env("PATH", crate::harness::agent_path(&bin))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/apps/desktop/src-tauri/src/harness/codex/codex.rs
+++ b/apps/desktop/src-tauri/src/harness/codex/codex.rs
@@ -126,7 +126,8 @@ pub async fn init(
         next_seq_by_session_id(session_id).await?
     };
 
-    let mut command = Command::new(crate::binpath::codex().await);
+    let bin = crate::binpath::codex().await;
+    let mut command = Command::new(&bin);
 
     if let Some(endpoint) = crate::orchestration::child_endpoint() {
         command.env("DRAY_ENDPOINT", endpoint);
@@ -136,7 +137,7 @@ pub async fn init(
         .arg("app-server")
         .current_dir(cwd)
         .env("DRAY_SESSION_ID", session_id)
-        .env("PATH", crate::harness::agent_path())
+        .env("PATH", crate::harness::agent_path(&bin))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/apps/desktop/src-tauri/src/harness/harness.rs
+++ b/apps/desktop/src-tauri/src/harness/harness.rs
@@ -26,11 +26,22 @@ use std::path::PathBuf;
 /// two name the same binary.
 ///
 /// Shared by both harnesses because the trap is the bundle's, not the CLI's.
+///
+/// The directory each resolved CLI was found in rides along too: an
+/// npm-installed one is a `node` script, and under a version manager `node`
+/// sits in that same per-version `bin` and nowhere the fixed list names.
 pub fn agent_path() -> String {
     let inherited = std::env::var_os("PATH").unwrap_or_default();
-    let mut dirs: Vec<PathBuf> = std::env::split_paths(&inherited).collect();
+    let mut extra = crate::binpath::known_dirs();
+    extra.extend(crate::binpath::resolved_bin_dirs());
+    with_dirs(&inherited, extra)
+}
 
-    for dir in crate::binpath::known_dirs() {
+/// `inherited` with each of `extra` appended once, in order.
+fn with_dirs(inherited: &std::ffi::OsStr, extra: Vec<PathBuf>) -> String {
+    let mut dirs: Vec<PathBuf> = std::env::split_paths(inherited).collect();
+
+    for dir in extra {
         if !dirs.contains(&dir) {
             dirs.push(dir);
         }
@@ -39,6 +50,28 @@ pub fn agent_path() -> String {
     std::env::join_paths(dirs)
         .map(|joined| joined.to_string_lossy().into_owned())
         .unwrap_or_else(|_| inherited.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod path_tests {
+    use super::with_dirs;
+    use std::path::PathBuf;
+
+    /// launchd's `PATH` plus a CLI resolved out of a version manager's bin:
+    /// that bin must be on the child's `PATH`, or the script's `env node`
+    /// finds nothing. Appended after the inherited dirs, and once.
+    #[test]
+    fn a_resolved_bin_dir_is_put_back_after_the_inherited_path() {
+        let launchd = std::ffi::OsStr::new("/usr/bin:/bin:/usr/sbin:/sbin");
+        let nvm_bin = PathBuf::from("/home/u/.nvm/versions/node/v25.2.1/bin");
+
+        let path = with_dirs(launchd, vec![PathBuf::from("/bin"), nvm_bin.clone(), nvm_bin]);
+
+        assert_eq!(
+            path,
+            "/usr/bin:/bin:/usr/sbin:/sbin:/home/u/.nvm/versions/node/v25.2.1/bin"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/harness/harness.rs
+++ b/apps/desktop/src-tauri/src/harness/harness.rs
@@ -13,7 +13,6 @@ pub mod codex;
 pub mod pi;
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 
 /// The child's `PATH`: the inherited one with the user-bin directories put
 /// back.
@@ -27,51 +26,12 @@ use std::path::PathBuf;
 ///
 /// Shared by both harnesses because the trap is the bundle's, not the CLI's.
 ///
-/// The directory each resolved CLI was found in rides along too: an
-/// npm-installed one is a `node` script, and under a version manager `node`
-/// sits in that same per-version `bin` and nowhere the fixed list names.
+/// The directory each resolved CLI was found in rides along too, and a `node`
+/// found the same way: an npm-installed CLI is a `node` script, and under a
+/// version manager `node` sits in a per-version `bin` the fixed list cannot
+/// name.
 pub fn agent_path() -> String {
-    let inherited = std::env::var_os("PATH").unwrap_or_default();
-    let mut extra = crate::binpath::known_dirs();
-    extra.extend(crate::binpath::resolved_bin_dirs());
-    with_dirs(&inherited, extra)
-}
-
-/// `inherited` with each of `extra` appended once, in order.
-fn with_dirs(inherited: &std::ffi::OsStr, extra: Vec<PathBuf>) -> String {
-    let mut dirs: Vec<PathBuf> = std::env::split_paths(inherited).collect();
-
-    for dir in extra {
-        if !dirs.contains(&dir) {
-            dirs.push(dir);
-        }
-    }
-
-    std::env::join_paths(dirs)
-        .map(|joined| joined.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| inherited.to_string_lossy().into_owned())
-}
-
-#[cfg(test)]
-mod path_tests {
-    use super::with_dirs;
-    use std::path::PathBuf;
-
-    /// launchd's `PATH` plus a CLI resolved out of a version manager's bin:
-    /// that bin must be on the child's `PATH`, or the script's `env node`
-    /// finds nothing. Appended after the inherited dirs, and once.
-    #[test]
-    fn a_resolved_bin_dir_is_put_back_after_the_inherited_path() {
-        let launchd = std::ffi::OsStr::new("/usr/bin:/bin:/usr/sbin:/sbin");
-        let nvm_bin = PathBuf::from("/home/u/.nvm/versions/node/v25.2.1/bin");
-
-        let path = with_dirs(launchd, vec![PathBuf::from("/bin"), nvm_bin.clone(), nvm_bin]);
-
-        assert_eq!(
-            path,
-            "/usr/bin:/bin:/usr/sbin:/sbin:/home/u/.nvm/versions/node/v25.2.1/bin"
-        );
-    }
+    crate::binpath::child_path(crate::binpath::resolved_bin_dirs())
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/harness/harness.rs
+++ b/apps/desktop/src-tauri/src/harness/harness.rs
@@ -33,7 +33,14 @@ use serde::{Deserialize, Serialize};
 /// beside rather than another harness's — a Claude on nvm's node 18 must not
 /// pick the interpreter for a pi installed against fnm's node 22.
 pub fn agent_path(bin: &std::path::Path) -> String {
-    let mut dirs: Vec<std::path::PathBuf> = bin.parent().map(Into::into).into_iter().collect();
+    // A bare-name fallback's parent is `""`, and an empty `PATH` segment is
+    // the working directory — a same-named file in the project would run.
+    let mut dirs: Vec<std::path::PathBuf> = bin
+        .is_absolute()
+        .then(|| bin.parent().map(Into::into))
+        .flatten()
+        .into_iter()
+        .collect();
     dirs.extend(crate::binpath::resolved_bin_dirs());
     crate::binpath::child_path(dirs)
 }
@@ -54,6 +61,15 @@ mod path_tests {
 
         assert_eq!(&dirs[..inherited.len()], &inherited[..]);
         assert_eq!(dirs[inherited.len()], bin.parent().unwrap());
+    }
+
+    /// A bare-name fallback must add nothing: its parent is `""`, which as a
+    /// `PATH` segment is the working directory.
+    #[test]
+    fn a_bare_name_adds_no_empty_segment() {
+        let path = super::agent_path(std::path::Path::new("pi"));
+
+        assert!(!path.split(':').any(str::is_empty), "{path}");
     }
 }
 

--- a/apps/desktop/src-tauri/src/harness/harness.rs
+++ b/apps/desktop/src-tauri/src/harness/harness.rs
@@ -29,9 +29,32 @@ use serde::{Deserialize, Serialize};
 /// The directory each resolved CLI was found in rides along too, and a `node`
 /// found the same way: an npm-installed CLI is a `node` script, and under a
 /// version manager `node` sits in a per-version `bin` the fixed list cannot
-/// name.
-pub fn agent_path() -> String {
-    crate::binpath::child_path(crate::binpath::resolved_bin_dirs())
+/// name. `bin`'s own dir leads, so a CLI runs on the `node` it was installed
+/// beside rather than another harness's — a Claude on nvm's node 18 must not
+/// pick the interpreter for a pi installed against fnm's node 22.
+pub fn agent_path(bin: &std::path::Path) -> String {
+    let mut dirs: Vec<std::path::PathBuf> = bin.parent().map(Into::into).into_iter().collect();
+    dirs.extend(crate::binpath::resolved_bin_dirs());
+    crate::binpath::child_path(dirs)
+}
+
+#[cfg(test)]
+mod path_tests {
+    /// The spawned binary's own dir is the first thing after the inherited
+    /// `PATH`, ahead of every other harness's cached dir — so its `env node`
+    /// lands on the node it was installed beside.
+    #[test]
+    fn the_spawned_binary_dir_leads_the_additions() {
+        let bin = std::path::Path::new("/home/u/.fnm/node-versions/v22/installation/bin/pi");
+        let inherited: Vec<std::path::PathBuf> =
+            std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()).collect();
+
+        let path = super::agent_path(bin);
+        let dirs: Vec<std::path::PathBuf> = std::env::split_paths(&path).collect();
+
+        assert_eq!(&dirs[..inherited.len()], &inherited[..]);
+        assert_eq!(dirs[inherited.len()], bin.parent().unwrap());
+    }
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/harness/pi/commands.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/commands.rs
@@ -104,7 +104,8 @@ pub async fn forget() {
 /// to where it runs, so a probe spawned anywhere else answers for the wrong
 /// project.
 async fn probe(cwd: &str) -> Result<Vec<SlashCommand>> {
-    let mut child = Command::new(crate::binpath::pi().await)
+    let bin = crate::binpath::pi().await;
+    let mut child = Command::new(&bin)
         .args([
             "--mode",
             "rpc",
@@ -114,7 +115,7 @@ async fn probe(cwd: &str) -> Result<Vec<SlashCommand>> {
             "--no-session",
         ])
         .current_dir(cwd)
-        .env("PATH", crate::harness::agent_path())
+        .env("PATH", crate::harness::agent_path(&bin))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())

--- a/apps/desktop/src-tauri/src/harness/pi/models.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/models.rs
@@ -82,7 +82,8 @@ pub async fn forget() {
 
 /// Spawns a throwaway pi, asks it, kills it.
 async fn probe() -> Result<Vec<Model>> {
-    let mut child = Command::new(crate::binpath::pi().await)
+    let bin = crate::binpath::pi().await;
+    let mut child = Command::new(&bin)
         .args([
             "--mode",
             "rpc",
@@ -91,7 +92,7 @@ async fn probe() -> Result<Vec<Model>> {
             // session list fills with empty runs Dray started.
             "--no-session",
         ])
-        .env("PATH", crate::harness::agent_path())
+        .env("PATH", crate::harness::agent_path(&bin))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())

--- a/apps/desktop/src-tauri/src/harness/pi/pi.rs
+++ b/apps/desktop/src-tauri/src/harness/pi/pi.rs
@@ -147,7 +147,8 @@ pub async fn init(
     args.push("--append-system-prompt".into());
     args.push(APPEND_SYSTEM_PROMPT.to_string());
 
-    let mut command = Command::new(crate::binpath::pi().await);
+    let bin = crate::binpath::pi().await;
+    let mut command = Command::new(&bin);
 
     // Which app the agent's own `dray` calls reach. Dev and release builds
     // listen on different sockets and the CLI's default names the release one.
@@ -159,7 +160,7 @@ pub async fn init(
         .args(args)
         .current_dir(cwd)
         .env("DRAY_SESSION_ID", session_id)
-        .env("PATH", crate::harness::agent_path())
+        .env("PATH", crate::harness::agent_path(&bin))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
Fixes DRA-139

A user reported Dray failed to detect a mise-managed `pi` at `~/.local/share/mise/installs/pi/latest/pi/pi`. A bundled app inherits launchd's PATH, so `binpath`'s known-dirs list is the only thing that can find a CLI, and it knew nvm alone among version managers.

- Glob the install layouts of mise, asdf, proto, fnm, nodenv and nvm (`find_versioned`, depth + layouts per manager)
- Add the fixed bin dirs of volta, pnpm, yarn, `n` and Nix profiles
- Skip mise/asdf shims: mise's refuses a tool pinned in no config, asdf's is a script needing `asdf` on PATH; both pass `is_executable`
- One resolver, so `claude`, `codex` and `gh` gain the same coverage

Verified against a real `mise install pi@latest`, which produced the reported layout exactly. Unit test pins the two-level shape and `latest` outranking a numbered dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)