### PR TITLE
Read pi's edit keys, so a pi edit draws a diff

### DIFF
--- a/apps/desktop/src/components/chat/ToolCall.tsx
+++ b/apps/desktop/src/components/chat/ToolCall.tsx
@@ -46,6 +46,9 @@ const EDIT_FIELDS = [
   ...SUMMARY_FIELDS,
   "old_string",
   "new_string",
+  // pi's spelling of the same pair.
+  "oldText",
+  "newText",
   "content",
   "new_source",
   "edits",

--- a/apps/desktop/src/lib/diff.test.ts
+++ b/apps/desktop/src/lib/diff.test.ts
@@ -1,6 +1,54 @@
 import { describe, expect, it } from "vitest";
 
-import { countUnifiedChanges, diffSide, diffSides } from "./diff";
+import { countUnifiedChanges, diffSide, diffSides, editSides } from "./diff";
+
+describe("editSides", () => {
+  it("reads Claude Code's spelling, single and multi", () => {
+    expect(editSides({ file_path: "x.ts", old_string: "a", new_string: "b" })).toEqual({
+      path: "x.ts",
+      oldText: "a",
+      newText: "b",
+    });
+    expect(
+      editSides({
+        file_path: "x.ts",
+        edits: [
+          { old_string: "a", new_string: "b" },
+          { old_string: "c", new_string: "d" },
+        ],
+      }),
+    ).toEqual({ path: "x.ts", oldText: "a\nc", newText: "b\nd" });
+  });
+
+  // pi's edit tool is `{path, edits: [{oldText, newText}]}` — the same two
+  // shapes under different keys, and unread they left every pi edit drawing no
+  // diff at all.
+  it("reads pi's spelling, single and multi", () => {
+    expect(editSides({ path: "x.ts", oldText: "a", newText: "b" })).toEqual({
+      path: "x.ts",
+      oldText: "a",
+      newText: "b",
+    });
+    expect(
+      editSides({
+        path: "x.ts",
+        edits: [
+          { oldText: "a", newText: "b" },
+          { oldText: "c", newText: "d" },
+        ],
+      }),
+    ).toEqual({ path: "x.ts", oldText: "a\nc", newText: "b\nd" });
+  });
+
+  it("still reads a whole-file write as a creation", () => {
+    expect(editSides({ path: "x.ts", content: "n" })).toEqual({
+      path: "x.ts",
+      oldText: null,
+      newText: "n",
+    });
+    expect(editSides({ path: "x.ts" })).toBeNull();
+  });
+});
 
 describe("diffSide", () => {
   it("keys on full path and content, names by basename", () => {

--- a/apps/desktop/src/lib/diff.ts
+++ b/apps/desktop/src/lib/diff.ts
@@ -21,6 +21,15 @@ function obj(input: JsonValue): Record<string, JsonValue> | null {
   return input as Record<string, JsonValue>;
 }
 
+/// The replaced region of one edit, in either spelling: Claude Code writes
+/// `old_string`/`new_string`, pi writes `oldText`/`newText`.
+function pair(edit: Record<string, JsonValue>): readonly [string, string] {
+  return [
+    str(edit, "old_string") ?? str(edit, "oldText") ?? "",
+    str(edit, "new_string") ?? str(edit, "newText") ?? "",
+  ] as const;
+}
+
 /// Resolves a `file_edit` tool's input into the two sides of a diff, or null
 /// when the call carries nothing comparable.
 ///
@@ -32,6 +41,9 @@ function obj(input: JsonValue): Record<string, JsonValue> | null {
 ///   also the only region worth reading.
 /// - `MultiEdit` sends an `edits` array of those same pairs. They apply in
 ///   sequence to one file, so the sides are the concatenation of each end.
+/// - pi's `edit` is those same shapes spelled `oldText`/`newText`. Its `edits`
+///   entries match against the *original* file rather than in sequence, which
+///   changes nothing here: the sides are the replaced regions either way.
 /// - `Write` sends `content` and no prior text. Treated as a creation even when
 ///   it overwrites, since the call never reports what it replaced.
 export function editSides(input: JsonValue): EditSides | null {
@@ -46,7 +58,7 @@ export function editSides(input: JsonValue): EditSides | null {
     const pairs = edits
       .map(obj)
       .filter((e): e is Record<string, JsonValue> => e !== null)
-      .map((e) => [str(e, "old_string") ?? "", str(e, "new_string") ?? ""] as const)
+      .map(pair)
       .filter(([before, after]) => before !== "" || after !== "");
 
     if (!pairs.length) return null;
@@ -57,10 +69,9 @@ export function editSides(input: JsonValue): EditSides | null {
     };
   }
 
-  const oldText = str(root, "old_string");
-  const newText = str(root, "new_string");
-  if (oldText !== null || newText !== null) {
-    return { path, oldText: oldText ?? "", newText: newText ?? "" };
+  const [oldText, newText] = pair(root);
+  if (oldText !== "" || newText !== "") {
+    return { path, oldText, newText };
   }
 
   // NotebookEdit calls its payload `new_source`; Write calls it `content`.


### PR DESCRIPTION
pi's `edit` tool spells the replaced region `oldText`/`newText` — flat, or inside an `edits[]` array (schema pinned in pi 0.84.4's `edit.d.ts`). `editSides` read only Claude Code's `old_string`/`new_string`, so every pi edit resolved to null and the row printed its raw arguments where a diff belongs.

One `pair()` helper reads either spelling, used by both branches. `oldText`/`newText` join `EDIT_FIELDS` so the expanded body stops repeating what the diff shows. pi's `read` and `write` already match the keys we read.

Same path Claude Code takes — sides reconstructed from the call's own input, not Codex's first-class `FileEdit`. So the diff is of the replaced regions and appears before the result lands; pi's own `details.patch` stays unread.

Both spellings pinned by test, single and multi.

Fixes DRA-146

🤖 Generated with [Claude Code](https://claude.com/claude-code)