### PR TITLE
Check for updates from Settings → About

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -172,6 +172,7 @@ function App() {
     status: updateStatus,
     manual: updateManual,
     install: installUpdate,
+    checkNow: checkForUpdates,
     channel: updateChannel,
     setChannel: setUpdateChannel,
   } = useUpdater();
@@ -1344,6 +1345,11 @@ function App() {
       }}
       initialTab={settingsTab}
       integrations={integrations}
+      updateStatus={updateStatus}
+      updateManual={updateManual}
+      updateBlocked={anyRunning}
+      onCheckUpdates={checkForUpdates}
+      onInstallUpdate={installUpdate}
       updateChannel={updateChannel}
       onUpdateChannelChange={setUpdateChannel}
     />

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -20,11 +20,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import Spinner from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAppSettings } from "@/hooks/useAppSettings";
 import type { useIntegrations } from "@/hooks/useIntegrations";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useTheme } from "@/hooks/useTheme";
+import type { ManualCheck } from "@/hooks/useUpdater";
 import {
   cachedApps,
   fileOpenerChoices,
@@ -37,7 +40,12 @@ import { useTranscriptionSettings } from "@/hooks/useTranscription";
 import { IS_MAC } from "@/lib/platform";
 import { hasLightMode, THEMES, type ThemeMode } from "@/lib/theme";
 import { cn } from "@/lib/utils";
-import type { ExternalApp, SettingsView, UpdateChannel } from "@/types/events";
+import type {
+  ExternalApp,
+  SettingsView,
+  UpdateChannel,
+  UpdateStatus,
+} from "@/types/events";
 
 /// Where to send someone who wants to say something. Direct message rather than an
 /// issue tracker: most feedback is a sentence, and a form is more than a sentence is
@@ -56,6 +64,11 @@ export default function SettingsDialog({
   onOpenChange,
   initialTab = "appearance",
   integrations,
+  updateStatus,
+  updateManual,
+  updateBlocked,
+  onCheckUpdates,
+  onInstallUpdate,
   updateChannel,
   onUpdateChannelChange,
 }: {
@@ -67,6 +80,14 @@ export default function SettingsDialog({
   initialTab?: SettingsTab;
   /// Owned by `App`, because the issues page and the composer read it too.
   integrations: ReturnType<typeof useIntegrations>;
+  /// The updater's state, owned by `App` — the sidebar's own `UpdateRow` draws
+  /// the same fields, and a second copy of the hook would run its own check.
+  updateStatus: UpdateStatus | null;
+  updateManual: ManualCheck;
+  /// A turn is in flight somewhere, so installing would kill a child mid-turn.
+  updateBlocked: boolean;
+  onCheckUpdates: () => void;
+  onInstallUpdate: () => void;
   /// Owned by `useUpdater`, for the reason its own doc comment gives: a second
   /// `useLocalStorage` here would write a value the checking effect never sees.
   updateChannel: UpdateChannel;
@@ -122,6 +143,13 @@ export default function SettingsDialog({
             about: (
               <>
                 <Section>
+                  <UpdatesRow
+                    status={updateStatus}
+                    manual={updateManual}
+                    blocked={updateBlocked}
+                    onCheck={onCheckUpdates}
+                    onInstall={onInstallUpdate}
+                  />
                   <BetaUpdatesRow
                     channel={updateChannel}
                     onChange={onUpdateChannelChange}
@@ -521,6 +549,89 @@ function BetaUpdatesRow({
         >
           {channel === "beta" ? "Turn off" : "Turn on"}
         </Button>
+      )}
+    </SettingRow>
+  );
+}
+
+/// Check for updates, and install one that has already downloaded.
+///
+/// The same answer the menu item gives, in a place a collapsed sidebar cannot
+/// take away — `UpdateRow` lives inside `<aside>`, so "Check for Updates…" had
+/// nowhere to report to while the sidebar was shut.
+///
+/// **One button, and its label is the whole state.** Checking, up to date,
+/// downloading and ready are four answers to one question, so a sentence under
+/// the row would say a second time what the label already says — and the label
+/// is where the reader is looking, having just pressed it. The verdicts retire
+/// themselves after a few seconds, so the button settles back to the offer.
+///
+/// It draws whatever the updater is doing rather than only what this button
+/// started: a background check that already found something leaves the row
+/// offering the restart, which is the more useful of the two answers. A blocked
+/// install takes `UpdateRow`'s treatment exactly — `aria-disabled` and a
+/// tooltip, never `disabled`, which fires no pointer events to open one.
+function UpdatesRow({
+  status,
+  manual,
+  blocked,
+  onCheck,
+  onInstall,
+}: {
+  status: UpdateStatus | null;
+  manual: ManualCheck;
+  blocked: boolean;
+  onCheck: () => void;
+  onInstall: () => void;
+}) {
+  const id = useId();
+  const ready = status?.state === "ready";
+  const downloading = status?.state === "downloading";
+
+  const label = ready
+    ? `Restart to update (v${status.version})`
+    : downloading
+      ? `Downloading${status.percent === null ? "…" : ` ${status.percent}%`}`
+      : manual === "checking"
+        ? "Checking…"
+        : manual === "up_to_date"
+          ? "Up to date"
+          : manual === "failed"
+            ? "Couldn't check"
+            : "Check for updates";
+
+  const button = (
+    <Button
+      id={id}
+      variant="outline"
+      size="sm"
+      // Only the install has a reason worth a tooltip, so only it gives up
+      // `disabled` for the aria form. A download in flight is its own answer,
+      // and the hook's in-flight guard would refuse a second check anyway.
+      aria-disabled={ready && blocked}
+      disabled={!ready && (manual === "checking" || downloading)}
+      onClick={() => {
+        if (!ready) return onCheck();
+        if (!blocked) onInstall();
+      }}
+      className="aria-disabled:cursor-default aria-disabled:opacity-50"
+    >
+      {manual === "checking" && !ready && <Spinner className="size-3.5" />}
+      {label}
+    </Button>
+  );
+
+  return (
+    <SettingRow id={id} label="Updates">
+      {ready && blocked ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{button}</TooltipTrigger>
+          <TooltipContent side="top">
+            Waiting for the running task to finish.
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        button
       )}
     </SettingRow>
   );

--- a/apps/desktop/src/hooks/useUpdater.ts
+++ b/apps/desktop/src/hooks/useUpdater.ts
@@ -66,6 +66,10 @@ export function useUpdater() {
   const channelRef = useRef(channel);
   channelRef.current = channel;
 
+  // The check itself is built inside the effect, so a caller outside reaches it
+  // through a ref rather than the effect being pulled apart to expose it.
+  const checkRef = useRef<(byHand?: boolean) => void>(() => {});
+
   useEffect(() => {
     const unlisten = listen<UpdateStatus>("update_status", (event) => {
       setStatus(event.payload);
@@ -104,6 +108,7 @@ export function useUpdater() {
         });
     };
 
+    checkRef.current = check;
     check();
     const timer = setInterval(() => check(), CHECK_INTERVAL_MS);
     const unlistenMenu = listen("check_update_requested", () => check(true));
@@ -133,10 +138,14 @@ export function useUpdater() {
     [],
   );
 
+  // Same path the menu item takes, so a check asked for in Settings and one
+  // asked for from the menu bar are one thing with one in-flight guard.
+  const checkNow = useCallback(() => checkRef.current(true), []);
+
   // Changing the channel re-arms the effect above, so the new manifest is
   // checked the moment the switch moves — or, when a check is mid-flight, the
   // moment it settles (its `finally` re-asks for the channel picked now). The
   // `ready` guard still holds: a bundle already downloaded is worth keeping
   // whichever channel the reader lands on.
-  return { status, manual, install, channel, setChannel };
+  return { status, manual, install, checkNow, channel, setChannel };
 }


### PR DESCRIPTION
An **Updates** row in Settings → About. One button carries every state:

`Check for updates` → `Checking…` → `Up to date` / `Couldn't check`, `Downloading N%`, `Restart to update (vX)` — and the same button installs when a bundle is ready, with the blocked-install tooltip `UpdateRow` uses.

No sentence under the row: the label is where the reader is looking, having just pressed it, and the verdicts retire themselves back to the offer.

`useUpdater` now hands out `checkNow`, the same hand-triggered path the menu bar item takes, so the two surfaces are one check behind one in-flight guard rather than two checkers.

Half-fixes the known issue where "Check for Updates…" answers into a void with the sidebar collapsed — the answer now has somewhere to land while Settings is open.

Fixes DRA-147

🤖 Generated with [Claude Code](https://claude.com/claude-code)