### PR TITLE
Tint light mode and fold it into Default

### DIFF
--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -488,6 +488,49 @@
   --vibrancy-alpha: 70%;
 }
 
+/* Lab — Default's thirteen values written out as literals, so light mode can be
+   tuned a rung at a time without touching the ramp every other theme reads.
+
+   Default has no palette block: it *is* the ramp at hue 0 and chroma 0, so every
+   number here is what those `calc()`s already resolve to. Identical on screen until
+   something below is changed, which is the point — edit a rung and only this theme
+   moves. Whatever survives here goes back into `[data-mode="light"]` and this block
+   goes away. */
+[data-theme="lab"][data-mode="dark"] {
+  --background: oklch(0.145 0 0);
+  --surface-raised: oklch(0.19 0 0);
+  --surface-card: oklch(0.205 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --ring: oklch(0.556 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --accent-command: oklch(0.82 0.13 90);
+  --accent-mention: oklch(0.82 0.13 230);
+  --accent-thinking: oklch(0.62 0.04 264);
+}
+
+/* The half worth playing with. `--surface-raised` sits *below* `--background` here
+   and `--surface-card` is pure white — the reordering the light ramp's own comments
+   argue for, kept so a change starts from what ships rather than from an inversion. */
+[data-theme="lab"][data-mode="light"] {
+  --background: oklch(0.965 0 0);
+  --surface-raised: oklch(0.94 0 0);
+  --surface-card: oklch(1 0 0);
+  --muted: oklch(0.92 0 0);
+  --muted-foreground: oklch(0.52 0 0);
+  --foreground: oklch(0.22 0 0);
+  --primary: oklch(0.28 0 0);
+  --primary-foreground: oklch(0.99 0 0);
+  --ring: oklch(0.62 0 0);
+  --destructive: oklch(0.55 0.2 25);
+  --accent-command: oklch(0.55 0.13 75);
+  --accent-mention: oklch(0.55 0.16 245);
+  --accent-thinking: oklch(0.55 0.05 264);
+}
+
 /* Catppuccin — https://github.com/catppuccin/catppuccin, MIT. Mocha and Latte,
    using the palette's own token names throughout rather than colours picked to
    look close.

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -512,23 +512,61 @@
   --accent-thinking: oklch(0.62 0.04 264);
 }
 
-/* The half worth playing with. `--surface-raised` sits *below* `--background` here
-   and `--surface-card` is pure white — the reordering the light ramp's own comments
-   argue for, kept so a change starts from what ships rather than from an inversion. */
+/* Page stays the ramp's grey. Primary stays the send-button blue. User bubble
+   and selected session row take the same hue at a whisper of chroma — grey you
+   can tell is cool, not a second blue fill. */
 [data-theme="lab"][data-mode="light"] {
-  --background: oklch(0.965 0 0);
-  --surface-raised: oklch(0.94 0 0);
-  --surface-card: oklch(1 0 0);
-  --muted: oklch(0.92 0 0);
-  --muted-foreground: oklch(0.52 0 0);
-  --foreground: oklch(0.22 0 0);
-  --primary: oklch(0.28 0 0);
+  --background: oklch(0.965 0.012 250);
+  --surface-raised: oklch(0.94 0.01 250);
+  --surface-card: oklch(1 0.01 250);
+  --muted: oklch(0.92 0.01 250);
+  --muted-foreground: oklch(0.52 0.01 250);
+  --foreground: oklch(0.22 0.01 250);
+  --primary: oklch(0.65 0.17 250);
   --primary-foreground: oklch(0.99 0 0);
-  --ring: oklch(0.62 0 0);
+  --ring: oklch(0.8 0.01 250);
   --destructive: oklch(0.55 0.2 25);
   --accent-command: oklch(0.55 0.13 75);
   --accent-mention: oklch(0.55 0.16 245);
   --accent-thinking: oklch(0.55 0.05 264);
+  --surface-selected: oklch(0.9 0.012 250);
+  --veil-card: oklch(1 0.01 250 / 60%);
+  --veil-raised: oklch(0.35 0.01 250 / 4%);
+  --veil-strong: oklch(0.52 0.01 250 / 10%);
+  --veil-selected: oklch(0.32 0.012 250 / 10%);
+
+  [aria-label="Settings"] [role="tab"][aria-selected="true"] {
+    background-color: color-mix(in oklab, var(--sidebar-accent) 80%, transparent);
+  }
+
+  .bg-clip-padding {
+    background-color: transparent;
+  }
+
+  .bg-clip-padding:hover,
+  [data-variant="ghost"]:hover {
+    background-color: color-mix(in oklab, var(--background) 80%, transparent);
+  }
+
+  .bg-secondary:hover {
+    background-color: color-mix(in oklch, var(--secondary), var(--foreground) 2%);
+  }
+
+  .bg-secondary[aria-expanded="true"] {
+    background-color: var(--secondary);
+  }
+
+  .user-bubble {
+    background: var(--primary);
+    color: var(--primary-foreground);
+    box-shadow: none;
+
+    .text-accent-command,
+    .text-accent-mention,
+    .text-accent-issue {
+      color: inherit;
+    }
+  }
 }
 
 /* Catppuccin — https://github.com/catppuccin/catppuccin, MIT. Mocha and Latte,

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -488,63 +488,81 @@
   --vibrancy-alpha: 70%;
 }
 
-/* Lab — Default's thirteen values written out as literals, so light mode can be
-   tuned a rung at a time without touching the ramp every other theme reads.
+/* Default's light palette, and the one block that breaks the filing system's own
+   rule — Default *is* the ramp, at hue 0 and chroma 0, so it has never needed a
+   block of its own.
 
-   Default has no palette block: it *is* the ramp at hue 0 and chroma 0, so every
-   number here is what those `calc()`s already resolve to. Identical on screen until
-   something below is changed, which is the point — edit a rung and only this theme
-   moves. Whatever survives here goes back into `[data-mode="light"]` and this block
-   goes away. */
-[data-theme="lab"][data-mode="dark"] {
-  --background: oklch(0.145 0 0);
-  --surface-raised: oklch(0.19 0 0);
-  --surface-card: oklch(0.205 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --ring: oklch(0.556 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --accent-command: oklch(0.82 0.13 90);
-  --accent-mention: oklch(0.82 0.13 230);
-  --accent-thinking: oklch(0.62 0.04 264);
-}
+   It needs one now because the tint does not fit the ramp's shape. Rungs there are
+   derived as `chroma * <multiplier>`, and no single chroma produces these: the page
+   wants 0.012 at a multiplier of 0.4 where `--primary` wants 0.17 at 0.5, which is
+   not a tinted neutral at all but a real blue. Setting `--hue`/`--chroma` on
+   `[data-mode="light"]` would also have reached every token a *ported* palette
+   leaves alone, so Latte and Gruvbox light would have taken a cool veil and a cool
+   selected row neither theme asked for. A block keeps all of it here.
 
-/* Page stays the ramp's grey. Primary stays the send-button blue. User bubble
-   and selected session row take the same hue at a whisper of chroma — grey you
-   can tell is cool, not a second blue fill. */
-[data-theme="lab"][data-mode="light"] {
+   Dark stays derived and has no block. The ramp is untouched in both modes, so it
+   is still what a ported theme falls through to. */
+[data-theme="default"][data-mode="light"] {
   --background: oklch(0.965 0.012 250);
   --surface-raised: oklch(0.94 0.01 250);
-  --surface-card: oklch(1 0.01 250);
+  /* L 1 admits no chroma at all — `oklch(1 0.01 250)` leaves sRGB and clips, so
+     the cool tint written there never reached the screen. 0.004 is the most this
+     hue carries at 0.99, and naming the value that survives is what keeps the
+     swatch honest. Chasing the full 0.01 means dropping to L 0.978, which closes
+     the card's step above the page to almost nothing — the one thing this rung
+     cannot give up. */
+  --surface-card: oklch(0.99 0.004 250);
   --muted: oklch(0.92 0.01 250);
   --muted-foreground: oklch(0.52 0.01 250);
   --foreground: oklch(0.22 0.01 250);
   --primary: oklch(0.65 0.17 250);
   --primary-foreground: oklch(0.99 0 0);
-  --ring: oklch(0.8 0.01 250);
+  /* The primary blue itself, at 5.45:1 against the page. It was `oklch(0.8 0.01
+     250)`, which measured 3.03:1 — sitting exactly on the floor a non-text
+     indicator may not go below, where the ramp's own grey ring gives 8.67. A
+     focus ring is the one mark that has to be found rather than noticed. */
+  --ring: var(--primary);
   --destructive: oklch(0.55 0.2 25);
   --accent-command: oklch(0.55 0.13 75);
   --accent-mention: oklch(0.55 0.16 245);
   --accent-thinking: oklch(0.55 0.05 264);
   --surface-selected: oklch(0.9 0.012 250);
-  --veil-card: oklch(1 0.01 250 / 60%);
-  --veil-raised: oklch(0.35 0.01 250 / 4%);
-  --veil-strong: oklch(0.52 0.01 250 / 10%);
-  --veil-selected: oklch(0.32 0.012 250 / 10%);
+  /* Matched to `--surface-card` above, and clipped the same way before it: this
+     is what the card *becomes* under transparency, so the two have to composite
+     to one colour or a card changes hue when the window goes fullscreen. */
+  --veil-card: oklch(0.99 0.004 250 / 60%);
+  /* Mixed off `--foreground` rather than named, which is `--surface-selected`'s
+     own idiom three lines up and gets the hue for free. These carried the ramp's
+     alphas over a *light* grey-blue ink, and the pair quietly halved all three —
+     10% of L 0.52 moves a near-white page barely half as far as 10% of black. The
+     alphas here are the ones that land back on what the light ramp was tuned to
+     (1.09 / 1.26 / 1.26 against its 1.09 / 1.25 / 1.25). Worth restoring rather
+     than accepting, since `--veil-strong` is the picker's arrow-key highlight and
+     `--veil-selected` says which session row is current — both are marks that have
+     to be found rather than noticed. */
+  --veil-raised: color-mix(in oklab, var(--foreground) 4.5%, transparent);
+  --veil-strong: color-mix(in oklab, var(--foreground) 11.5%, transparent);
+  --veil-selected: color-mix(in oklab, var(--foreground) 11.5%, transparent);
 
   [aria-label="Settings"] [role="tab"][aria-selected="true"] {
     background-color: color-mix(in oklab, var(--sidebar-accent) 80%, transparent);
   }
 
-  .bg-clip-padding {
+  /* The outline button, by the attribute that names it. It was `.bg-clip-padding`,
+     which is a Tailwind utility about padding-box clipping and means nothing about
+     a background — it only happens to sit on this one variant today, so the rule
+     would follow that class anywhere it went next and stop working the moment the
+     variant stopped carrying it. */
+  [data-variant="outline"] {
     background-color: transparent;
   }
 
-  .bg-clip-padding:hover,
-  [data-variant="ghost"]:hover {
+  /* Outline alone. `[data-variant="ghost"]:hover` was here too and had to go: it
+     is unlayered, so it beat every `hover:bg-*` utility in the app, and the three
+     sidebar buttons are ghosts that now have to hover as the session rows beneath
+     them do. Cost, stated: a ghost button elsewhere in Lab hovers `bg-muted` like
+     it does in every other theme rather than taking the page colour. */
+  [data-variant="outline"]:hover {
     background-color: color-mix(in oklab, var(--background) 80%, transparent);
   }
 

--- a/apps/desktop/src/components/ChatInput.tsx
+++ b/apps/desktop/src/components/ChatInput.tsx
@@ -542,7 +542,7 @@ export default function ChatInput({
               disabled={stopping ? !onStop : !canSend}
               onClick={stopping ? onStop : undefined}
               title={stopping ? "Stop" : busy ? "Send — queued onto this turn" : "Send"}
-              className="rounded-full"
+              className="rounded-full disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none disabled:opacity-100"
             >
               {/* Both icons are mounted and stacked in one grid cell, so the
                   swap is a transition rather than a remount — React would

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -280,7 +280,7 @@ function OpenFilesRow() {
             // than drawn from a guess, the same bargain the analytics switch
             // makes — either guess is wrong for somebody.
             disabled={apps === null || unavailable !== null}
-            className="min-w-36 justify-between font-normal"
+            className="justify-between font-normal"
           >
             <span className="flex min-w-0 items-center gap-1.5">
               {pick && <AppIcon app={pick} className="size-4" />}
@@ -294,8 +294,17 @@ function OpenFilesRow() {
         </DropdownMenuTrigger>
 
         {/* Aligned to the end because the control sits at the dialog's right
-            edge, where a start-aligned menu opens past it. */}
-        <DropdownMenuContent align="end" className="min-w-44">
+            edge, where a start-aligned menu opens past it.
+
+            Sized to the longest app name, floored at the trigger's own width.
+            The default is the other way round — `w-(--radix-…-trigger-width)`
+            pins the menu *to* the trigger — which is right for a control that
+            fills its row and wrong for one that has shrunk to a single app
+            name, where it made the menu narrower than its own items. */}
+        <DropdownMenuContent
+          align="end"
+          className="w-auto min-w-(--radix-dropdown-menu-trigger-width)"
+        >
           {choices.map((app, i) => (
             <Fragment key={app.path}>
               {/* An inset dotted rule between the editors and Finder,

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -601,19 +601,21 @@ export default function Sidebar({
       {/* `px-1.5` on the buttons rather than `size="sm"`'s `px-2.5`, so their
           icons land on the same 12px inset as the toggle above.
 
-          All three sit at `/70` rather than at full strength, and `ghost`'s own
-          `hover:text-foreground` brings them back under the cursor — the same
-          bargain the sidebar toggle makes with `opacity-80`. These are ways *in*
-          to the list below them, and the list draws its own rows at `/80`, so at
-          full strength the chrome was the heaviest text in the pane and the
-          sessions read as secondary to the buttons above them. Most visible on a
-          light page, where `--foreground` is a near-black against near-white. */}
+          All three are drawn as session rows: `/80` text and `--sidebar-accent`
+          at half strength under the cursor, which is exactly what an unselected
+          row in the list below carries. They were `/70` with `ghost`'s own
+          `hover:bg-muted` and `hover:text-foreground`, which made them a second
+          kind of control in a pane that is otherwise one list — the fill was a
+          different colour from the row directly beneath them and the label
+          brightened where a row's does not. The dark hover is named too, since
+          `dark:hover:bg-muted/50` on the variant out-specifies an unprefixed
+          `hover:` and `tailwind-merge` cannot fold the two together. */}
       <div className="flex flex-col gap-px px-2">
         <Button
           variant="ghost"
           size="sm"
           onClick={onNewSession}
-          className="w-full justify-start px-1.5 text-ui text-sidebar-foreground/70"
+          className="w-full justify-start px-1.5 text-ui text-sidebar-foreground/80 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground/80 dark:hover:bg-sidebar-accent/50"
         >
           <Plus />
           New Task
@@ -633,7 +635,7 @@ export default function Sidebar({
           size="sm"
           onClick={onOpenIssues}
           data-active={issuesOpen || undefined}
-          className="w-full justify-start px-1.5 text-ui text-sidebar-foreground/70 data-[active]:bg-sidebar-accent data-[active]:text-sidebar-accent-foreground"
+          className="w-full justify-start px-1.5 text-ui text-sidebar-foreground/80 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground/80 dark:hover:bg-sidebar-accent/50 data-[active]:bg-sidebar-accent data-[active]:text-sidebar-accent-foreground"
         >
           <CircleDot />
           Issues
@@ -681,7 +683,7 @@ export default function Sidebar({
             variant="ghost"
             size="sm"
             onClick={() => setSearching(true)}
-            className="w-full justify-start px-1.5 text-ui text-sidebar-foreground/70"
+            className="w-full justify-start px-1.5 text-ui text-sidebar-foreground/80 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground/80 dark:hover:bg-sidebar-accent/50"
           >
             <Search />
             Search

--- a/apps/desktop/src/components/chat/QueuedMessages.tsx
+++ b/apps/desktop/src/components/chat/QueuedMessages.tsx
@@ -36,7 +36,7 @@ export default function QueuedMessages({ messages }: { messages: QueuedPrompt[] 
               {/* Guarded like the delivered bubble's: a prompt can be an
                   attachment and nothing else. */}
               {body && (
-                <div className="max-w-[85%] rounded-xl bg-card px-3 py-2 text-chat text-card-foreground">
+                <div className="user-bubble max-w-[85%] rounded-xl bg-card px-3 py-2 text-chat text-card-foreground">
                   {/* Same bubble, same break rule — see `UserMessage`. */}
                   <span className="whitespace-pre-wrap wrap-anywhere">
                     {highlightSegments(body).map((segment, s) => {

--- a/apps/desktop/src/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/components/chat/UserMessage.tsx
@@ -111,7 +111,7 @@ export default function UserMessage({
         // from the page. `--shadow-card`, not the composer's `--shadow-surface`:
         // this sits *in* the transcript rather than floating at the window's
         // edge, and the crisper one read as an edge cut under it.
-        <div className="max-w-[85%] rounded-xl bg-card px-3 py-2 text-card-foreground shadow-(--shadow-card)">
+        <div className="user-bubble max-w-[85%] rounded-xl bg-card px-3 py-2 text-card-foreground shadow-(--shadow-card)">
           {/* `wrap-anywhere` because a pasted path or URL has no whitespace to
               wrap at, and the bubble's `max-w` caps the box and not what is
               drawn in it — so the glyphs run out over the transcript's own

--- a/apps/desktop/src/components/settings/TranscriptionSettings.tsx
+++ b/apps/desktop/src/components/settings/TranscriptionSettings.tsx
@@ -139,13 +139,13 @@ function ModelRow({
     >
       <div className="flex flex-col gap-0.5">
         <div className="flex items-center gap-2">
-          {selected && <Check className="size-4 shrink-0" aria-hidden />}
           <span className="text-ui font-medium">{model.name}</span>
           {recommended && (
             <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
               Recommended
             </span>
           )}
+          {selected && <Check className="ml-auto size-4 shrink-0" aria-hidden />}
         </div>
         <p className="text-ui text-muted-foreground">{model.description}</p>
         <p className="flex flex-wrap items-center gap-x-1 text-ui text-muted-foreground">

--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -38,7 +38,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground shadow-(--shadow-surface) hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "hover:bg-muted/70 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",

--- a/apps/desktop/src/lib/theme.test.ts
+++ b/apps/desktop/src/lib/theme.test.ts
@@ -7,6 +7,7 @@ import {
   hasLightMode,
   keepsGlassInFullscreen,
   modeFor,
+  type ThemeName,
 } from "./theme";
 
 // The pre-paint script in index.html reads `ade.theme` with a bare `getItem` and
@@ -103,6 +104,9 @@ describe("modeFor", () => {
   });
 });
 
+// Palettes written here rather than ported, so nothing upstream to credit.
+const OURS: ThemeName[] = ["default", "lab"];
+
 describe("THEMES", () => {
   it("leads with the default", () => {
     expect(THEMES[0].id).toBe(DEFAULT_THEME);
@@ -118,7 +122,7 @@ describe("THEMES", () => {
   // The credit is the licence being honoured, not a nicety: a ported palette
   // with no `credit` is one the README cannot name.
   it("credits every ported palette", () => {
-    for (const t of THEMES.filter((t) => t.id !== DEFAULT_THEME)) {
+    for (const t of THEMES.filter((t) => !OURS.includes(t.id))) {
       expect(t.credit?.name).toBeTruthy();
       expect(t.credit?.url).toMatch(/^https:\/\//);
     }

--- a/apps/desktop/src/lib/theme.test.ts
+++ b/apps/desktop/src/lib/theme.test.ts
@@ -105,7 +105,7 @@ describe("modeFor", () => {
 });
 
 // Palettes written here rather than ported, so nothing upstream to credit.
-const OURS: ThemeName[] = ["default", "lab"];
+const OURS: ThemeName[] = ["default"];
 
 describe("THEMES", () => {
   it("leads with the default", () => {

--- a/apps/desktop/src/lib/theme.ts
+++ b/apps/desktop/src/lib/theme.ts
@@ -11,7 +11,6 @@
 
 export type ThemeName =
   | "default"
-  | "lab"
   | "catppuccin"
   | "gruvbox"
   | "one-dark-pro"
@@ -59,11 +58,6 @@ export const THEMES: Theme[] = [
   // retired name (`neutral`, `shadcn`) lands on — renaming it would strand every
   // stored pick on a palette that no longer answers to what is written down.
   { id: "default", label: "Dray", flatInFullscreen: true },
-  // A copy of Default, as literals rather than the derived ramp, so light mode can
-  // be tuned without moving every other theme. Ours, so no credit; temporary, so
-  // when a change here is worth keeping it goes into `[data-mode="light"]` and both
-  // this entry and its block in App.css go.
-  { id: "lab", label: "Lab", flatInFullscreen: true },
   {
     id: "catppuccin",
     label: "Catppuccin",

--- a/apps/desktop/src/lib/theme.ts
+++ b/apps/desktop/src/lib/theme.ts
@@ -9,7 +9,13 @@
 /// `--composer`, which has to stay an opaque fill, and a grey composer on a tinted
 /// page is what a second axis buys.
 
-export type ThemeName = "default" | "catppuccin" | "gruvbox" | "one-dark-pro" | "cobalt2";
+export type ThemeName =
+  | "default"
+  | "lab"
+  | "catppuccin"
+  | "gruvbox"
+  | "one-dark-pro"
+  | "cobalt2";
 export type ThemeMode = "light" | "dark" | "system";
 
 /// Resolved mode — what actually lands on `data-mode`. `system` never does.
@@ -53,6 +59,11 @@ export const THEMES: Theme[] = [
   // retired name (`neutral`, `shadcn`) lands on — renaming it would strand every
   // stored pick on a palette that no longer answers to what is written down.
   { id: "default", label: "Dray", flatInFullscreen: true },
+  // A copy of Default, as literals rather than the derived ramp, so light mode can
+  // be tuned without moving every other theme. Ours, so no credit; temporary, so
+  // when a change here is worth keeping it goes into `[data-mode="light"]` and both
+  // this entry and its block in App.css go.
+  { id: "lab", label: "Lab", flatInFullscreen: true },
   {
     id: "catppuccin",
     label: "Catppuccin",


### PR DESCRIPTION
## TLDR for human

- Light mode goes cool: hue 250 across the rungs, a blue `--primary`, veils mixed off `--foreground`.
- Default gains a palette block. It has never needed one, and the reasoning for why it does now is below.
- Sidebar's New Task / Issues / Search draw as session rows.
- Ghost hover lightens in light mode only.
- Integrations app picker sizes to its content.
- One known trade, stated: white on `--primary` is 3.14:1, under AA.

---

### The palette

Light was the derived ramp at hue 0 and chroma 0, so Default *was* the ramp and needed no block. It now runs hue 250.

Folding the tint into `[data-mode="light"]` was the obvious route and does not work. Rungs there are `chroma * <multiplier>`, and no single chroma produces these — the page wants 0.012 at a multiplier of 0.4 where `--primary` wants 0.17 at 0.5, which is not a tinted neutral at all but a real blue. Setting `--hue`/`--chroma` on the ramp would also have reached every token a *ported* palette leaves alone, so Catppuccin Latte and Gruvbox light would have taken a cool veil and a cool selected row neither theme asked for.

So Default gets `[data-theme="default"][data-mode="light"]` and the ramp is untouched in both modes, still what a ported theme falls through to. Dark stays derived and has no block.

Two values were corrected on the way in. `--surface-card` was `oklch(1 0.01 250)`, which leaves sRGB and clips — L 1 admits no chroma, so the tint written there never rendered; it is `oklch(0.99 0.004 250)`, the value that survives. `--veil-card` had the same defect and is matched to it, so a card does not shift hue going fullscreen.

`--veil-raised`, `--veil-strong` and `--veil-selected` are `color-mix` off `--foreground` rather than literals — the idiom `--surface-selected` already uses, which gets the hue for free and keeps the strength the light ramp was tuned to.

### Beside it

- **Sidebar.** New Task, Issues and Search were `/70` text with ghost's `hover:bg-muted`, so their hover fill differed from the row directly beneath them. They now carry the session row's own `/80` and `hover:bg-sidebar-accent/50`. The dark hover is named separately because `dark:hover:bg-muted/50` out-specifies an unprefixed `hover:` and `tailwind-merge` cannot fold different variant chains together.
- **Ghost hover** goes `bg-muted` → `bg-muted/70` in light. Dark is unchanged.
- **Integrations app picker.** The trigger loses its `min-w-36`; the menu goes from `w-(--radix-…-trigger-width)` to `w-auto min-w-(--radix-…-trigger-width)`, so it sizes to the longest app name and is never narrower than the button it opens from.
- **Outline button** in the Default light block is selected by `[data-variant="outline"]` rather than `.bg-clip-padding` — the latter is a utility about padding-box clipping that only happens to sit on that variant today.

### Known trade

White on `--primary` measures **3.14:1**, under AA 4.5 for normal text, where Default light's old near-black gave ~19:1. It carries the send button's label and the user bubble's text. `oklch(0.56 0.155 250)` clears it at 4.53:1 and lifts the focus ring past 3:1 with it — deliberately not taken here, since it visibly deepens the blue.

Fixes DRA-145