### PR TITLE
Space switcher: click to switch, dots for the map

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -78,6 +78,7 @@ import {
   activeSpace,
   allowedInSpace,
   inSpace,
+  moveSpace,
   sessionInSpace,
   spaceNames,
   SPACE_KEY,
@@ -829,6 +830,16 @@ function App() {
   const createSpace = (name: string) =>
     setDeclaredSpaces((prev) => (prev.includes(name) ? prev : [...prev, name]));
 
+  /// Steps a space one place in the order the switcher walks.
+  ///
+  /// The **whole** list goes down, not the declared half of it: order is the
+  /// declared list, and a space carried only by a project's tag has no place in
+  /// it yet — so a name is declared here on the way past, which is the only way
+  /// it can have somewhere to be moved to. Membership is untouched either way,
+  /// since the tag on the project is what records that.
+  const moveSpaceBy = (name: string, delta: number) =>
+    setDeclaredSpaces(moveSpace(spaces, name, delta));
+
   /// Renames a space wherever it is written down: every project carrying the
   /// tag, the declared list, and the reader's own pick.
   ///
@@ -1139,6 +1150,9 @@ function App() {
           space={space}
           onSpaceChange={changeSpace}
           onNewSpace={openNewSpace}
+          // Only while the dialog is actually up: it is cleared on close, so a
+          // cancelled naming puts the switcher back on All Spaces by itself.
+          namingSpace={settingsOpen && namingSpace}
           projectFilter={projectFilter}
           onProjectFilterChange={setProjectFilter}
           statusBySession={statusBySession}
@@ -1548,6 +1562,7 @@ function App() {
       onCreateSpace={createSpace}
       onRenameSpace={renameSpace}
       onRemoveSpace={removeSpace}
+      onMoveSpace={moveSpaceBy}
       integrations={integrations}
       updateStatus={updateStatus}
       updateManual={updateManual}

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -73,6 +73,7 @@ export default function SettingsDialog({
   onCreateSpace,
   onRenameSpace,
   onRemoveSpace,
+  onMoveSpace,
   integrations,
   updateStatus,
   updateManual,
@@ -100,6 +101,7 @@ export default function SettingsDialog({
   onCreateSpace: (name: string) => void;
   onRenameSpace: (from: string, to: string) => void;
   onRemoveSpace: (name: string) => void;
+  onMoveSpace: (name: string, delta: number) => void;
   /// Owned by `App`, because the issues page and the composer read it too.
   integrations: ReturnType<typeof useIntegrations>;
   /// The updater's state, owned by `App` — the sidebar's own `UpdateRow` draws
@@ -150,6 +152,7 @@ export default function SettingsDialog({
                 onCreateSpace={onCreateSpace}
                 onRenameSpace={onRenameSpace}
                 onRemoveSpace={onRemoveSpace}
+                onMoveSpace={onMoveSpace}
               />
             ),
             transcription: (

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -33,7 +33,6 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
@@ -117,6 +116,9 @@ type SidebarProps = {
   /// only place the reader is thinking about spaces, so it is where making one
   /// has to be offered — it just isn't where the making happens.
   onNewSpace: () => void;
+  /// Whether that field is up, which is what the switcher's New space entry is
+  /// lit by while no space exists.
+  namingSpace: boolean;
   // `null` is every project, and it is the entry the filter opens on.
   projectFilter: string | null;
   onProjectFilterChange: (path: string | null) => void;
@@ -599,6 +601,13 @@ export function SettingsButton({ onOpen }: { onOpen: () => void }) {
   );
 }
 
+/// Every space there is, as the switcher walks them. "All" is an entry rather
+/// than a special case, so the click and the dots read one list and cannot
+/// disagree about what comes next.
+function spaceEntries(spaces: string[]): (string | null)[] {
+  return [null, ...spaces];
+}
+
 /// Which space the whole sidebar is scoped to.
 ///
 /// A switch narrows what is *drawn* and nothing else: every session in every
@@ -606,67 +615,112 @@ export function SettingsButton({ onOpen }: { onOpen: () => void }) {
 /// nothing until the reader comes back to it. That is the whole feature — the
 /// point is a screen somebody else can look at, not a second app.
 ///
+/// Shaped like the project filter below it: the name over a dot track, a click
+/// steps to the next one. Two controls scoping the same list should not be two
+/// different kinds of control, and the dots say how many spaces there are,
+/// which the chevron never did. No swipe — this sits in the titlebar strip, one
+/// line high, where the project filter has a whole band to aim at.
+///
 /// Switching only. Making a space and filing projects into it live in Settings,
 /// since both are things done once and neither belongs in the strip a reader
-/// passes through twenty times a day — so "New space" here opens that tab
-/// rather than growing a second way to do it.
+/// passes through twenty times a day.
+///
+/// Until the first space exists there is nothing to switch between, so the cycle
+/// carries one more entry — New space — which opens that tab's name field on
+/// landing. A ＋ standing in the strip for good is a permanent offer to somebody
+/// who may never want a space, where an entry is only ever met by a reader who
+/// stepped onto it. It drops out the moment a space exists, so ordinary
+/// switching can never land on it.
 function SpaceSwitcher({
   spaces,
   value,
+  naming,
   onChange,
   onNew,
 }: {
   spaces: string[];
   value: string | null;
+  /// Whether the name field is up. This is what lights the New space entry:
+  /// held here rather than as a click of its own, so cancelling the dialog puts
+  /// the switcher back on All Spaces with no state to unwind.
+  naming: boolean;
   onChange: (space: string | null) => void;
   onNew: () => void;
 }) {
+  const offersNew = spaces.length === 0;
+  // Two entries with nothing to name yet — the second's label is the only thing
+  // that makes it New space rather than a space.
+  const entries = offersNew ? [null, null] : spaceEntries(spaces);
+
+  // A space removed elsewhere leaves its name behind in the stored pick, and the
+  // dot track needs a real index. All is the fallback `activeSpace` already makes.
+  const found = entries.indexOf(value);
+  const activeIndex = offersNew ? (naming ? 1 : 0) : found === -1 ? 0 : found;
+
+  const label = (i: number) =>
+    offersNew && i === 1 ? "New space" : (entries[i] ?? "All Spaces");
+
+  // Wraps: a click has no direction and no dot to slide, so a dead end at the
+  // last space would just look broken. With nothing made yet there is only the
+  // one place to go, and the dialog covers the strip once it opens.
+  const cycle = () => {
+    if (offersNew) return onNew();
+    onChange(entries[(activeIndex + 1) % entries.length]);
+  };
+
   return (
-    <DropdownMenu>
-      {/* No tooltip, unlike the two icon buttons beside it: the trigger already
-          draws the answer in words, so one would only repeat the label. */}
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          // Named, not a glyph: which space you are in is the one fact this
-          // control exists to state, and an icon can only say that a control is
-          // here.
-          className="max-w-28 gap-1 px-1.5 text-ui text-muted-foreground opacity-80 transition-opacity hover:opacity-100"
-        >
-          <span className="truncate">{value ?? "All"}</span>
-          <ChevronDown className="size-3 shrink-0 opacity-60" />
-        </Button>
-      </DropdownMenuTrigger>
-
-      {/* Hugs its widest entry rather than holding a fixed width open beside
-          two short names. */}
-      <DropdownMenuContent align="end">
-        <DropdownMenuRadioGroup
-          // Radix radio values are strings, so every space rides on its own name
-          // and the empty one stands for all of them — a space cannot be named
-          // nothing, so the two can't collide.
-          value={value ?? ""}
-          onValueChange={(next) => onChange(next === "" ? null : next)}
-        >
-          <DropdownMenuRadioItem value="" className="text-ui">
-            All
-          </DropdownMenuRadioItem>
-          {spaces.map((name) => (
-            <DropdownMenuRadioItem key={name} value={name} className="text-ui">
-              <span className="truncate">{name}</span>
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
-
-        {/* No rule above it: the menu is one short list of things to do with
-            spaces, and a line through it says the two halves are unrelated. */}
-        <DropdownMenuItem onSelect={onNew} className="text-ui">
-          <Plus className="size-3.5" />
-          New space
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    // No tooltip, unlike the two icon buttons beside it: this one draws its
+    // answer in words, so one would only repeat the label. Unselectable because
+    // the name is the target's face, not prose.
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={cycle}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          cycle();
+        }
+      }}
+      className="group/spaces relative flex cursor-pointer items-center px-1.5 select-none focus-visible:outline-none"
+    >
+      {/* Every name in one grid cell, all but the current one hidden, so the
+          box is as wide as the **longest** name and never a pixel wider.
+          That is what makes stepping through smooth: a box that hugs the
+          current name resized on every switch, sliding the two icon buttons
+          beside it and jumping the dots out from under the word. A fixed width
+          fixed that and cost more — it left the name adrift in the middle of
+          the strip, since the widest name is usually far short of it. */}
+      <span className="grid max-w-28 text-ui">
+        {entries.map((_, i) => (
+          <span
+            key={i}
+            aria-hidden={i !== activeIndex}
+            className={cn(
+              "col-start-1 row-start-1 truncate text-center text-muted-foreground transition-colors group-hover/spaces:text-foreground",
+              i !== activeIndex && "invisible",
+            )}
+          >
+            {/* "All Spaces", not "All", to match the project filter's own
+                first entry — and it is the longest label a one-space app has,
+                which is what stops the box being narrower than the word beside
+                it. */}
+            {label(i)}
+          </span>
+        ))}
+      </span>
+      {/* Out of flow, and that is the whole of why: this sits in the titlebar
+          strip beside the session header, so a column with the dots in it left
+          the name riding high of the words next to it — by half a dot at rest
+          and by nothing the reader could account for. */}
+      <div className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2">
+        <DotTrack
+          count={entries.length}
+          activeIndex={activeIndex}
+          className="opacity-0 transition-opacity duration-150 group-hover/spaces:opacity-100"
+        />
+      </div>
+    </div>
   );
 }
 
@@ -729,6 +783,7 @@ export default function Sidebar({
   space,
   onSpaceChange,
   onNewSpace,
+  namingSpace,
   projectFilter,
   onDetach,
   onProjectFilterChange,
@@ -855,6 +910,7 @@ export default function Sidebar({
               <SpaceSwitcher
                 spaces={spaces}
                 value={space}
+                naming={namingSpace}
                 onChange={onSpaceChange}
                 onNew={onNewSpace}
               />
@@ -865,6 +921,7 @@ export default function Sidebar({
             <SpaceSwitcher
               spaces={spaces}
               value={space}
+              naming={namingSpace}
               onChange={onSpaceChange}
               onNew={onNewSpace}
             />
@@ -1174,6 +1231,68 @@ const DOT_PITCH = DOT + DOT_GAP;
 // Five slots. Odd, so there is a real middle for the active dot to sit in.
 const DOT_TRACK_W = DOT_PITCH * 5 - DOT_GAP;
 
+/// The map under a switcher's label: one dot per entry, **the active one always
+/// in the middle**, so the row slides under a fixed centre rather than a marker
+/// travelling along a fixed row. That is what keeps the indicator readable once
+/// there are more entries than dots that fit.
+///
+/// The track holds its width whatever the count, and the row always slides.
+/// Hugging the dots to centre the *group* while they fit was tried and is why
+/// this comment exists: with the group centred there is nothing left to move,
+/// so a switch became a colour change and the whole control stopped feeling
+/// like anything. The sliding row **is** the smoothness.
+///
+/// Shared by the two controls that scope the session list, since a reader
+/// meeting the same shape twice should not have to learn it twice.
+function DotTrack({
+  count,
+  activeIndex,
+  className,
+}: {
+  count: number;
+  activeIndex: number;
+  className?: string;
+}) {
+  // Reserved height, so revealing the track never shifts what is under it. One
+  // entry is the whole story already — a lone dot would offer a gesture that
+  // can't go anywhere.
+  return (
+    <div className="h-1.5">
+      {count > 1 && (
+        <div
+          className={cn("flex h-full items-center overflow-hidden", className)}
+          style={{
+            width: DOT_TRACK_W,
+            // Faded at both ends, so a dot leaving the track reads as sliding
+            // out rather than as being cut off.
+            maskImage:
+              "linear-gradient(to right, transparent, black 30%, black 70%, transparent)",
+          }}
+        >
+          <div
+            className="flex items-center transition-transform duration-200 ease-out"
+            style={{
+              gap: DOT_GAP,
+              // Puts the active dot's centre on the track's centre.
+              transform: `translateX(${DOT_TRACK_W / 2 - DOT / 2 - activeIndex * DOT_PITCH}px)`,
+            }}
+          >
+            {Array.from({ length: count }, (_, i) => (
+              <span
+                key={i}
+                className={cn(
+                  "size-1 shrink-0 rounded-full transition-colors",
+                  i === activeIndex ? "bg-foreground/80" : "bg-muted-foreground/30",
+                )}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // How far a swipe must travel before it counts as one. Momentum keeps firing
 // `wheel` long after the fingers lift, so a gesture ends on one of two signs
 // that the push is over: a stretch of quiet, or deltas decayed to the tail.
@@ -1355,44 +1474,11 @@ function ProjectFilter({
           {menuMode && <ChevronDown className="size-3 shrink-0 opacity-60" />}
         </span>
 
-        {/* Reserved height, so revealing the dots never shifts the list below.
-            One entry is the whole story already — a lone dot would offer a
-            gesture that can't go anywhere. */}
-        <div className="h-1.5">
-          {entries.length > 1 && (
-            <div
-              className="flex h-full items-center overflow-hidden opacity-0 transition-opacity duration-150 group-hover/projects:opacity-100"
-              style={{
-                width: DOT_TRACK_W,
-                // Faded at both ends, so a dot leaving the track reads as
-                // sliding out rather than as being cut off.
-                maskImage:
-                  "linear-gradient(to right, transparent, black 30%, black 70%, transparent)",
-              }}
-            >
-              <div
-                className="flex items-center transition-transform duration-200 ease-out"
-                style={{
-                  gap: DOT_GAP,
-                  // Puts the active dot's centre on the track's centre.
-                  transform: `translateX(${DOT_TRACK_W / 2 - DOT / 2 - activeIndex * DOT_PITCH}px)`,
-                }}
-              >
-                {entries.map((entry, i) => (
-                  <span
-                    key={entry.path ?? ""}
-                    className={cn(
-                      "size-1 shrink-0 rounded-full transition-colors",
-                      i === activeIndex
-                        ? "bg-foreground/80"
-                        : "bg-muted-foreground/30",
-                    )}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
+        <DotTrack
+          count={entries.length}
+          activeIndex={activeIndex}
+          className="opacity-0 transition-opacity duration-150 group-hover/projects:opacity-100"
+        />
       </div>
     </div>
   );

--- a/apps/desktop/src/components/settings/SpacesSettings.tsx
+++ b/apps/desktop/src/components/settings/SpacesSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { ChevronDown, Pencil, Plus, Trash2, X } from "lucide-react";
+import { ChevronDown, ChevronUp, Pencil, Plus, Trash2, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -32,6 +32,7 @@ export default function SpacesSettings({
   onCreateSpace,
   onRenameSpace,
   onRemoveSpace,
+  onMoveSpace,
 }: {
   projects: Project[];
   spaces: string[];
@@ -44,6 +45,9 @@ export default function SpacesSettings({
   onCreateSpace: (name: string) => void;
   onRenameSpace: (from: string, to: string) => void;
   onRemoveSpace: (name: string) => void;
+  /// Steps a space one place. Order is the sidebar switcher's, which walks the
+  /// list in the order it is drawn here.
+  onMoveSpace: (name: string, delta: number) => void;
 }) {
   // The space being named — `""` for a new one, an existing name for a rename.
   // One at a time and held here rather than per row, so opening a second closes
@@ -89,7 +93,8 @@ export default function SpacesSettings({
 
         <p className="text-ui text-muted-foreground">
           Switching space in the sidebar shows that set of projects alone.
-          Everything else keeps running, out of sight and quiet.
+          Everything else keeps running, out of sight and quiet. This order is
+          the one the switcher steps through.
         </p>
 
         {naming === "" && (
@@ -106,7 +111,7 @@ export default function SpacesSettings({
           <p className="text-ui text-muted-foreground">No spaces yet.</p>
         )}
 
-        {spaces.map((name) =>
+        {spaces.map((name, i) =>
           naming === name ? (
             <SpaceNameField
               key={name}
@@ -148,6 +153,36 @@ export default function SpacesSettings({
                 </div>
               ) : (
                 <div className="flex shrink-0 items-center gap-0.5">
+                  {/* Two buttons rather than a drag handle: a row this size is
+                      a small thing to catch hold of, dragging says nothing
+                      about where it will land until it lands, and a keyboard
+                      reaches these. Disabled at the ends, since the list is the
+                      order and there is nowhere past them to go — the pair also
+                      says which end you are at, which a drag never does.
+
+                      `mr-1` sets the move controls apart from the two that act
+                      on the space itself, so one group is not read as four
+                      buttons doing four unrelated things. */}
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    disabled={i === 0}
+                    aria-label={`Move ${name} up`}
+                    onClick={() => onMoveSpace(name, -1)}
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <ChevronUp />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    disabled={i === spaces.length - 1}
+                    aria-label={`Move ${name} down`}
+                    onClick={() => onMoveSpace(name, 1)}
+                    className="mr-1 text-muted-foreground hover:text-foreground"
+                  >
+                    <ChevronDown />
+                  </Button>
                   {/* Renaming is a button, not the name itself: a label that
                       turns into a field when clicked is a control nothing says
                       is one, and the row already carries one real button. */}

--- a/apps/desktop/src/lib/space.test.ts
+++ b/apps/desktop/src/lib/space.test.ts
@@ -5,6 +5,7 @@ import {
   allowedInSpace,
   displayPath,
   inSpace,
+  moveSpace,
   sessionInSpace,
   spaceNames,
 } from "@/lib/space";
@@ -25,15 +26,27 @@ const projects = [
 ];
 
 describe("spaces", () => {
-  it("lists tags and declared names as one set, sorted", () => {
+  it("lists tags and declared names as one set, declared order first", () => {
     expect(spaceNames(projects)).toEqual(["Personal", "Work"]);
     // A space just made holds nothing, and a name is not doubled by being both
-    // declared and carried.
+    // declared and carried. The reader's own arrangement leads; a tag they have
+    // never declared follows it.
     expect(spaceNames(projects, ["Work", "Side"])).toEqual([
-      "Personal",
-      "Side",
       "Work",
+      "Side",
+      "Personal",
     ]);
+  });
+
+  it("steps a space one place and refuses to fall off either end", () => {
+    const names = ["Work", "Side", "Personal"];
+    expect(moveSpace(names, "Side", -1)).toEqual(["Side", "Work", "Personal"]);
+    expect(moveSpace(names, "Side", 1)).toEqual(["Work", "Personal", "Side"]);
+    // The ends are where the buttons are disabled, so a move arriving anyway
+    // must not wrap the space around to the other end.
+    expect(moveSpace(names, "Work", -1)).toEqual(names);
+    expect(moveSpace(names, "Personal", 1)).toEqual(names);
+    expect(moveSpace(names, "Gone", 1)).toEqual(names);
   });
 
   it("falls back to every project when the stored space no longer exists", () => {

--- a/apps/desktop/src/lib/space.ts
+++ b/apps/desktop/src/lib/space.ts
@@ -14,14 +14,39 @@ export const SPACE_KEY = "ade.space";
 /// project filed on another machine from reading as filed nowhere.
 export const SPACE_LIST_KEY = "ade.spaces";
 
-/// Every space there is. Sorted, since creation order would reorder the
-/// switcher under the reader every time a project moved.
+/// Every space there is, in the order the switcher walks them.
+///
+/// The declared list **is** the order — it is what the reader arranges — so it
+/// leads as written. A name carried only by a project's tag is one filed on
+/// another machine, with no place in this reader's arrangement yet, so those
+/// follow sorted: alphabetical is arbitrary but stable, where the order
+/// projects happen to be attached in would move the switcher under the reader
+/// every time one did.
 export function spaceNames(projects: Project[], declared: string[] = []): string[] {
   const tagged = projects
     .map((p) => p.space)
     .filter((s): s is string => Boolean(s));
 
-  return [...new Set([...declared, ...tagged])].sort((a, b) => a.localeCompare(b));
+  const undeclared = [...new Set(tagged)]
+    .filter((s) => !declared.includes(s))
+    .sort((a, b) => a.localeCompare(b));
+
+  return [...new Set([...declared, ...undeclared])];
+}
+
+/// The list with one name stepped `delta` places.
+///
+/// A step off either end is the list unchanged rather than a wrap: the buttons
+/// are disabled there, so a move that arrives anyway is a mistake to absorb and
+/// not a request to send the space to the other end.
+export function moveSpace(names: string[], name: string, delta: number): string[] {
+  const from = names.indexOf(name);
+  const to = from + delta;
+  if (from === -1 || to < 0 || to >= names.length) return names;
+
+  const next = [...names];
+  next.splice(to, 0, ...next.splice(from, 1));
+  return next;
 }
 
 /// The space actually in force. A stored name that has since been removed falls


### PR DESCRIPTION
## TLDR for human

- The sidebar's space switcher is now shaped like the project filter: the name over a dot track, a click steps to the next space. No dropdown, no swipe.
- Spaces can be reordered — ▲▼ on each row in Settings › Spaces. That order is the one the switcher walks.
- With no space made yet, the cycle carries a **New space** entry instead of the strip holding a ＋ button for good.
- `DotTrack` is now shared with the project filter, and always slides. Project switching renders identically to before.

---

**Why a switcher and not a menu.** Two controls scope the same session list and they should not be two different kinds of control. The dots also say how many spaces there are, which the chevron never did.

**The slide is the feel.** Centring the dot *group* while it fits was tried, and it takes the motion away — with the group centred there is nothing left to move and a switch becomes a colour change. The track holds its width and the row slides under a fixed centre, active dot in the middle. `DotTrack` carries that as a comment so it doesn't come back.

**Order is the declared list.** `spaceNames` leads with the reader's own arrangement and appends any name carried only by a project's tag, sorted — those are spaces filed on another machine, with no place in this reader's order yet. Moving one writes the whole list back, which declares such a name on the way past; that is the only way it has somewhere to be moved to. Membership is still the tag on the project and is untouched.

**Why the ＋ went.** A button standing in the strip for good is a permanent offer to somebody who may never want a space. As a cycle entry it is only ever met by a reader who stepped onto it, and it drops out the moment a space exists, so ordinary switching can never land on it. It is lit by the name field actually being up, so cancelling the dialog puts the switcher back on All Spaces with no state to unwind.

**Alignment.** The dots sit out of flow, or the name rides high of the session header beside it. The label is every entry in one grid cell with the inactive ones hidden, so the box is the width of the longest name and never resizes mid-switch.

Fixes DRA-158

🤖 Generated with [Claude Code](https://claude.com/claude-code)