### PR TITLE
Reserve width for the sidebar row's orb

### DIFF
--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -1989,7 +1989,12 @@ function SessionRow({
             read at once; `visibility` would flip instantly while the button's
             inherited `transition-all` still crossfades, which is what read as an
             overlap. */}
-        <div className="relative flex shrink-0 items-center justify-end self-stretch pl-2">
+        {/* `min-w-5` because the slot's width comes from the buttons, and a row
+            that inherits its pin while mid-turn draws neither of them — leaving
+            a zero-width slot for the absolutely-drawn orb to hang out of, over
+            the title. 20px is the orb's own box, the widest thing that can be
+            shown with no button beside it. */}
+        <div className="relative flex min-w-5 shrink-0 items-center justify-end self-stretch pl-2">
           {/* `pointer-events-none` unconditionally: it's never a target, and a
               faded-but-present element still hit-tests — stacked on `right-0` it
               would otherwise swallow the cursor over the last button, which reads


### PR DESCRIPTION
A session row's right-hand slot takes its width from the hover buttons. A row inheriting its pin draws no Pin button and a row mid-turn draws no Settle button — both absent together collapses the slot to zero width, and the absolutely-placed orb hangs out over the truncated title.

`min-w-5` on the slot: the orb's own 20px box, the widest thing that can be drawn there with no button beside it.

Fixes DRA-162

🤖 Generated with [Claude Code](https://claude.com/claude-code)