### PR TITLE
Start a task from a sidebar project heading, and step projects with ⌘⇧P

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -953,6 +953,12 @@ function App() {
             goToSession(() => void handleSelectSessionIndexItem(sessionId))
           }
           onNewSession={() => goToSession(handleNewSession)}
+          onNewSessionInProject={(path) =>
+            goToSession(() => {
+              handleSelectProject(path);
+              handleNewSession();
+            })
+          }
           onOpenIssues={() => setIssuesOpen(true)}
           issuesOpen={issuesOpen}
           onDetach={detachSession}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -797,6 +797,20 @@ function App() {
   const toggleSidebar = () => setCollapsed((prev) => !prev);
   useHotkey("b", toggleSidebar);
   useHotkey("n", () => goToSession(handleNewSession));
+  // Steps the composer's project picker, and only while that picker is on
+  // screen: it is drawn for a new task alone, and `enabled` unregisters rather
+  // than no-opping, so a session's composer doesn't have ⌘⇧P eaten from it.
+  // Wraps, since one key with a clamp dead-ends on the last project with no way
+  // back. Nothing picked yet finds no index and lands on the first, which is
+  // also the answer for a project detached out from under the pick.
+  useHotkey(
+    "p",
+    () => {
+      const next = projects[(projects.findIndex((p) => p.path === projectPath) + 1) % projects.length];
+      if (next) handleSelectProject(next.path);
+    },
+    { shift: true, enabled: !selectedSessionId && !issuesOpen && projects.length > 1 },
+  );
   // ⌘⇧ rather than plain ⌘: the composer is focused most of the time, where
   // ⌘↑/↓ is the webview's own jump-to-start/end of the input.
   useHotkey("ArrowUp", () => goToSession(() => stepSession(-1)), { shift: true });

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -107,6 +107,10 @@ type SidebarProps = {
   // `null` is every project, and it is the entry the filter opens on.
   projectFilter: string | null;
   onProjectFilterChange: (path: string | null) => void;
+  /// Starts a new task with the composer's project picker already on this
+  /// project — the only thing a project heading can offer, since the picker is
+  /// hidden once a session exists.
+  onNewSessionInProject: (projectPath: string) => void;
   updateStatus: UpdateStatus | null;
   // Any session mid-turn, not just the open one — installing relaunches the
   // whole app.
@@ -635,6 +639,7 @@ export default function Sidebar({
   projectFilter,
   onDetach,
   onProjectFilterChange,
+  onNewSessionInProject,
   updateStatus,
   updateBlocked,
   updateManual,
@@ -927,9 +932,17 @@ export default function Sidebar({
                 )}
 
                 {heading !== null && (
-                  <div className="flex min-h-6 items-center truncate pr-2 pl-2 text-ui text-muted-foreground/70">
-                    {heading}
-                  </div>
+                  // A project heading is a way in to that project: clicking it
+                  // opens the empty composer already pointed there. Pinned is
+                  // not — it spans projects, so there is nothing to point at.
+                  <HeadingRow
+                    onClick={
+                      group.kind === "project"
+                        ? () => onNewSessionInProject(group.projectPath)
+                        : undefined
+                    }
+                    label={heading}
+                  />
                 )}
 
                 {group.rows.map(({ item, depth, guides, opens }) => (
@@ -1045,6 +1058,42 @@ const DOT_TRACK_W = DOT_PITCH * 5 - DOT_GAP;
 // Quiet alone was not enough — the tail can outlast a second deliberate swipe,
 // which is what made every other swipe do nothing.
 const SWIPE_PX = 36;
+/// A group heading, and where the group is a project, the button that starts a
+/// task in it. The plus only appears under the cursor: the row is a label first
+/// and every heading carrying one at rest would draw more chrome than the
+/// sessions beneath it.
+function HeadingRow({
+  onClick,
+  label,
+}: {
+  onClick?: () => void;
+  label: string;
+}) {
+  // `pr-0.5` is the session rows' own right inset, so the plus lands under their
+  // timestamps rather than short of them.
+  const shared =
+    "flex min-h-6 items-center truncate pr-0.5 pl-2 text-ui text-muted-foreground/70";
+
+  if (!onClick) return <div className={shared}>{label}</div>;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`New task in ${label}`}
+      // Hover stops short of `--foreground`: at full strength the heading became
+      // the brightest text in the pane, louder than the sessions it labels.
+      className={cn(
+        shared,
+        "group/heading w-full cursor-pointer text-left transition-colors duration-150 hover:text-foreground/75",
+      )}
+    >
+      <span className="truncate">{label}</span>
+      <Plus className="ml-auto size-3.5 shrink-0 opacity-0 transition-opacity duration-150 group-hover/heading:opacity-100" />
+    </button>
+  );
+}
+
 const SWIPE_END_MS = 120;
 const SWIPE_TAIL = 2;
 

--- a/apps/desktop/src/components/composer/ProjectSelector.tsx
+++ b/apps/desktop/src/components/composer/ProjectSelector.tsx
@@ -9,6 +9,12 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { basename } from "@/lib/format";
 import type { Project } from "@/types/events";
 
@@ -42,23 +48,39 @@ export default function ProjectSelector({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="max-w-40 gap-1.5 px-1.5 text-ui text-muted-foreground"
-        >
-          {/* Same slot and same size as the branch picker's glyph beside it —
-              the row reads as one set of controls or as three unrelated ones.
-              Filled, since lucide draws a folder as an outline and at 14px the
-              open shape reads as a shard rather than a folder. */}
-          <Folder className="size-3.5 shrink-0 fill-current" />
-          <span className="truncate">
-            {value ? basename(value) : "Attach project"}
-          </span>
-        </Button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="max-w-40 gap-1.5 px-1.5 text-ui text-muted-foreground"
+            >
+              {/* Same slot and same size as the branch picker's glyph beside it —
+                  the row reads as one set of controls or as three unrelated ones.
+                  Filled, since lucide draws a folder as an outline and at 14px the
+                  open shape reads as a shard rather than a folder. */}
+              <Folder className="size-3.5 shrink-0 fill-current" />
+              <span className="truncate">
+                {value ? basename(value) : "Attach project"}
+              </span>
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        {/* The chord steps to the next project rather than opening this menu,
+            so it is only worth saying where there is a next one. */}
+        {projects.length > 1 && (
+          <TooltipContent side="top" className="max-w-none whitespace-nowrap">
+            Next project
+            <KbdGroup>
+              <Kbd>⌘</Kbd>
+              <Kbd>Shift</Kbd>
+              <Kbd>P</Kbd>
+            </KbdGroup>
+          </TooltipContent>
+        )}
+      </Tooltip>
 
       <DropdownMenuContent align="start" className="min-w-52">
         <DropdownMenuRadioGroup value={value ?? ""} onValueChange={onSelect}>


### PR DESCRIPTION
A project heading in the sidebar was a label only. Hovering it now reveals a plus, and clicking opens the empty composer with that project already picked — the one place a project can be chosen, since the composer hides the picker once a session exists. Pinned draws no plus: it spans projects, so there is nothing to point at.

⌘⇧P steps the composer's project picker to the next project, wrapping. Bound only where that picker is drawn, so it never eats the key from a session's composer.

Fixes DRA-144