### PR TITLE
Rename main-column Changes tab to Diff

### DIFF
--- a/apps/desktop/src/components/layout/ViewTabs.tsx
+++ b/apps/desktop/src/components/layout/ViewTabs.tsx
@@ -12,7 +12,7 @@ export type ViewTab = (typeof VIEW_TABS)[number];
 
 const LABELS: Record<ViewTab, string> = {
   chat: "Chat",
-  changes: "Changes",
+  changes: "Diff",
   browser: "Browser",
 };
 


### PR DESCRIPTION
The main column's tab is now "Diff". The right panel's Changes tab is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)