### PR TITLE
Track download button clicks

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
-import { AppleGlyph } from "@/components/AppleGlyph";
 import { ClaudeGlyph } from "@/components/ClaudeGlyph";
+import { DownloadButton } from "@/components/DownloadButton";
 // import { Board } from "@/components/Board";
 import { Features } from "@/components/Features";
 import { Footer } from "@/components/Footer";
@@ -10,7 +10,7 @@ import { PiGlyph } from "@/components/PiGlyph";
 import { Testimonials } from "@/components/Testimonials";
 import { UsedBy } from "@/components/UsedBy";
 // import { Tweets } from "@/components/Tweets";
-import { DOWNLOAD, DOWNLOAD_SIZE } from "@/lib/links";
+import { DOWNLOAD_SIZE } from "@/lib/links";
 import hero from "../../public/hero-pr-dray.png";
 
 /// Two widths, nested. The shell caps at 6xl and only the hero screenshot
@@ -72,13 +72,7 @@ export default function Home() {
         </p>
 
         <div className="mt-5 flex items-center gap-3">
-          <a
-            href={DOWNLOAD}
-            className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-2.5 text-sm font-medium text-background transition-opacity hover:opacity-90"
-          >
-            <AppleGlyph className="size-4" />
-            Download for macOS
-          </a>
+          <DownloadButton />
           <span className="text-sm text-muted-foreground">{DOWNLOAD_SIZE}</span>
         </div>
 

--- a/apps/web/src/components/DownloadButton.tsx
+++ b/apps/web/src/components/DownloadButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { track } from "@vercel/analytics";
+import { AppleGlyph } from "@/components/AppleGlyph";
+import { DOWNLOAD } from "@/lib/links";
+
+/// The download link, split out as a client component so the click can be
+/// counted. The href is a plain navigation off-site, so the event fires on the
+/// way out — `track` posts with `keepalive`, which is what lets it survive the
+/// unload.
+export function DownloadButton() {
+  return (
+    <a
+      href={DOWNLOAD}
+      onClick={() => track("download", { platform: "macos" })}
+      className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-2.5 text-sm font-medium text-background transition-opacity hover:opacity-90"
+    >
+      <AppleGlyph className="size-4" />
+      Download for macOS
+    </a>
+  );
+}


### PR DESCRIPTION
The homepage download button was a plain anchor, so Vercel Analytics counted the pageview and nothing else. It now fires `track("download", { platform: "macos" })` on click.

Split into a small client component so `page.tsx` stays a server component. The href is unchanged.

Custom events may need a Pro plan on the Vercel project — worth checking Analytics → Events after deploy.

Fixes DRA-161

🤖 Generated with [Claude Code](https://claude.com/claude-code)