### PR TITLE
Stop the merge button's spinner wobbling

### DIFF
--- a/apps/desktop/src/components/ui/spinner.tsx
+++ b/apps/desktop/src/components/ui/spinner.tsx
@@ -25,7 +25,17 @@ export default function Spinner({ className }: { className?: string }) {
       // `@keyframes` block for a name some `--animate-*` theme variable
       // reaches, so spelling the animation out by hand is how you get a rule
       // that references keyframes the build then leaves out.
-      className={cn("size-4 animate-spin [animation-duration:0.4s]", className)}
+      //
+      // `will-change-transform` is what stops the wobble, and it is about where
+      // the spinner sits rather than about this shape: unpromoted, Chromium
+      // re-rasterizes the rotating box every frame and snaps it to whole device
+      // pixels, so a 16px arc orbits by a subpixel. It only shows over the
+      // window's vibrancy — the PR panel's merge button wobbled where the
+      // composer's dictation spinner, on an opaque fill, did not.
+      className={cn(
+        "size-4 animate-spin will-change-transform [animation-duration:0.4s]",
+        className,
+      )}
       aria-hidden
     >
       <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.2" />


### PR DESCRIPTION
The spinner inside the PR panel's merge button orbits by a subpixel as it turns, reading as a wobble. The dictation spinner, the same component, looks fine.

Not the shape. Rendered against the real compiled Tailwind CSS with the button's exact class list: `transform-origin` is dead centre of a 16×16 box at an integer position, and `[animation-duration:0.4s]` does win the cascade.

It is where the spinner sits. Unpromoted, Chromium re-rasterizes the rotating box every frame and snaps it to whole device pixels. That only shows over the window's vibrancy — the PR panel — and not over the composer's opaque fill.

`will-change-transform` puts the rotation on its own compositor layer. On the shared component rather than the merge button, since the cause is the surface a spinner is drawn over and any future caller over glass hits the same thing. Nothing visible changes for dictation; it just stops being re-rasterized too.

Verified on a throwaway demo page driving the real `Readiness` through Merge → Confirm, with a promoted/unpromoted pair blown up beside it. Page is deleted.

Fixes DRA-142

🤖 Generated with [Claude Code](https://claude.com/claude-code)