### PR TITLE
Draw the first prompt before send_msg resolves on a new session

### DIFF
--- a/apps/desktop/src/components/chat/QueuedMessages.tsx
+++ b/apps/desktop/src/components/chat/QueuedMessages.tsx
@@ -1,8 +1,7 @@
 import ImageRow from "@/components/chat/ImageRow";
-import type { QueuedPrompt } from "@/hooks/useSessions";
+import { imagesOf, type QueuedPrompt } from "@/hooks/useSessions";
 import { SEGMENT_COLOR, highlightSegments, splitMention } from "@/lib/highlight";
 import { stripSenderPrefix } from "@/lib/relay";
-import type { Attachment, ImageRef } from "@/types/events";
 
 /// Prompts typed into the running turn that the app is still holding.
 ///
@@ -75,14 +74,3 @@ export default function QueuedMessages({ messages }: { messages: QueuedPrompt[] 
 
 /// The pictures among the attachments, in the shape the delivered bubble's row
 /// takes. A file draws nothing — see CLAUDE.md.
-///
-/// Through `url` and never `path`: the archived copy the asset protocol's scope
-/// allows is written at flush, so these still name where the user picked them
-/// from and `convertFileSrc` would resolve one to nothing.
-function imagesOf(attachments: Attachment[]): ImageRef[] {
-  return attachments.flatMap((attachment) =>
-    attachment.isImage && attachment.preview
-      ? [{ path: null, url: attachment.preview, mimeType: attachment.mimeType }]
-      : [],
-  );
-}

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -16,9 +16,20 @@ import { DEFAULT_MODEL_FOR, isUnsetModel, rememberedModel, usableModel } from "@
 import { notifyOS } from "@/lib/notify";
 import { stanceFor } from "@/lib/permission";
 import { playNotification } from "@/lib/sound";
-import { AgentEvent, ApprovalPolicy, Attachment, BackgroundTask, BranchList, Effort, Harness, IssueRef, Model, ModelId, Project, QueuedMessage, SendOutcome, SessionIndexItem, SessionSnapshot, SessionStatus, SessionStatusEvent, SessionTitleEvent } from "../types/events";
+import { AgentEvent, ApprovalPolicy, Attachment, BackgroundTask, BranchList, Effort, Harness, ImageRef, IssueRef, Model, ModelId, Project, QueuedMessage, SendOutcome, SessionIndexItem, SessionSnapshot, SessionStatus, SessionStatusEvent, SessionTitleEvent } from "../types/events";
 
 const DEFAULT_EFFORT: Effort = "high";
+
+/// Images for a prompt the backend has not archived yet, through `url` and never
+/// `path`: the copy the asset protocol's scope allows is written at flush, so
+/// the picked path would resolve to nothing.
+export function imagesOf(attachments: Attachment[]): ImageRef[] {
+  return attachments.flatMap((attachment) =>
+    attachment.isImage && attachment.preview
+      ? [{ path: null, url: attachment.preview, mimeType: attachment.mimeType }]
+      : [],
+  );
+}
 
 /// A held prompt and what it was sent with.
 ///
@@ -366,11 +377,47 @@ const withEarlyEvents = (snapshot: SessionSnapshot): SessionSnapshot => {
 // `withEarlyEvents`, and for the same reason it is exact.
 const mergeEvents = (into: SessionSnapshot, from: AgentEvent[]): SessionSnapshot => {
   const seen = new Set(into.events.map((e) => e.id));
-  const missing = from.filter((e) => !seen.has(e.id));
+  // A snapshot is read back from the log after the prompt landed, so it always
+  // carries the real prompt and the provisional one is retired here.
+  const missing = from.filter((e) => !seen.has(e.id) && !isProvisional(e));
   if (!missing.length) return into;
 
   return { ...into, events: [...into.events, ...missing].sort((a, b) => a.seq - b.seq) };
 };
+
+// The user's own prompt, drawn before the backend has answered for the session.
+// A new session's `send_msg` resolves only once the worktree is made, the child
+// spawned and the harness has taken the prompt — 1–2s on pi and Codex in a
+// worktree — and the real `user_message` is minted at the far end of that wait.
+// The id prefix is what retires it, on either path the real one can arrive by.
+const PROVISIONAL_PREFIX = "provisional:";
+const isProvisional = (e: AgentEvent) => e.id.startsWith(PROVISIONAL_PREFIX);
+
+const provisionalPrompt = (
+  sessionId: string,
+  harness: Harness,
+  text: string,
+  attachments: Attachment[],
+): AgentEvent => ({
+  id: `${PROVISIONAL_PREFIX}${sessionId}`,
+  sessionId,
+  harness,
+  seq: 0,
+  ts: new Date().toISOString(),
+  turnId: null,
+  subagent: null,
+  payload: {
+    type: "user_message",
+    text,
+    images: imagesOf(attachments),
+    issues: [],
+    baseline: null,
+    queued: false,
+    from: null,
+    cwd: null,
+  },
+  raw: null,
+});
 
 const upsertSession = (snapshot: SessionSnapshot) =>
   setSessions((prev) =>
@@ -439,7 +486,7 @@ const handleSendMsg = async (
   // title, the recorded branch — arrive with the snapshot and replace these.
   if (isNewSession) {
     const shell: SessionSnapshot = {
-      events: [],
+      events: [provisionalPrompt(sessionId, harness, message, attachments)],
       sessionId,
       harness,
       cwd,
@@ -1231,9 +1278,11 @@ useEffect(() => {
                 return prev;
             }
 
+            // The real prompt retires the provisional one drawn at send.
+            const settled = agentEvent.payload.type === "user_message";
             return prev.map((s) =>
                 s.sessionId === agentEvent.sessionId
-                ? { ...s, events: [...s.events, agentEvent] }
+                ? { ...s, events: [...(settled ? s.events.filter((e) => !isProvisional(e)) : s.events), agentEvent] }
                 : s,
             );
             });


### PR DESCRIPTION
Fixes DRA-138

On a new session the user's bubble appeared only when `send_msg` resolved. That call awaits Dray's own `git worktree add` (pi and Codex, since Claude's `-w` runs after spawn), the process spawn, and the harness handshake plus prompt ack. Measured ~0.8s in main, ~1.5–2s in a worktree on pi and Codex. Later prompts emit the `user_message` before any of that, so only the first lagged.

The shell row the frontend already creates now carries a provisional `user_message` with the text and image previews. The real event retires it on both paths: the live listener and the returned snapshot. `imagesOf` moved out of `QueuedMessages` so both draw previews the same way.

The backend wait itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)