### PR TITLE
Cmd+F focuses sidebar search, and unsettling clears the query

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -39,6 +39,7 @@ import RightPanel, {
   type PanelTab,
 } from "@/components/RightPanel";
 import Sidebar, {
+  SEARCH_INPUT_ID,
   SidebarToggle,
   filterSessions,
   sortSessions,
@@ -465,6 +466,10 @@ function App() {
   // and a session dropping out of it as a query is typed would stop its repo
   // being polled and make the notice forget a pull request was already ready.
   const [search, setSearch] = useState("");
+  // Whether the sidebar's search row is drawn as a field. Up here rather than in
+  // the sidebar, since ⌘F has to open it from a collapsed one, which is not
+  // mounted at all.
+  const [searchOpen, setSearchOpen] = useState(false);
   const searchedSessions = useMemo(
     () => filterSessions(visibleSessions, search),
     [visibleSessions, search],
@@ -1038,6 +1043,12 @@ function App() {
     if (flags.archived === true && sessionId === selectedSessionId) {
       goToSession(handleNewSession);
     } else if (flags.archived === false) {
+      // Unsettling is the reader saying they found what they came for, so the
+      // query that found it has done its job — and left standing it would hide
+      // the row they just acted on, since the list it lands in is filtered too.
+      setSearch("");
+      setSearchOpen(false);
+
       // The row has just left whichever list it was drawn from, so follow it to
       // the one it landed in and keep it selected — from the sidebar's menu the
       // reader pressed that row, and from the composer's bar they are reading
@@ -1057,6 +1068,15 @@ function App() {
 
   const toggleSidebar = () => setCollapsed((prev) => !prev);
   useHotkey("b", toggleSidebar);
+  // Takes the sidebar with it: the field lives there, and a chord that opened a
+  // search nobody can see would be worse than no chord. `autoFocus` covers the
+  // field this press mounts; the select covers the one already on screen, which
+  // is also what makes ⌘F on a query a replace rather than an append.
+  useHotkey("f", () => {
+    setCollapsed(false);
+    setSearchOpen(true);
+    document.querySelector<HTMLInputElement>(`#${SEARCH_INPUT_ID}`)?.select();
+  });
   useHotkey("n", () => goToSession(handleNewSession));
   // Steps the composer's project picker, and only while that picker is on
   // screen: it is drawn for a new task alone, and `enabled` unregisters rather
@@ -1223,6 +1243,8 @@ function App() {
           items={searchedSessions}
           search={search}
           onSearchChange={setSearch}
+          searchOpen={searchOpen}
+          onSearchOpenChange={setSearchOpen}
           projects={spaceProjects}
           spaces={spaces}
           space={space}

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -58,6 +58,11 @@ import type {
   UpdateStatus,
 } from "@/types/events";
 
+/// The sidebar's search field. Named so ⌘F can reach it from `App`: the chord
+/// has to work with the sidebar collapsed, so it lives up there, and `autoFocus`
+/// only covers the field being *mounted* by that same press.
+export const SEARCH_INPUT_ID = "sidebar-search";
+
 type SidebarProps = {
   // Already scoped to `projectFilter` and to `search` by the caller, so the list
   // and the ⌘⇧↑/↓ walk step through exactly the same rows.
@@ -67,6 +72,13 @@ type SidebarProps = {
   // would leave the shortcut stepping rows the sidebar no longer draws.
   search: string;
   onSearchChange: (query: string) => void;
+  /// Whether the search row is drawn as an input rather than as its button.
+  /// Apart from the query itself, since an empty input and the button look the
+  /// same and this is only about where the caret is — and owned by the caller
+  /// because ⌘F has to open it from a *collapsed* sidebar, which is not
+  /// mounted.
+  searchOpen: boolean;
+  onSearchOpenChange: (open: boolean) => void;
   // The live status of every session the app has heard about this run. Wins over
   // the item's own field, which is only as fresh as the last list fetch.
   statusBySession: Record<string, SessionStatus>;
@@ -762,6 +774,8 @@ export default function Sidebar({
   items,
   search,
   onSearchChange,
+  searchOpen,
+  onSearchOpenChange,
   statusBySession,
   askingSessions,
   prFor,
@@ -795,13 +809,8 @@ export default function Sidebar({
 }: SidebarProps) {
   const fullscreen = useFullscreen();
 
-  // Whether the search row is drawn as an input rather than as its button. Kept
-  // apart from the query itself: the empty input and the button look the same,
-  // so this is only about where the caret is.
-  const [searching, setSearching] = useState(false);
-
   const closeSearch = () => {
-    setSearching(false);
+    onSearchOpenChange(false);
     onSearchChange("");
   };
 
@@ -984,11 +993,12 @@ export default function Sidebar({
             that is otherwise plain buttons. The transparent border is what holds
             that promise to the pixel: every button carries one, so the icon
             would sit a pixel further out without it. */}
-        {searching ? (
+        {searchOpen ? (
           <div className="flex h-7 w-full items-center gap-1 border border-transparent px-1.5 text-ui">
             <Search className="size-3.5 shrink-0" />
             <input
               autoFocus
+              id={SEARCH_INPUT_ID}
               type="text"
               value={search}
               placeholder="Search"
@@ -1005,20 +1015,29 @@ export default function Sidebar({
               // Only where there is nothing to lose. Clicking away from a query
               // that is narrowing the list is not a request to drop it.
               onBlur={() => {
-                if (!search) setSearching(false);
+                if (!search) onSearchOpenChange(false);
               }}
               className="min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
             />
+            {/* Where ⌘F's keycaps were, saying the other half: Escape is the
+                way out and it takes the query with it. Only with something to
+                lose — over an empty field it would be naming the way out of a
+                state nothing is holding open. */}
+            {search && <Kbd>Esc</Kbd>}
           </div>
         ) : (
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => setSearching(true)}
+            onClick={() => onSearchOpenChange(true)}
             className="w-full justify-start px-1.5 text-ui text-sidebar-foreground/80 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground/80 dark:hover:bg-sidebar-accent/50"
           >
             <Search />
             Search
+            <KbdGroup className="ml-auto">
+              <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+              <Kbd>F</Kbd>
+            </KbdGroup>
           </Button>
         )}
       </div>


### PR DESCRIPTION
⌘F opens the sidebar's search field and selects whatever is in it. Bound in `App` rather than `Sidebar`, because it has to work with the sidebar collapsed — which unmounts it — so the open/closed state is lifted out and the field carries an id `App` can reach. `autoFocus` covers the field the press mounts; the select covers the one already on screen.

Keycaps are drawn on the Search button like New Task and Issues, and `Esc` takes that slot while the field holds a query — Escape already closed the field and dropped the query, and nothing on screen said so.

Unsettling a task clears the query and closes the field: unsettling is the reader saying they found what they came for, and the list the row lands in is filtered by the same query.

Fixes DRA-175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
