### PR TITLE
Grow the question card's free-text box

### DIFF
--- a/apps/desktop/demo.html
+++ b/apps/desktop/demo.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en" data-theme="default" data-mode="dark" data-transparency class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dray — QuestionRequest demo</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/demo.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/src/components/chat/QuestionRequest.tsx
+++ b/apps/desktop/src/components/chat/QuestionRequest.tsx
@@ -74,7 +74,7 @@ export default function QuestionRequest({
     const target =
       form?.querySelector<HTMLInputElement>(
         "[data-slot=questionnaire-choice] input"
-      ) ?? form?.querySelector<HTMLInputElement>("[data-slot=questionnaire-input]");
+      ) ?? form?.querySelector<HTMLTextAreaElement>("[data-slot=questionnaire-input]");
 
     target?.focus();
   }, []);
@@ -166,9 +166,26 @@ export default function QuestionRequest({
                   handed a string it has no branch for. */}
               {question.freeText && (
                 <QuestionnaireInput
+                  // A typed answer is prose and can run to a sentence or two, so
+                  // the box grows down instead of scrolling one line sideways —
+                  // an answer the reader cannot see all of is one they cannot
+                  // check before sending. `field-sizing: content` does the
+                  // growing natively; the cap stops a pasted essay pushing Send
+                  // off the bottom of the transcript.
+                  render={<textarea rows={1} />}
                   aria-label="Another answer"
                   placeholder="Something else…"
-                  className="min-h-0 h-8"
+                  // `sm:min-h-10` as well as `min-h-10`: the component's own
+                  // base drops its touch-target floor to zero above `sm`, which
+                  // is every window this app runs in.
+                  className="field-sizing-content h-auto max-h-40 min-h-10 resize-none py-2 sm:min-h-10"
+                  onKeyDown={(event) => {
+                    // Enter answers the card — the questionnaire's own handler
+                    // sits on the form above and takes it whatever the target —
+                    // so a newline needs the other chord, and stopping the
+                    // bubble is the only way to leave it to the textarea.
+                    if (event.key === "Enter" && event.shiftKey) event.stopPropagation();
+                  }}
                 />
               )}
             </QuestionnaireChoices>

--- a/apps/desktop/src/demo.tsx
+++ b/apps/desktop/src/demo.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from "react";
+import ReactDOM from "react-dom/client";
+
+import QuestionRequest from "@/components/chat/QuestionRequest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Question } from "@/types/events";
+import "./App.css";
+
+/// The card the agent blocks on, with the harness faked out.
+///
+/// It exists to answer one thing — what the free-text box does as an answer runs
+/// past a line — which cannot be looked at in the real app without an agent
+/// asking something first. Delete the page once it has answered.
+const CASES: { title: string; questions: Question[] }[] = [
+  {
+    title: "One question with a free-text box — what the growing box is for",
+    questions: [
+      {
+        question: "Which package manager should the release script call?",
+        header: "Package manager",
+        multiSelect: false,
+        freeText: true,
+        options: [
+          { label: "pnpm", description: "What the repo already uses.", preview: null },
+          { label: "npm", description: null, preview: null },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Free text and no options — pi's `input` dialog",
+    questions: [
+      {
+        question: "Name the worktree.",
+        header: null,
+        multiSelect: false,
+        freeText: true,
+        options: [],
+      },
+    ],
+  },
+  {
+    title: "Two questions: multi-select, then a closed list with previews",
+    questions: [
+      {
+        question: "Which checks should run on push?",
+        header: "Checks",
+        multiSelect: true,
+        freeText: true,
+        options: [
+          { label: "cargo test", description: "Rust tests.", preview: null },
+          { label: "tsc", description: "Type check.", preview: null },
+          { label: "vitest", description: null, preview: null },
+        ],
+      },
+      {
+        question: "Tabs or spaces?\nThe repo is inconsistent below apps/web.",
+        header: "Indentation",
+        multiSelect: false,
+        freeText: false,
+        options: [
+          { label: "Spaces", description: "Two.", preview: "const a = {\n  b: 1,\n}" },
+          { label: "Tabs", description: null, preview: "const a = {\n\tb: 1,\n}" },
+        ],
+      },
+    ],
+  },
+];
+
+function Demo() {
+  // Remounting on a key is the point: the card is one-shot, so answering it once
+  // leaves nothing to look at.
+  const [round, setRound] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string> | null>(null);
+
+  return (
+    <TooltipProvider>
+      <div className="min-h-screen bg-background p-8 text-foreground">
+        <div className="flex flex-col gap-10">
+          {CASES.map((demo) => (
+            <section key={demo.title} className="flex flex-col gap-3">
+              <h2 className="text-sm font-medium text-muted-foreground">{demo.title}</h2>
+              <QuestionRequest
+                key={`${demo.title}:${round}`}
+                questions={demo.questions}
+                onAnswer={setAnswers}
+              />
+            </section>
+          ))}
+        </div>
+
+        {/* The answer map, since what the card sends is half of what it does. */}
+        <pre className="mt-10 rounded-lg border border-border p-3 font-mono text-xs">
+          {answers ? JSON.stringify(answers, null, 2) : "no answer sent yet"}
+        </pre>
+
+        <button
+          className="mt-3 rounded-lg border border-border px-3 py-1.5 text-sm"
+          onClick={() => {
+            setAnswers(null);
+            setRound((n) => n + 1);
+          }}
+        >
+          Reset cards
+        </button>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <Demo />
+  </React.StrictMode>,
+);


### PR DESCRIPTION
`AskUserQuestion`'s "Something else…" box was a one-line `input`, so a typed answer longer than the card scrolled sideways — the reader could not see what they were about to send.

Now a `textarea` with `field-sizing: content`: 40px floor, grows with the answer, capped at `max-h-40` so a long one cannot push Send off screen. Shift+Enter inserts a newline; plain Enter still sends, since the questionnaire's own Enter handler sits on the form and takes Enter whatever the target — the textarea has to stop that bubble.

`demo.html` + `src/demo.tsx` carry the card with the harness faked out, since it cannot be looked at in the app without an agent asking something first. Delete both once they have answered. `pnpm build` still emits `index.html` alone.

Verified in the browser: growth, Shift+Enter, Enter-sends, and the answer map. Typecheck clean.

Fixes DRA-151

🤖 Generated with [Claude Code](https://claude.com/claude-code)