### PR TITLE
Change an issue's status and priority from Dray

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,15 @@ Linear puts uploads *in* the description's markdown, pointing at `uploads.linear
 - **Panel tab `issue`, hidden with no link.** Rows are drawn from the session's own `IssueRef`s, so the tab exists the moment something links one. **Linking is the agent's**, through `dray issue link`. The description is drawn here where the PR panel leaves the PR body out, and the difference is who wrote it.
 - **No Start button** — it would create a session, so it must name a project, and the page is workspace-wide. Tagging with `#` in the composer already starts work against an issue from a place that knows the project.
 
-**Dray never writes to the tracker** — no status move, no comment, no attachment. The skill says so out loud, because an agent assuming otherwise tells the user their issue moved when nothing of the sort happened.
+**Dray writes exactly two fields, and only from the opened issue's header** — status and priority, through `update_issue` over Linear's `issueUpdate`. Nothing else: no comment, no attachment, no assignee, no label. **The `dray` CLI writes nothing at all**, and [SKILL.md](apps/cli/skill/SKILL.md) says so out loud, because an agent assuming otherwise tells the user their issue moved when nothing of the sort happened.
+
+The two menus live on `IssueRow`'s header in [IssuePanel](apps/desktop/src/components/IssuePanel.tsx), so the session's Issue tab and the Issues page get them from one component. **A status menu is drawn from `IssueDetail.states`, the issue's own *team* workflow, which rides the read the panel already makes** — a menu that has to fetch before it can open is a menu that opens empty. Sorted by kind and *then* `position`: Linear only makes position meaningful within one state type, so a single sort on it lists Done above Todo. No states means no menu, just the glyph.
+
+**`None` means leave it and `Some(None)` means clear it**, which is why priority crosses as `Option<IssuePriority>` rather than a number — "no priority" is a level a reader can pick and it goes down the wire as `0`. **`issueUpdate` answers `success: false` at 200 with no `errors`** for a write it understood and refused, so that field is checked; without it the panel re-reads, finds nothing moved, and silently redraws what was already there. The mutation's own `issue` echo is deliberately unread — the panel draws a whole `IssueDetail`, and asking for that field set back would be a fourth copy of it in `linear.rs`.
+
+**A write is the one moment every cached answer about issues stops being true**, so `update` calls `forgetIssues()` and then puts the freshly-read detail back — *after* the generation bump, or the guard that makes the clearing stick refuses it. `useIssueList` subscribes to that generation for the same reason: without it the row beside the panel keeps saying "Backlog" under a heading the issue has just left. Failure reports through the panel's existing banner; nothing is optimistic.
+
+**⌘-click on an issue row opens it in the tracker**, on the panel's rows and the page's list alike — the same modifier the transcript's link dialog uses to mean "out there, not here". A shortcut, not the affordance: the row's own button is that.
 
 ## Opening the working directory
 
@@ -825,7 +833,7 @@ Several things are deliberately unfinished — don't mistake them for bugs.
 - **Only *ranged* `Read` renders its code; a whole-file read has no expander at all.** That read is the agent pulling a file into context, not showing it to the reader, and its result is the file itself. A *failed* read still expands, since its error text is the only place the reason lives. A read of an image is the exception.
 - **The PR panel reads and acts, never writes prose.** No commenting, no replying to a review, no requesting review, no closing.
 - **Forks copy the conversation whole and record no lineage.** The CLI exposes no fork-at-message, and `fork_from` is cleared once the CLI carries the fork out, so nothing on disk says which session a fork came from.
-- **Dray never writes to the issue tracker**, and there is **no issue-side project mapping** — the connection is workspace-wide.
+- **Dray writes only status and priority**, from the opened issue's header — no comment, no attachment, no assignee, no label — and there is **no issue-side project mapping**, the connection being workspace-wide. The `dray` CLI writes nothing.
 - **The handoff row has no Revert, Amend or Stash** — each destroys or rewrites work, and a button that sends a prompt for one is a button whose blast radius is decided by the model. No Push either, and that one went on width.
 - **The repo view reads — no fetch, no pull, no discard.** The ahead count is against the *last known* upstream, so a branch someone else pushed to reads as level until the push itself fails.
 - **Sidebar PR marks say open, draft or merged; checks say running or failing.** No number, no per-check detail, no merge readiness, nothing at all for passing.

--- a/apps/cli/skill/SKILL.md
+++ b/apps/cli/skill/SKILL.md
@@ -315,10 +315,11 @@ the cure is safe.
 
 ## Limits
 
-- **Dray does not write to the tracker.** Tagging records the link on the
+- **`dray` does not write to the tracker.** Tagging records the link on the
   session and nothing else: no status change, no comment, no attachment. If the
   user wants the issue moved or commented on, do it through the tracker's own
-  MCP server.
+  MCP server. (The app's own issue panel has status and priority menus, but they
+  are the user's to click — nothing here reaches them.)
 - **The browser is the session's own.** `dray browser` reaches the tabs of the
   session running it and nothing else; downloads, file pickers and native
   dialogs are out of reach.

--- a/apps/desktop/COPY-ISSUES.md
+++ b/apps/desktop/COPY-ISSUES.md
@@ -30,13 +30,17 @@ it until connected would hide its own entrance.
 
 **Subtext, under the heading**
 
-> Paste a personal API key with read access. Dray only reads — it never changes an issue.
+> Paste a personal API key with read and write access. A read-only key works too — you just cannot change a status or priority.
 
-Two sentences, the shape the analytics row uses: what it needs, and what it will
-never do. "Read access" is the whole point of the first — it is the smallest
-thing that works, and saying so makes pasting a credential into a desktop app a
-smaller decision. The second is what stops anyone expecting their issue to move
-to In Progress on its own.
+Two sentences: what it needs, and what the smaller version of that costs. Write
+is named first because the app now does it — the status and priority menus in an
+opened issue's header — and a reader who found that out from a menu that failed
+would rightly read it as the app being broken.
+
+Read-only is still offered, and second, because it is what somebody wary of
+pasting a credential into a desktop app can give. Naming the cost exactly, rather
+than warning them off, is what keeps that a small decision: everything on this
+page works, and two menus do not.
 
 **Key field placeholder**
 
@@ -53,7 +57,7 @@ to In Progress on its own.
 
 **Note under it**, above a rule — the other half of the setup
 
-> This key is read-only, and it is for Dray. To let the agent read and manage issues in chat, add [Linear's MCP server](https://linear.app/docs/mcp) to your CLI.
+> Dray reads your issues with this key, and writes only the status or priority you pick. To let the agent read and manage issues in chat, add [Linear's MCP server](https://linear.app/docs/mcp) to your CLI.
 
 Said here and only here. The key fills Dray's own screens and gives the agent
 nothing; someone who finds that out later finds it out from a model working off

--- a/apps/desktop/src-tauri/src/issues/issues.rs
+++ b/apps/desktop/src-tauri/src/issues/issues.rs
@@ -80,12 +80,34 @@ impl IssueStateKind {
     pub fn settled(self) -> bool {
         matches!(self, Self::Completed | Self::Canceled)
     }
+
+    /// Where the kind sits in the workflow, so a status menu reads in the order
+    /// work moves through rather than in whatever order the API listed.
+    ///
+    /// Linear orders a team's states by type first and by `position` only
+    /// *within* one, so position alone is not an ordering across the whole
+    /// workflow — sorting by it puts "Done" above "Todo" wherever a workspace
+    /// has been reorganised.
+    pub fn flow_rank(self) -> u8 {
+        match self {
+            Self::Triage => 0,
+            Self::Backlog => 1,
+            Self::Unstarted => 2,
+            Self::Started => 3,
+            Self::Completed => 4,
+            Self::Canceled => 5,
+            Self::Other => 6,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "events.ts")]
 #[serde(rename_all = "camelCase")]
 pub struct IssueState {
+    /// The tracker's own id. What a status write names — a state is addressed
+    /// by id and never by name, since two teams can both call one "In Review".
+    pub id: String,
     pub name: String,
     pub kind: IssueStateKind,
     /// The tracker's own colour, so a status reads the same here as it does in
@@ -116,6 +138,20 @@ impl IssuePriority {
             3 => Self::Medium,
             4 => Self::Low,
             _ => Self::None,
+        }
+    }
+
+    /// Level back to wire integer. The inverse of [`from_wire`], and the only
+    /// place a priority write spells a number.
+    ///
+    /// [`from_wire`]: Self::from_wire
+    pub fn to_wire(self) -> i64 {
+        match self {
+            Self::Urgent => 1,
+            Self::High => 2,
+            Self::Medium => 3,
+            Self::Low => 4,
+            Self::None => 0,
         }
     }
 
@@ -211,6 +247,14 @@ pub struct IssueDetail {
     /// for, which the panel says plainly rather than drawing an empty box.
     pub description: Option<String>,
     pub comments: Vec<IssueComment>,
+    /// Every status this issue's own team offers, in workflow order — what the
+    /// header's status menu draws.
+    ///
+    /// On the detail rather than read by a command of its own, because it rides
+    /// the read the panel already makes: a menu that has to fetch before it can
+    /// open is a menu that opens empty. Per *team*, so an issue moved between
+    /// teams offers the states of wherever it now lives.
+    pub states: Vec<IssueState>,
 }
 
 /// Whose issues to list.
@@ -259,6 +303,13 @@ pub struct IssueQuery {
 pub struct IssueFilters {
     pub teams: Vec<IssueGroup>,
     pub projects: Vec<IssueGroup>,
+    /// Every team's workflow states, keyed by team **key** (`DRA`) — what a
+    /// row carries, where `teams` above is keyed by UUID.
+    ///
+    /// Here rather than on each issue because a workflow belongs to a team: one
+    /// answer serves every row that team owns, so the issues page's status menus
+    /// cost one read per connection instead of a copy per row.
+    pub team_states: HashMap<String, Vec<IssueState>>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -857,6 +908,37 @@ pub async fn get_issue(
     linear::get_issue(&key, &identifier, id.as_deref()).await
 }
 
+/// Moves an issue's status or priority, and answers with the issue as it now
+/// stands.
+///
+/// **The only write this app makes to a tracker.** Everything else here reads:
+/// a link is a fact about the session, and status and priority are the two
+/// things a reader otherwise leaves the app to change. Assignee, labels and
+/// comments stay out — the agent has the tracker's own MCP server for those,
+/// and each is a picker over a workspace-wide list this panel has no room for.
+///
+/// Both fields are optional and `None` means *leave it*, which is why priority
+/// arrives as an `Option<IssuePriority>` rather than as a number: "no priority"
+/// is a level a reader can choose ([`IssuePriority::None`], wire `0`), so a
+/// bare integer could not tell clearing one from not touching it.
+///
+/// Re-read afterwards rather than trusting the mutation's own echo: the panel
+/// draws a whole [`IssueDetail`], and one read is what keeps description,
+/// comments and the new status arriving as one answer.
+#[tauri::command]
+pub async fn update_issue(
+    identifier: String,
+    id: String,
+    state_id: Option<String>,
+    priority: Option<IssuePriority>,
+) -> Result<IssueDetail, IssueUnavailable> {
+    let key = read_key(IssueTracker::Linear).await.ok_or(IssueUnavailable::NotConnected)?;
+
+    linear::update_issue(&key, &id, state_id.as_deref(), priority).await?;
+
+    linear::get_issue(&key, &identifier, Some(&id)).await
+}
+
 /// A file uploaded to an issue, fetched with the stored key.
 ///
 /// **The whole reason this command exists.** Linear's uploads live behind the
@@ -905,8 +987,9 @@ pub async fn list_issue_filters() -> Result<IssueFilters, IssueUnavailable> {
 /// Reads the issue back before recording it, so the link carries the current
 /// title rather than whatever the caller believed — the CLI passes a string a
 /// person typed, and the picker one it read a moment ago.
-/// Untags a session. The issue itself is untouched — this app never writes to
-/// the tracker, so removing a link is a fact about the session alone.
+/// Untags a session. The issue itself is untouched: a link is a fact about the
+/// session, and the only write this app makes to a tracker is [`update_issue`],
+/// which a reader has to ask for by name.
 #[tauri::command]
 pub async fn unlink_issue(
     session_id: String,

--- a/apps/desktop/src-tauri/src/issues/linear.rs
+++ b/apps/desktop/src-tauri/src/issues/linear.rs
@@ -110,7 +110,7 @@ const ISSUES: &str = r#"
 query($filter:IssueFilter,$first:Int!){
  issues(filter:$filter,first:$first,orderBy:updatedAt){nodes{
   id identifier title url priority updatedAt
-  state{name type color}
+  state{id name type color}
   assignee{name avatarUrl}
   labels(first:10){nodes{name color}}
   team{key}
@@ -128,10 +128,10 @@ const ISSUE_BY_ID: &str = r#"
 query($id:String!){
  issue(id:$id){
   id identifier title url priority updatedAt description
-  state{name type color}
+  state{id name type color}
   assignee{name avatarUrl}
   labels(first:10){nodes{name color}}
-  team{key}
+  team{key states(first:50){nodes{id name type color position}}}
   project{name}
   comments(first:50){nodes{body createdAt url user{name avatarUrl}}}
  }}
@@ -147,10 +147,10 @@ const ISSUE: &str = r#"
 query($key:String!,$number:Float!){
  issues(filter:{team:{key:{eq:$key}},number:{eq:$number}},first:1){nodes{
   id identifier title url priority updatedAt description
-  state{name type color}
+  state{id name type color}
   assignee{name avatarUrl}
   labels(first:10){nodes{name color}}
-  team{key}
+  team{key states(first:50){nodes{id name type color position}}}
   project{name}
   comments(first:50){nodes{body createdAt url user{name avatarUrl}}}
  }}}
@@ -257,12 +257,18 @@ pub async fn fetch_asset(
     })
 }
 
-/// The filter row's options. Archived teams and projects are left out by
-/// Linear's own defaults, which is the right way round — a filter offering a
-/// team nobody works in is a row to skip past.
+/// The filter row's options, and every team's workflow with them. Archived
+/// teams and projects are left out by Linear's own defaults, which is the right
+/// way round — a filter offering a team nobody works in is a row to skip past.
+///
+/// The states ride this read rather than the list read, and that is the whole
+/// reason the issues page's rows can offer a status menu at all: a workflow is
+/// per *team*, so asking for it on every issue would repeat one team's answer a
+/// hundred times down the wire. Read once per connection, keyed by team key —
+/// which is what a row carries, `DRA` and not a UUID.
 const FILTERS: &str = r#"
 query{
- teams(first:100){nodes{id name}}
+ teams(first:100){nodes{id key name states(first:50){nodes{id name type color position}}}}
  projects(first:100){nodes{id name}}}
 "#;
 
@@ -386,7 +392,64 @@ fn read_detail(node: &Value, identifier: &str) -> Result<IssueDetail, IssueUnava
             .filter(|body| !body.is_empty())
             .map(str::to_string),
         comments: map_comments(node),
+        states: map_team_states(node),
     })
+}
+
+/// Moves an issue's status, its priority, or both.
+///
+/// One mutation for the pair, so a reader changing both in one go could never
+/// land half of it — and `issueUpdate` takes them in one input anyway. An
+/// input with neither field is refused before the request goes out: Linear
+/// answers `success` for it, which reads as a write that happened.
+///
+/// The mutation's own `issue` echo is deliberately not read. The panel draws a
+/// whole [`IssueDetail`] — description, comments, the team's states — and
+/// asking for that field set back here would be a fourth copy of it in this
+/// file, free to drift from the three above. The caller re-reads instead.
+const UPDATE: &str = r#"
+mutation($id:String!,$input:IssueUpdateInput!){
+ issueUpdate(id:$id,input:$input){success}}
+"#;
+
+/// The mutation's input, or `None` where the caller asked for no change.
+///
+/// Split out so the one thing worth pinning here is testable with nothing
+/// spawned: `Some(IssuePriority::None)` is a write of wire `0` and *not* the
+/// same as `None`, which is "leave it". Collapsing the two would make clearing
+/// a priority silently do nothing.
+fn update_input(state_id: Option<&str>, priority: Option<IssuePriority>) -> Option<Value> {
+    let mut input = serde_json::Map::new();
+
+    if let Some(state_id) = state_id {
+        input.insert("stateId".into(), json!(state_id));
+    }
+    if let Some(priority) = priority {
+        input.insert("priority".into(), json!(priority.to_wire()));
+    }
+
+    (!input.is_empty()).then(|| Value::Object(input))
+}
+
+pub async fn update_issue(
+    key: &str,
+    id: &str,
+    state_id: Option<&str>,
+    priority: Option<IssuePriority>,
+) -> Result<(), IssueUnavailable> {
+    let input = update_input(state_id, priority)
+        .ok_or_else(|| IssueUnavailable::Other("Nothing to change".into()))?;
+
+    let data = query(key, UPDATE, json!({ "id": id, "input": input })).await?;
+
+    // `success: false` is how Linear refuses a write it understood — a state
+    // belonging to another team, most likely. It comes back at 200 with no
+    // `errors`, so without this the panel re-reads, finds nothing moved, and
+    // silently redraws what the reader was already looking at.
+    match data.pointer("/issueUpdate/success").and_then(Value::as_bool) {
+        Some(true) => Ok(()),
+        _ => Err(IssueUnavailable::Other("Linear refused the change".into())),
+    }
 }
 
 pub async fn list_filters(key: &str) -> Result<IssueFilters, IssueUnavailable> {
@@ -395,6 +458,16 @@ pub async fn list_filters(key: &str) -> Result<IssueFilters, IssueUnavailable> {
     Ok(IssueFilters {
         teams: map_groups(&data, "teams"),
         projects: map_groups(&data, "projects"),
+        // A team with no key names nothing a row could join on, so it is left
+        // out rather than filed under an empty string — where it would answer
+        // for every row whose own team came back blank.
+        team_states: nodes(&data, "teams")
+            .iter()
+            .filter_map(|team| {
+                let key = optional(team, "key")?;
+                Some((key, map_states(team)))
+            })
+            .collect(),
     })
 }
 
@@ -543,6 +616,7 @@ fn map_issue(node: &Value) -> Option<Issue> {
 fn map_state(value: Option<&Value>) -> IssueState {
     let Some(value) = value.filter(|v| !v.is_null()) else {
         return IssueState {
+            id: String::new(),
             name: "Unknown".into(),
             kind: IssueStateKind::Other,
             color: String::new(),
@@ -550,6 +624,7 @@ fn map_state(value: Option<&Value>) -> IssueState {
     };
 
     IssueState {
+        id: text(value, "id"),
         name: text(value, "name"),
         kind: match value
             .get("type")
@@ -566,6 +641,43 @@ fn map_state(value: Option<&Value>) -> IssueState {
         },
         color: text(value, "color"),
     }
+}
+
+/// The team's own workflow states, in the order Linear draws them.
+///
+/// Sorted by kind and then by `position`, which is the two-level ordering
+/// Linear itself uses: `position` is only meaningful *within* a type, so a
+/// single sort on it interleaves Done with Todo. A state with no id is dropped
+/// — it names nothing a write could set.
+fn map_team_states(node: &Value) -> Vec<IssueState> {
+    let Some(team) = node.get("team").filter(|team| !team.is_null()) else {
+        return Vec::new();
+    };
+
+    map_states(team)
+}
+
+/// The same, from a team node itself — what the filters read hands back.
+fn map_states(team: &Value) -> Vec<IssueState> {
+    let mut states: Vec<(f64, IssueState)> = nodes(team, "states")
+        .iter()
+        .filter(|state| !text(state, "id").is_empty())
+        .map(|state| {
+            (
+                state.get("position").and_then(Value::as_f64).unwrap_or(0.0),
+                map_state(Some(state)),
+            )
+        })
+        .collect();
+
+    states.sort_by(|(a_pos, a), (b_pos, b)| {
+        a.kind
+            .flow_rank()
+            .cmp(&b.kind.flow_rank())
+            .then(a_pos.total_cmp(b_pos))
+    });
+
+    states.into_iter().map(|(_, state)| state).collect()
 }
 
 fn map_person(value: &Value) -> Option<IssuePerson> {
@@ -842,6 +954,70 @@ mod tests {
         assert!(first_error(&json!({ "data": { "viewer": {} } })).is_none());
         // An error array with an unfamiliar shape still reads as an error.
         assert!(first_error(&json!({ "errors": [{}] })).is_some());
+    }
+
+    /// `position` alone is not an ordering across a workflow — Linear only
+    /// makes it meaningful *within* one state type, so a team whose states were
+    /// reordered lists Done above Todo unless the kind is sorted on first.
+    #[test]
+    fn team_states_read_in_workflow_order() {
+        let node = json!({ "team": { "key": "DRA", "states": { "nodes": [
+            { "id": "d", "name": "Done", "type": "completed", "color": "#0a0", "position": 0.0 },
+            { "id": "r", "name": "In Review", "type": "started", "color": "#fc0", "position": 2.0 },
+            { "id": "p", "name": "In Progress", "type": "started", "color": "#fc0", "position": 1.0 },
+            { "id": "t", "name": "Todo", "type": "unstarted", "color": "#eee", "position": 9.0 },
+            // No id: nothing a write could name, so it is dropped rather than
+            // offered as a status that cannot be set.
+            { "name": "Ghost", "type": "started", "color": "#000", "position": 0.0 }
+        ]}}});
+
+        let names: Vec<_> = map_team_states(&node)
+            .iter()
+            .map(|state| state.name.clone())
+            .collect();
+
+        assert_eq!(names, ["Todo", "In Progress", "In Review", "Done"]);
+    }
+
+    /// An issue with no team on it must not fail the read — the panel simply
+    /// draws its status as a glyph with no menu behind it.
+    #[test]
+    fn a_teamless_issue_offers_no_states() {
+        assert!(map_team_states(&json!({ "team": Value::Null })).is_empty());
+        assert!(map_team_states(&json!({})).is_empty());
+    }
+
+    /// "No priority" is a level a reader can pick, so it has to reach the wire
+    /// as `0` — and an absent priority has to reach it not at all.
+    #[test]
+    fn clearing_a_priority_is_not_the_same_as_leaving_it() {
+        assert_eq!(
+            update_input(None, Some(IssuePriority::None)),
+            Some(json!({ "priority": 0 }))
+        );
+        assert_eq!(
+            update_input(Some("state-1"), None),
+            Some(json!({ "stateId": "state-1" }))
+        );
+        // Linear answers `success` for an empty input, which would read as a
+        // write that happened.
+        assert_eq!(update_input(None, None), None);
+    }
+
+    /// Every level survives the trip out and back. The two tables are written
+    /// separately and a typo in either is invisible until a priority set here
+    /// reads back as a different one.
+    #[test]
+    fn priority_round_trips_through_the_wire() {
+        for level in [
+            IssuePriority::Urgent,
+            IssuePriority::High,
+            IssuePriority::Medium,
+            IssuePriority::Low,
+            IssuePriority::None,
+        ] {
+            assert_eq!(IssuePriority::from_wire(level.to_wire()), level);
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -658,6 +658,7 @@ pub fn run() {
             issues::fetch_issue_asset,
             issues::list_issue_filters,
             issues::unlink_issue,
+            issues::update_issue,
             github::prs_for_branch,
             github::pr_marks,
             github::merge_pr,

--- a/apps/desktop/src/components/IssueMenus.tsx
+++ b/apps/desktop/src/components/IssueMenus.tsx
@@ -1,0 +1,214 @@
+/// The two writes this app makes to a tracker, as two glyphs that open menus.
+///
+/// One component for both surfaces that offer them — the panel's row header and
+/// the issues page's list rows — since a status moved from one place and a
+/// status moved from the other are the same act, and two copies would be two
+/// vocabularies for it.
+///
+/// They call [updateIssue] themselves rather than taking a callback. There is no
+/// state behind the write: it drops every cached answer and every mounted list
+/// and panel re-reads off that, so a prop threaded down from `App` would carry
+/// nothing the module does not already have.
+///
+/// [updateIssue]: ../hooks/useIssues.ts
+import { useState } from "react";
+
+import IssueStateIcon, { IssuePriorityIcon, PRIORITY_LABEL } from "@/components/IssueStateIcon";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Kbd } from "@/components/ui/kbd";
+import { updateIssue } from "@/hooks/useIssues";
+
+import type { IssuePriority, IssueState } from "@/types/events";
+
+/// What a menu needs to name the issue it writes to. Satisfied by both `Issue`
+/// and `IssueDetail`, which is what lets one component serve a list row and an
+/// opened body without knowing which it has.
+type Target = { identifier: string; id: string };
+
+/// One row of a menu. The two menus differ only in what fills this, which is
+/// why the keyboard rule below is written once.
+type Choice = {
+  key: string;
+  glyph: React.ReactNode;
+  label: string;
+  checked: boolean;
+  pick: () => void;
+};
+
+/// Urgent first, the order Linear's own menu uses and the order `IssuePriority`
+/// sorts by. "No priority" last, because it is the thing being cleared to rather
+/// than a level in its own right.
+const PRIORITIES: IssuePriority[] = ["urgent", "high", "medium", "low", "none"];
+
+/// How many rows get a number. One digit, so the tenth row and beyond are
+/// reachable by arrow and mouse alone — a two-key shortcut in a menu this small
+/// would cost more to read than the row it saves.
+const NUMBERED = 9;
+
+/// A glyph that opens a menu, without becoming a second thing to look at.
+///
+/// The trigger draws the mark the row drew before it and nothing else — no
+/// chevron, no border, no label. Status and priority are read at a glance far
+/// more often than they are changed, so the resting row has to say exactly what
+/// it said when it was only a picture; hover is where it admits to being a
+/// control.
+///
+/// **A `span`, not a `button`.** The issues page's row is itself a `button` and
+/// one cannot nest another — the same bargain `FileLink` makes, and the reason
+/// the "Work on it" control beside this is a span too.
+///
+/// Two containment rules, and they are not the same rule twice:
+///
+/// - **The click is stopped on the trigger *and* on the content.** A React
+///   portal bubbles through the React tree, not the DOM one, so a click on a
+///   menu item reaches the row's own `onClick` and opens the pane behind the
+///   menu the reader was answering.
+/// - **The keydown is stopped nowhere.** `useHotkey` listens on `document`, and
+///   Radix returns focus to this trigger when the menu closes — so a blanket
+///   `stopPropagation` here silently killed every shortcut in the app from the
+///   first time anybody opened one of these. Nothing needs it: the panel's row
+///   ignores keys whose target is not itself, and a `button` row only activates
+///   on its own focus.
+function GlyphMenu({
+  label,
+  children,
+  choices,
+}: {
+  label: string;
+  children: React.ReactNode;
+  choices: Choice[];
+}) {
+  // Controlled, so a numbered pick can close the menu it was made in. Radix
+  // closes on a click of its own; a key this component handles is ours to end.
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <span
+          role="button"
+          tabIndex={0}
+          // `aria-label` and no `title`: the menu names the current row on
+          // opening, so the OS tooltip only sat over the glyph repeating it a
+          // second late — and the app's rule is that a tooltip is a real one or
+          // nothing.
+          aria-label={label}
+          onClick={(e) => e.stopPropagation()}
+          // Padding pulled back out as margin, so a hit area and a hover fill
+          // around the glyph do not move the row it sits in.
+          className="-m-1 flex shrink-0 items-center rounded-md p-1 transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+        >
+          {children}
+        </span>
+      </DropdownMenuTrigger>
+
+      {/* Wider than the trigger, which is one glyph — the content's default
+          width tracks the trigger's. */}
+      <DropdownMenuContent
+        align="start"
+        className="w-52"
+        onClick={(e) => e.stopPropagation()}
+        // A digit picks the row wearing it. `preventDefault` is what takes the
+        // key off Radix's own typeahead, which composes after this handler and
+        // would otherwise treat "3" as the start of a label to jump to.
+        onKeyDown={(e) => {
+          if (e.metaKey || e.ctrlKey || e.altKey) return;
+          const n = Number(e.key);
+          if (!Number.isInteger(n) || n < 1 || n > Math.min(choices.length, NUMBERED)) return;
+
+          e.preventDefault();
+          setOpen(false);
+          choices[n - 1].pick();
+        }}
+      >
+        {choices.map((choice, i) => (
+          <DropdownMenuCheckboxItem
+            key={choice.key}
+            checked={choice.checked}
+            // The current row is a checkmark, not a disabled one: picking it
+            // again is a no-op the reader can make freely, where a greyed row in
+            // the middle of a list reads as a state that cannot be reached.
+            onCheckedChange={choice.pick}
+          >
+            {choice.glyph}
+            {choice.label}
+
+            {/* The row's right edge holds one thing: the number that picks it,
+                or the check saying it is already picked. They share the slot
+                rather than sitting side by side — a shortcut for the state the
+                issue is already in is a key that does nothing, and drawing both
+                would make every row's right edge two glyphs wide to say what
+                one of them says.
+
+                Absolute, in the space the item's own `pr-8` reserves, which is
+                where the check indicator draws too. */}
+            {!choice.checked && i < NUMBERED && (
+              <Kbd className="absolute top-1/2 right-2 -translate-y-1/2">{i + 1}</Kbd>
+            )}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/// The issue's own team workflow, in the order Linear draws it.
+///
+/// Falls back to the plain glyph where no states were given — an issue with no
+/// team on it, or a filters read that has not landed yet. A menu that opens
+/// empty is worse than no menu.
+export function StatusMenu({
+  issue,
+  state,
+  states,
+}: {
+  issue: Target;
+  /// Where the issue is now, which is what the trigger draws and what the menu
+  /// checks against.
+  state: IssueState;
+  /// Every status its team offers. Empty is ordinary.
+  states: IssueState[];
+}) {
+  if (!states.length) {
+    return <IssueStateIcon kind={state.kind} color={state.color} label={state.name} />;
+  }
+
+  return (
+    <GlyphMenu
+      label={`Status: ${state.name}`}
+      choices={states.map((option) => ({
+        key: option.id,
+        glyph: <IssueStateIcon kind={option.kind} color={option.color} />,
+        label: option.name,
+        checked: option.id === state.id,
+        pick: () => void updateIssue(issue, { state: option }),
+      }))}
+    >
+      <IssueStateIcon kind={state.kind} color={state.color} />
+    </GlyphMenu>
+  );
+}
+
+/// Linear's five levels. Fixed, unlike status — the levels are the tracker's own
+/// and no workspace renames them, so this needs nothing read for it.
+export function PriorityMenu({ issue, priority }: { issue: Target; priority: IssuePriority }) {
+  return (
+    <GlyphMenu
+      label={PRIORITY_LABEL[priority]}
+      choices={PRIORITIES.map((level) => ({
+        key: level,
+        glyph: <IssuePriorityIcon priority={level} />,
+        label: PRIORITY_LABEL[level],
+        checked: level === priority,
+        pick: () => void updateIssue(issue, { priority: level }),
+      }))}
+    >
+      <IssuePriorityIcon priority={priority} />
+    </GlyphMenu>
+  );
+}

--- a/apps/desktop/src/components/IssuePanel.tsx
+++ b/apps/desktop/src/components/IssuePanel.tsx
@@ -5,6 +5,7 @@ import { ChevronRight, ExternalLink, Unlink } from "lucide-react";
 
 import Avatar from "@/components/Avatar";
 import { IssueFile, IssueImage } from "@/components/IssueAsset";
+import { PriorityMenu, StatusMenu } from "@/components/IssueMenus";
 import IssueStateIcon, { IssuePriorityIcon } from "@/components/IssueStateIcon";
 import { Markdown } from "@/components/chat/Markdown";
 import { Button } from "@/components/ui/button";
@@ -154,18 +155,36 @@ function IssueRow({
   const open = !collapsible || !collapsed;
   const toggle = () => setCollapsed((prev) => !prev);
 
+  /// ⌘-click leaves for the tracker, the same bargain [LinkDialog] makes with
+  /// a link in the transcript — the modifier is how this app spells "not here,
+  /// out there". Bound whether or not the row collapses, since it is a
+  /// shortcut rather than the affordance: the row's own button is that.
+  ///
+  /// [LinkDialog]: ./chat/LinkDialog.tsx
+  const activate = (e: React.MouseEvent) => {
+    if (e.metaKey || e.ctrlKey) {
+      void openUrl(issue.url);
+      return;
+    }
+    if (collapsible) toggle();
+  };
+
   return (
     <div className="border-b border-border last:border-b-0">
       {/* A div behaving as a button, because the buttons inside it are real
           ones and a button cannot nest a button — the same shape `PrRow` and
           `SessionRow` use. */}
       <div
+        onClick={activate}
         {...(collapsible
           ? {
               role: "button",
               tabIndex: 0,
-              onClick: toggle,
               onKeyDown: (e: React.KeyboardEvent) => {
+                // A control inside the row answers its own keys. Without this
+                // Enter on the status menu opens it and collapses the row it
+                // was opened from, in one press.
+                if (e.target !== e.currentTarget) return;
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   toggle();
@@ -190,19 +209,23 @@ function IssueRow({
 
         {/* Always drawn, "no priority" included — the slot is reserved so the
             row does not reflow when the read lands. `none` until it does,
-            which is the honest resting value rather than a guess. */}
-        <IssuePriorityIcon priority={detail?.priority ?? "none"} />
+            which is the honest resting value rather than a guess.
+
+            A menu only once the read has landed: before that there is nothing
+            to check against and no id to write with, and a menu that opens on
+            a guess is worse than a glyph that waits. */}
+        {detail ? (
+          <PriorityMenu issue={detail} priority={detail.priority} />
+        ) : (
+          <IssuePriorityIcon priority="none" />
+        )}
 
         <span className="shrink-0 font-medium tabular-nums">{issue.identifier}</span>
 
         {/* From the read where it has landed, and a resting glyph until then —
             so the row never jumps between two heights as detail arrives. */}
         {detail ? (
-          <IssueStateIcon
-            kind={detail.state.kind}
-            color={detail.state.color}
-            label={detail.state.name}
-          />
+          <StatusMenu issue={detail} state={detail.state} states={detail.states} />
         ) : (
           <IssueStateIcon kind="other" label={loading ? "Loading" : "Unknown"} />
         )}

--- a/apps/desktop/src/components/IssuePanel.tsx
+++ b/apps/desktop/src/components/IssuePanel.tsx
@@ -33,6 +33,19 @@ function errorText(error: IssueUnavailable): string {
   return UNAVAILABLE[error.kind] || (error.kind === "other" ? error.detail : "");
 }
 
+/// What a status or priority write names, taken from **both** halves the row
+/// holds — and taking either from one alone is a bug.
+///
+/// The identifier comes from the *link*, because that is the key
+/// `useSessionIssues` caches this body under; the id comes from the *detail*,
+/// because that is the tracker's own and what the write is looked up by. The two
+/// spellings differ after a team move, where a session linked to `DRA-53` reads
+/// back an issue that now calls itself `ENG-12` — and a write keyed off the
+/// response then patches a cache entry nobody reads.
+function target(link: IssueRef, detail: IssueDetail) {
+  return { id: detail.id, identifier: link.identifier };
+}
+
 /// Uploads inside a description, drawn rather than linked.
 ///
 /// Linear puts both in the description's markdown — an image as `![](…)`, a
@@ -215,7 +228,7 @@ function IssueRow({
             to check against and no id to write with, and a menu that opens on
             a guess is worse than a glyph that waits. */}
         {detail ? (
-          <PriorityMenu issue={detail} priority={detail.priority} />
+          <PriorityMenu issue={target(issue, detail)} priority={detail.priority} />
         ) : (
           <IssuePriorityIcon priority="none" />
         )}
@@ -225,7 +238,7 @@ function IssueRow({
         {/* From the read where it has landed, and a resting glyph until then —
             so the row never jumps between two heights as detail arrives. */}
         {detail ? (
-          <StatusMenu issue={detail} state={detail.state} states={detail.states} />
+          <StatusMenu issue={target(issue, detail)} state={detail.state} states={detail.states} />
         ) : (
           <IssueStateIcon kind="other" label={loading ? "Loading" : "Unknown"} />
         )}

--- a/apps/desktop/src/components/IssueStateIcon.tsx
+++ b/apps/desktop/src/components/IssueStateIcon.tsx
@@ -1,3 +1,5 @@
+import { useTheme } from "@/hooks/useTheme";
+import { readableStateColor } from "@/lib/issueColor";
 import { cn } from "@/lib/utils";
 import type { IssuePriority, IssueStateKind } from "@/types/events";
 
@@ -25,6 +27,7 @@ const KIND_COLOR: Record<IssueStateKind, string> = {
   canceled: "#95a2b3",
   other: "#bec2c8",
 };
+
 
 /// How far round the ring is filled. Linear draws progress as a pie wedge
 /// inside an outlined circle, and the fraction is the whole of what separates
@@ -68,7 +71,11 @@ export default function IssueStateIcon({
   label?: string;
   className?: string;
 }) {
-  const fill = color || KIND_COLOR[kind];
+  // Read rather than taken as a prop: every row in a long list draws one of
+  // these, and the theme store is what keeps them from disagreeing about the
+  // mode mid-render. Same bargain `useCodeTheme` makes across mounted diffs.
+  const { resolvedMode } = useTheme();
+  const fill = readableStateColor(color || KIND_COLOR[kind], resolvedMode === "light");
   const shared = {
     width: 14,
     height: 14,
@@ -136,7 +143,7 @@ const BARS: Record<Exclude<IssuePriority, "urgent" | "none">, number> = {
   low: 1,
 };
 
-const PRIORITY_LABEL: Record<IssuePriority, string> = {
+export const PRIORITY_LABEL: Record<IssuePriority, string> = {
   none: "No priority",
   low: "Low priority",
   medium: "Medium priority",
@@ -163,7 +170,18 @@ export function IssuePriorityIcon({
     return (
       // The one that is not bars at all. Urgent is a filled square with a bang
       // in it, so it reads as an alarm rather than as "one bar more than high".
-      <svg {...shared} className={cn("size-4 shrink-0 text-destructive", className)} fill="currentColor">
+      //
+      // Painted, not inherited — the same reason `IssueStateIcon` above sets a
+      // `fill` rather than a text colour. A menu row recolours every descendant
+      // on focus (`focus:**:text-accent-foreground`), which beats a class on
+      // this element and turned the one glyph whose colour *is* the signal
+      // white on hover. An inline style outranks the selector; the bars below
+      // are neutral and are meant to follow the row.
+      <svg
+        {...shared}
+        className={cn("size-4 shrink-0", className)}
+        style={{ fill: "var(--destructive)" }}
+      >
         <path d="M3 1C1.91067 1 1 1.91067 1 3V13C1 14.0893 1.91067 15 3 15H13C14.0893 15 15 14.0893 15 13V3C15 1.91067 14.0893 1 13 1H3ZM7 4L9 4L8.75391 8.99836H7.25L7 4ZM9 11C9 11.5523 8.55228 12 8 12C7.44772 12 7 11.5523 7 11C7 10.4477 7.44772 10 8 10C8.55228 10 9 10.4477 9 11Z" />
       </svg>
     );

--- a/apps/desktop/src/components/IssuesView.tsx
+++ b/apps/desktop/src/components/IssuesView.tsx
@@ -622,8 +622,14 @@ function IssueRow({
   };
 
   return (
-    <button
-      type="button"
+    // A div behaving as a button, the shape `IssuePanel`'s own row uses. This
+    // was a real `button` back when the only thing inside it was one span
+    // pretending to be one; it now carries two menu triggers as well, and three
+    // focusable controls nested in a `button` is invalid markup whose keyboard
+    // behaviour assistive tech is free to collapse into the row's own action.
+    <div
+      role="button"
+      tabIndex={0}
       // ⌘-click leaves for the tracker, the same modifier the transcript's link
       // dialog uses to mean "out there, not here". An ordinary click still opens
       // the pane, which is what this row is for — Linear is the shortcut.
@@ -634,8 +640,17 @@ function IssueRow({
         }
         onPick(issue);
       }}
+      // A control inside the row answers its own keys, or Enter on a status menu
+      // opens it and picks the row underneath in one press.
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key !== "Enter" && e.key !== " ") return;
+        e.preventDefault();
+        onPick(issue);
+      }}
       className={cn(
-        "group flex w-full items-center gap-2 px-3 py-2 text-left text-ui transition-colors",
+        "group flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-ui transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
         picked ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/50",
       )}
     >
@@ -708,6 +723,6 @@ function IssueRow({
       <span className="hidden w-16 shrink-0 text-right text-muted-foreground sm:inline">
         {calendarDay(issue.updatedAt)}
       </span>
-    </button>
+    </div>
   );
 }

--- a/apps/desktop/src/components/IssuesView.tsx
+++ b/apps/desktop/src/components/IssuesView.tsx
@@ -679,11 +679,14 @@ function IssueRow({
         </span>
       )}
 
-      {/* A span carrying `buttonVariants` rather than a `Button`, because the
-          row itself is a button and a nested one is invalid markup — the click
-          would open the pane instead. Same bargain `FileLink` makes, and
-          `stopPropagation` on the key as well as the click is what keeps them
-          apart.
+      {/* A span carrying `buttonVariants` rather than a `Button`. The row is a
+          div with `role="button"` and this stays a span with it: the row's
+          accessible role is what a nested control conflicts with, not the tag
+          it happens to use, so promoting either to a real `button` would put
+          the invalid nesting straight back. Same bargain `FileLink` makes, and
+          `stopPropagation` on the key as well as the click is what keeps the
+          two apart — the row's own `target === currentTarget` guard is the
+          other half.
 
           Its slot is reserved whether or not it is drawn: revealed by adding
           width, the whole row would shift under the cursor that revealed it.

--- a/apps/desktop/src/components/IssuesView.tsx
+++ b/apps/desktop/src/components/IssuesView.tsx
@@ -4,7 +4,8 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { ChevronRight, Plus, RefreshCw, Search, SlidersHorizontal } from "lucide-react";
 
 import Avatar from "@/components/Avatar";
-import IssueStateIcon, { IssuePriorityIcon } from "@/components/IssueStateIcon";
+import { PriorityMenu, StatusMenu } from "@/components/IssueMenus";
+import IssueStateIcon from "@/components/IssueStateIcon";
 import LinearIcon from "@/components/LinearIcon";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
@@ -19,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { IS_MAC } from "@/lib/platform";
+import { useHotkey } from "@/hooks/useHotkey";
 import { useIssues } from "@/hooks/useIssues";
 import { groupIssues } from "@/lib/issue";
 import { calendarDay } from "@/lib/format";
@@ -28,9 +30,20 @@ import type {
   IssueGroup,
   IssueQuery,
   IssueScope,
+  IssueState,
   IssueStateKind,
   IssueUnavailable,
 } from "@/types/events";
+
+/// The page's search field. Named so ⌘⇧F can reach it — the same trick the
+/// sidebar's own field uses, and for the same reason: the chord has to be able
+/// to *re-focus* a field already on screen, which a `ref` threaded up through
+/// the page would do no better.
+///
+/// **Shifted, where the sidebar's is not.** ⌘F belongs to the sidebar and is
+/// bound app-wide, so a second field claiming it would take the one search that
+/// works from anywhere and make it depend on which view is up.
+const ISSUE_SEARCH_INPUT_ID = "issues-search";
 
 /// Where a personal API key is made. Linked rather than described, because the
 /// path through Linear's own settings is theirs to change and a stale sentence
@@ -79,9 +92,10 @@ const SETTLED_KINDS: { key: IssueStateKind; label: string }[] = [
 /// session about", and this answers "what is there to work on" — which has no
 /// session to hang off and is the thing you look at before there is one.
 ///
-/// It reads. Clicking a row opens the issue in the tracker, which is where its
-/// text, its status and its people can actually be changed — a second place to
-/// edit them is a second place to be wrong about them.
+/// Clicking a row opens it in the pane beside the list, where its status and
+/// its priority can be moved. Everything else about an issue — its text, its
+/// people, its conversation — is still the tracker's to edit, and ⌘-clicking a
+/// row is the shortcut there.
 export default function IssuesView({
   active,
   connected,
@@ -128,6 +142,25 @@ export default function IssuesView({
   }, [refreshRef, refresh]);
 
   const set = (patch: Partial<IssueQuery>) => setQuery({ ...query, ...patch });
+
+  // Bound here rather than in `App`, unlike ⌘F: this field only exists while
+  // the page does, and `enabled` unregisters the listener outright rather than
+  // leaving a chord claimed — `useHotkey` calls `preventDefault` on every match,
+  // so a binding left standing would eat ⌘⇧F from whatever *is* on screen.
+  // `select` rather than `focus`, so pressing it on a query replaces it.
+  useHotkey(
+    "f",
+    () => document.querySelector<HTMLInputElement>(`#${ISSUE_SEARCH_INPUT_ID}`)?.select(),
+    { shift: true, enabled: active && connected },
+  );
+
+  /// The workflow a row's status menu offers, which belongs to the issue's own
+  /// team. Read once per connection with the filter options rather than per
+  /// issue — a team's states are the same answer for every row it owns, so
+  /// asking for them on the list read would repeat one workflow a hundred times
+  /// down the wire. Empty until that read lands, which draws a plain glyph.
+  const statesFor = (issue: Issue) =>
+    (issue.team && filters?.teamStates[issue.team]) || [];
   const groups = useMemo(() => groupIssues(issues), [issues]);
   const settledGroups = useMemo(() => groupIssues(settled.issues), [settled.issues]);
 
@@ -191,9 +224,10 @@ export default function IssuesView({
           filled field above a borderless list draws a box round the least
           interesting third of the page. The glyph does the work the border
           was doing: it says "type here" without enclosing anything. */}
-      <div className="flex h-11 shrink-0 items-center gap-2 px-3">
+      <div className="group flex h-11 shrink-0 items-center gap-2 px-3">
         <Search className="size-4 shrink-0 text-muted-foreground" />
         <Input
+          id={ISSUE_SEARCH_INPUT_ID}
           value={query.text ?? ""}
           placeholder="Search issues"
           spellCheck={false}
@@ -203,7 +237,30 @@ export default function IssuesView({
           // fill on screen.
           className="h-full rounded-none border-0 bg-transparent p-0 shadow-none focus-visible:ring-0 dark:bg-transparent"
           onChange={(e) => set({ text: e.currentTarget.value || null })}
+          // Escape drops the query, the sidebar's rule. It does *not* blur:
+          // this field is always drawn, so there is nothing to close and a
+          // caret left where it was is a second search ready to be typed.
+          onKeyDown={(e) => {
+            if (e.key !== "Escape" || !query.text) return;
+            e.preventDefault();
+            set({ text: null });
+          }}
         />
+
+        {/* The slot names whichever key does something here, and which one that
+            is turns on focus alone — the sidebar's rule, and the two fields
+            should not need learning twice. Escape reaches this input and
+            nothing else; ⌘⇧F is what brings focus back to a field left holding
+            a query. Esc is withheld over an empty field, the one state neither
+            key has anything to do in. */}
+        {query.text && <Kbd className="hidden group-focus-within:inline-flex">Esc</Kbd>}
+        <KbdGroup className="group-focus-within:hidden">
+          <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+          {/* Spelled out, not ⇧. Beside a single glyph the arrow reads as part
+              of the key next to it; the word cannot be mistaken for one. */}
+          <Kbd>Shift</Kbd>
+          <Kbd>F</Kbd>
+        </KbdGroup>
       </div>
 
       {/* Under the header rather than over the rows: a failed refresh leaves
@@ -240,6 +297,7 @@ export default function IssuesView({
                   key={issue.id}
                   issue={issue}
                   picked={issue.identifier === picked}
+                  states={statesFor(issue)}
                   onPick={onPick}
                   onWorkOn={onWorkOn}
                 />
@@ -274,6 +332,7 @@ export default function IssuesView({
                       key={issue.id}
                       issue={issue}
                       picked={issue.identifier === picked}
+                      states={statesFor(issue)}
                       onPick={onPick}
                       onWorkOn={onWorkOn}
                     />
@@ -315,10 +374,14 @@ function Connect({
             <LinearIcon />
             Connect Linear
           </p>
-          {/* Read access is the whole ask, and saying so is what makes pasting
-              a key into a desktop app a smaller decision than it looks. */}
+          {/* The smaller ask is still offered, and second: read alone is what
+              somebody wary of pasting a credential into a desktop app can give,
+              and naming it is what keeps that a small decision. Write is named
+              first because it is what the app now does, and leaving it out
+              would have the reader find out from a status menu that fails. */}
           <p className="text-ui text-muted-foreground">
-            Paste a personal API key with read access. Dray only reads — it never changes an issue.
+            Paste a personal API key with read and write access. A read-only key works too — you
+            just cannot change a status or priority.
           </p>
         </div>
 
@@ -364,8 +427,8 @@ function Connect({
             model working off a one-line title, finds it out the expensive way.
             Said here, while they are already setting this up, and said once. */}
         <p className="border-t border-border pt-3 text-ui text-muted-foreground">
-          This key is read-only, and it is for Dray. To let the agent read and manage issues in
-          chat, add{" "}
+          Dray reads your issues with this key, and writes only the status or priority you pick.
+          To let the agent read and manage issues in chat, add{" "}
           <button
             type="button"
             className="text-foreground underline underline-offset-2 hover:text-foreground/80"
@@ -541,11 +604,15 @@ function FilterMenu({
 function IssueRow({
   issue,
   picked,
+  states,
   onPick,
   onWorkOn,
 }: {
   issue: Issue;
   picked: boolean;
+  /// The statuses this issue's team offers. Empty until the filters read lands,
+  /// which leaves the glyph a plain one.
+  states: IssueState[];
   onPick: (issue: Issue) => void;
   onWorkOn: (issue: Issue) => void;
 }) {
@@ -557,7 +624,16 @@ function IssueRow({
   return (
     <button
       type="button"
-      onClick={() => onPick(issue)}
+      // ⌘-click leaves for the tracker, the same modifier the transcript's link
+      // dialog uses to mean "out there, not here". An ordinary click still opens
+      // the pane, which is what this row is for — Linear is the shortcut.
+      onClick={(e) => {
+        if (e.metaKey || e.ctrlKey) {
+          void openUrl(issue.url);
+          return;
+        }
+        onPick(issue);
+      }}
       className={cn(
         "group flex w-full items-center gap-2 px-3 py-2 text-left text-ui transition-colors",
         picked ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/50",
@@ -566,15 +642,20 @@ function IssueRow({
       {/* Always drawn, "no priority" included. A glyph that appears on only
           some rows shifts every title beside it, and a ragged left edge reads
           as disorder rather than as information. */}
-      <IssuePriorityIcon priority={issue.priority} />
+      <PriorityMenu issue={issue} priority={issue.priority} />
 
       <span className="w-16 shrink-0 truncate text-muted-foreground tabular-nums">
         {issue.identifier}
       </span>
 
-      {/* No status glyph here. The rows are already gathered under a heading
-          that carries one, so a second copy on every row says what the row's
-          own position has just said. */}
+      {/* The status glyph repeats the heading the row is already gathered
+          under, and it earns that repetition by being a *control*: moving an
+          issue to In Progress is the commonest thing anybody does on this page,
+          and sending them into the pane to do it made the list a place you only
+          read from. Same order as the panel's own header — priority, then the
+          identifier, then status — so the two surfaces read as one. */}
+      <StatusMenu issue={issue} state={issue.state} states={states} />
+
       <span className="min-w-0 flex-1 truncate">{issue.title}</span>
 
       {issue.project && (

--- a/apps/desktop/src/components/NoticeStack.tsx
+++ b/apps/desktop/src/components/NoticeStack.tsx
@@ -51,7 +51,16 @@ const ACTION: Record<NoticeKind, string> = {
   // "Delete worktree" button — the card names the reason and this puts the
   // reader back in front of the control that runs the rest.
   "worktree-failed": "View",
+  // Nowhere to send anybody. The issue is still on screen where the reader
+  // changed it from, and nothing moved — so the only thing this button can
+  // honestly offer is taking the card away.
+  "issue-failed": "Dismiss",
 };
+
+/// The kinds that go somewhere when taken. Everything else is read and
+/// dismissed, and stating the set here is what stops `take` from calling
+/// `onSelect` with something that is not a session id at all.
+const NAVIGATES: NoticeKind[] = ["completed", "asking", "pr", "worktree-failed"];
 
 /// The bar's colour, matching the rail mark the row will be wearing when the
 /// reader gets there.
@@ -74,6 +83,9 @@ const BAR: Record<NoticeKind, string> = {
   // through: the two are the same deletion, and this one is the only place the
   // reader learns it stopped part way.
   "worktree-failed": "bg-destructive/70",
+  // A refusal, so the destructive colour like the other card that reports one.
+  // There is no rail mark to match here at all — no session is involved.
+  "issue-failed": "bg-destructive/70",
 };
 
 /// How long the card lingers after its work is done, to say so. Long enough to
@@ -338,11 +350,12 @@ export default function NoticeStack({
   //
   // `worktree-failed` navigates like the rest, and has to: it is the one card
   // whose subject is a session the reader is being sent back to, where the
-  // button that tries the removal again still is.
+  // button that tries the removal again still is. `issue-failed` names no
+  // session at all, so it is read and dismissed — see `NAVIGATES`.
   const take = (notice: Notice) => {
     dismissNotice(notice.sessionId, notice.kind);
     if (notice.kind === "pr") onOpenPr(notice.sessionId);
-    else if (notice.kind !== "worktree") onSelect(notice.sessionId);
+    else if (NAVIGATES.includes(notice.kind)) onSelect(notice.sessionId);
   };
 
   // ⌘G takes the navigating kinds — a session, or a session and its PR tab —

--- a/apps/desktop/src/hooks/useIssues.ts
+++ b/apps/desktop/src/hooks/useIssues.ts
@@ -221,18 +221,22 @@ function patched<T extends { state: IssueState; priority: IssuePriority }>(
 /// race is not a race at all, it happens every time. Stamped, nothing goes out
 /// until the write says so.
 ///
-/// **Rows are matched on the stable id; only the detail cache is keyed by the
-/// identifier**, because that is the slot `useSessionIssues` files a body under
-/// — the link's spelling, which after a team move is not the one the list holds.
+/// **Everything is matched on the stable id, bodies included** — the identifier
+/// is a cache *slot*, never an identity. One issue can occupy two slots at once
+/// after a team move: a session panel files it under the link's `DRA-53` while
+/// the issues page files the same issue under `ENG-12`. Looking the body up by
+/// the caller's spelling patched one of them and left the other drawing the old
+/// status until the reconcile landed.
 function patchCachedIssue(target: { identifier: string; id: string }, patch: IssuePatch): Rollback {
   const now = Date.now();
   const undo: (() => void)[] = [];
-  const detail = detailCache.get(target.identifier);
 
-  if (detail) {
-    undo.push(() => detailCache.set(target.identifier, detail));
-    detailCache.set(target.identifier, patched(detail, patch));
-    detailFetchedAt.set(target.identifier, now);
+  for (const [slot, detail] of detailCache) {
+    if (detail.id !== target.id) continue;
+
+    undo.push(() => detailCache.set(slot, detail));
+    detailCache.set(slot, patched(detail, patch));
+    detailFetchedAt.set(slot, now);
   }
 
   for (const [key, issues] of cache) {

--- a/apps/desktop/src/hooks/useIssues.ts
+++ b/apps/desktop/src/hooks/useIssues.ts
@@ -1,7 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 
+import { pushNotice } from "@/hooks/useNotices";
 import {
+  isSettled,
   issueGeneration,
   newIssueGeneration,
   subscribeIssueGeneration,
@@ -11,8 +13,10 @@ import type {
   Issue,
   IssueDetail,
   IssueFilters,
+  IssuePriority,
   IssueQuery,
   IssueRef,
+  IssueState,
   IssueUnavailable,
 } from "@/types/events";
 
@@ -44,14 +48,22 @@ const fetchedAt = new Map<string, number>();
 /// Small: a reader works through two or three filter combinations, not twenty.
 const MAX_CACHED = 12;
 
+/// An object rather than a tuple, because the key is read back apart from being
+/// compared: `settledOfKey` below needs one field out of it, and a positional
+/// shape would hand it a different field the day this gains one.
 const keyOf = (query: IssueQuery) =>
-  JSON.stringify([
-    query.text ?? "",
-    query.scope,
-    query.teamId ?? "",
-    query.projectId ?? "",
-    query.settled,
-  ]);
+  JSON.stringify({
+    text: query.text ?? "",
+    scope: query.scope,
+    teamId: query.teamId ?? "",
+    projectId: query.projectId ?? "",
+    settled: query.settled,
+  });
+
+/// Which half of the workspace a cached list asked for, read back out of its own
+/// key. By name, so adding a field to `keyOf` cannot silently change what this
+/// answers.
+const settledOfKey = (key: string) => Boolean((JSON.parse(key) as IssueQuery).settled);
 
 function remember(key: string, issues: Issue[], generation: number) {
   // A read issued before the connection changed must not put its answer back
@@ -134,6 +146,130 @@ export function forgetIssues() {
   newIssueGeneration();
 }
 
+/// What a menu picked. The **whole** state, not its id, and that is what makes
+/// the optimistic paint below possible: the menu already held the name, the kind
+/// and the colour the row has to draw, so nothing has to be read back to show
+/// the change.
+export type IssuePatch = { state?: IssueState; priority?: IssuePriority };
+
+/// One issue with the patch applied. Serves `Issue` and `IssueDetail` alike,
+/// since both carry exactly these two fields.
+function patched<T extends { state: IssueState; priority: IssuePriority }>(
+  issue: T,
+  patch: IssuePatch,
+): T {
+  return {
+    ...issue,
+    state: patch.state ?? issue.state,
+    priority: patch.priority ?? issue.priority,
+  };
+}
+
+/// Writes the patch into every cached answer holding this issue, **without**
+/// touching a freshness stamp.
+///
+/// That omission is the whole trick. Every mounted list and panel re-reads its
+/// own cache on a generation bump and asks the network only for what is stale —
+/// so patching in place and bumping repaints on the next frame and sends no
+/// request at all. Clearing the stamps here instead would fire a read that
+/// leaves *before* the mutation lands and write the old status straight back
+/// over the one the reader just picked.
+function patchCachedIssue(identifier: string, patch: IssuePatch) {
+  const detail = detailCache.get(identifier);
+  if (detail) detailCache.set(identifier, patched(detail, patch));
+
+  for (const [key, issues] of cache) {
+    if (!issues.some((issue) => issue.identifier === identifier)) continue;
+
+    // A status write can move a row out of the half its list asked for — Done
+    // belongs to the settled read, not the open one. Patched in place it would
+    // draw a second "Done" heading inside the open groups until the re-read
+    // dropped it, so the row leaves here instead, which is what the answer will
+    // say anyway.
+    const wantsSettled = settledOfKey(key);
+
+    cache.set(
+      key,
+      issues.flatMap((issue) => {
+        if (issue.identifier !== identifier) return [issue];
+        const moved = patched(issue, patch);
+        return isSettled(moved.state.kind) === wantsSettled ? [moved] : [];
+      }),
+    );
+  }
+
+  // Repaint, not invalidate: the stamps above are deliberately untouched, so
+  // every reader takes the patched copy and nothing goes out.
+  newIssueGeneration();
+}
+
+/// Moves an issue's status or priority — the one write this app makes to a
+/// tracker.
+///
+/// A module function rather than something a hook hands down, because both
+/// surfaces that offer it are far from the hook that reads for them: the panel's
+/// row header and the issues page's list rows. Threading a callback from `App`
+/// through both would be two props for one function with no state behind it.
+///
+/// **Painted first, sent second.** The write is three Linear round trips deep —
+/// the mutation, the read-back, and then every list re-reading — and a glyph
+/// that does not move until all three land reads as a menu that ignored the
+/// click. The reader picked a state this app already holds in full, so there is
+/// nothing to wait for before showing it.
+///
+/// **Reconciled by `forgetIssues`, which is the moment every cached answer about
+/// issues really does stop being true** — the row, the group it is filed under,
+/// the body in the pane. The freshly-read detail goes back *after* that bump,
+/// since a write stamped with the old generation is refused by the very guard
+/// that makes the clearing stick.
+///
+/// Failure raises a notice and is not thrown, and clears the optimistic paint
+/// with it: `forgetIssues` there is what puts the tracker's own answer back on
+/// screen rather than leaving a status the reader picked and never got.
+export async function updateIssue(issue: { identifier: string; id: string }, patch: IssuePatch) {
+  patchCachedIssue(issue.identifier, patch);
+
+  try {
+    const next = await invoke<IssueDetail>("update_issue", {
+      identifier: issue.identifier,
+      id: issue.id,
+      stateId: patch.state?.id ?? null,
+      // `null` is "leave it" and `"none"` is a level in its own right, which is
+      // why this cannot be a number: Linear spells no-priority `0`.
+      priority: patch.priority ?? null,
+    });
+
+    forgetIssues();
+    rememberDetail(next.identifier, next, issueGeneration());
+  } catch (e) {
+    forgetIssues();
+    pushNotice({
+      sessionId: issue.identifier,
+      kind: "issue-failed",
+      label: "Could not update",
+      subject: issue.identifier,
+      // The tracker's own words. A rejected key, an unreachable workspace and a
+      // state belonging to another team each need a different thing done about
+      // them, and only the sentence tells them apart.
+      detail: issueErrorText(asUnavailable(e)),
+    });
+  }
+}
+
+/// A failed write in one line, in terms of what the reader would do about it.
+function issueErrorText(error: IssueUnavailable): string {
+  switch (error.kind) {
+    case "unauthorized":
+      return "Linear rejected the saved key. Disconnect it in Settings, then paste a new one.";
+    case "offline":
+      return "Could not reach Linear.";
+    case "not_connected":
+      return "No issue tracker connected.";
+    default:
+      return error.detail;
+  }
+}
+
 /// What `invoke` rejected with, as the backend meant it.
 ///
 /// Tauri hands the serialized `Err` back, so this is already the right shape —
@@ -160,6 +296,12 @@ const DEFAULT_QUERY: IssueQuery = {
 /// with no round trip behind them until somebody opens one.
 function useIssueList(query: IssueQuery, enabled: boolean, generation: number) {
   const key = keyOf(query);
+
+  // Subscribed, not merely read — the same bargain `useSessionIssues` makes.
+  // A connection changing under the page, or a status written in the pane
+  // beside this list, both land as a generation bump, and without this the row
+  // keeps saying "Backlog" under a heading the issue has just left.
+  const connection = useSyncExternalStore(subscribeIssueGeneration, issueGeneration);
 
   const [issues, setIssues] = useState<Issue[]>(() => cache.get(key) ?? []);
   const [loading, setLoading] = useState(false);
@@ -237,7 +379,7 @@ function useIssueList(query: IssueQuery, enabled: boolean, generation: number) {
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [enabled, key, query, generation]);
+  }, [enabled, key, query, generation, connection]);
 
   return { issues, loading, unavailable, loaded: answered };
 }

--- a/apps/desktop/src/hooks/useIssues.ts
+++ b/apps/desktop/src/hooks/useIssues.ts
@@ -165,18 +165,29 @@ function patched<T extends { state: IssueState; priority: IssuePriority }>(
   };
 }
 
-/// Writes the patch into every cached answer holding this issue, **without**
-/// touching a freshness stamp.
+/// Writes the patch into every cached answer holding this issue, and **stamps
+/// each one fresh**.
 ///
-/// That omission is the whole trick. Every mounted list and panel re-reads its
-/// own cache on a generation bump and asks the network only for what is stale —
-/// so patching in place and bumping repaints on the next frame and sends no
-/// request at all. Clearing the stamps here instead would fire a read that
-/// leaves *before* the mutation lands and write the old status straight back
-/// over the one the reader just picked.
+/// The stamp is the load-bearing half, and getting it wrong is visible. Every
+/// mounted reader re-reads its own cache on a generation bump and then asks the
+/// network for whatever is stale — so an entry left with its old stamp fires a
+/// read *immediately*, that read leaves before the mutation lands, and Linear
+/// answers with the status the reader has just moved away from. It then writes
+/// that answer back over the patch. On screen: the new status, then the old one,
+/// then the new one again once the reconcile lands.
+///
+/// It was tempting to read the stamp as "when the tracker last told us", which
+/// this is not — but `FRESH_MS` is a minute, so on any list older than that the
+/// race is not a race at all, it happens every time. Stamped, nothing goes out
+/// until `forgetIssues` says so, which is after the write.
 function patchCachedIssue(identifier: string, patch: IssuePatch) {
+  const now = Date.now();
   const detail = detailCache.get(identifier);
-  if (detail) detailCache.set(identifier, patched(detail, patch));
+
+  if (detail) {
+    detailCache.set(identifier, patched(detail, patch));
+    detailFetchedAt.set(identifier, now);
+  }
 
   for (const [key, issues] of cache) {
     if (!issues.some((issue) => issue.identifier === identifier)) continue;
@@ -185,7 +196,8 @@ function patchCachedIssue(identifier: string, patch: IssuePatch) {
     // belongs to the settled read, not the open one. Patched in place it would
     // draw a second "Done" heading inside the open groups until the re-read
     // dropped it, so the row leaves here instead, which is what the answer will
-    // say anyway.
+    // say anyway. The half it moves *into* is left to the reconcile: it is a
+    // row appearing late, never a wrong one on screen.
     const wantsSettled = settledOfKey(key);
 
     cache.set(
@@ -196,10 +208,12 @@ function patchCachedIssue(identifier: string, patch: IssuePatch) {
         return isSettled(moved.state.kind) === wantsSettled ? [moved] : [];
       }),
     );
+    fetchedAt.set(key, now);
   }
 
-  // Repaint, not invalidate: the stamps above are deliberately untouched, so
-  // every reader takes the patched copy and nothing goes out.
+  // Repaint, not invalidate. The bump is also what refuses any read already in
+  // flight, which is holding the generation it started under and would put the
+  // pre-write answer back for the same reason.
   newIssueGeneration();
 }
 

--- a/apps/desktop/src/hooks/useIssues.ts
+++ b/apps/desktop/src/hooks/useIssues.ts
@@ -162,15 +162,35 @@ export type IssuePatch = { state?: IssueState; priority?: IssuePriority };
 /// then sends one read to find out which of the two actually happened.
 type Rollback = () => void;
 
-/// The newest write per issue, so a response that has been superseded can be
-/// dropped rather than applied.
+/// Writes in flight per issue, chained so one lands before the next is sent.
 ///
-/// Two picks on one issue can complete out of order, and the older completing
-/// last is the damaging one: it would run `forgetIssues` over the newer pick's
-/// paint and then stamp its own stale detail fresh for a minute. Both still go
-/// out — the reconcile reads whatever the tracker ended up with, so a wire that
-/// applies them out of order costs a correction rather than a lie.
-const writes = new Map<string, number>();
+/// **Keyed by the tracker's stable id, never the identifier.** One issue can be
+/// two spellings at once — a session linked to `DRA-53` reading a body that now
+/// calls itself `ENG-12` — and two surfaces writing under two aliases would take
+/// two independent places in the queue and race each other again.
+const queues = new Map<string, Promise<unknown>>();
+
+/// How many writes are outstanding per issue, so a completion can tell whether
+/// another is coming behind it and leave the settling to that one.
+const outstanding = new Map<string, number>();
+
+/// Whether this completion is the last one for its issue, and so the one that
+/// reconciles. Read *before* [`released`] takes this write off the count.
+function settles(id: string): boolean {
+  return (outstanding.get(id) ?? 1) === 1;
+}
+
+function released(id: string) {
+  const left = (outstanding.get(id) ?? 1) - 1;
+  if (left > 0) {
+    outstanding.set(id, left);
+    return;
+  }
+  // Nothing else is waiting, so no later write is chained off this queue entry
+  // and dropping it cannot orphan one.
+  outstanding.delete(id);
+  queues.delete(id);
+}
 
 /// One issue with the patch applied. Serves `Issue` and `IssueDetail` alike,
 /// since both carry exactly these two fields.
@@ -199,28 +219,26 @@ function patched<T extends { state: IssueState; priority: IssuePriority }>(
 /// It was tempting to read the stamp as "when the tracker last told us", which
 /// this is not — but `FRESH_MS` is a minute, so on any list older than that the
 /// race is not a race at all, it happens every time. Stamped, nothing goes out
-/// until `forgetIssues` says so, which is after the write.
-function patchCachedIssue(identifier: string, patch: IssuePatch): Rollback {
+/// until the write says so.
+///
+/// **Rows are matched on the stable id; only the detail cache is keyed by the
+/// identifier**, because that is the slot `useSessionIssues` files a body under
+/// — the link's spelling, which after a team move is not the one the list holds.
+function patchCachedIssue(target: { identifier: string; id: string }, patch: IssuePatch): Rollback {
   const now = Date.now();
   const undo: (() => void)[] = [];
-  const detail = detailCache.get(identifier);
+  const detail = detailCache.get(target.identifier);
 
   if (detail) {
-    undo.push(() => {
-      detailCache.set(identifier, detail);
-      detailFetchedAt.delete(identifier);
-    });
-    detailCache.set(identifier, patched(detail, patch));
-    detailFetchedAt.set(identifier, now);
+    undo.push(() => detailCache.set(target.identifier, detail));
+    detailCache.set(target.identifier, patched(detail, patch));
+    detailFetchedAt.set(target.identifier, now);
   }
 
   for (const [key, issues] of cache) {
-    if (!issues.some((issue) => issue.identifier === identifier)) continue;
+    if (!issues.some((issue) => issue.id === target.id)) continue;
 
-    undo.push(() => {
-      cache.set(key, issues);
-      fetchedAt.delete(key);
-    });
+    undo.push(() => cache.set(key, issues));
 
     // A status write can move a row out of the half its list asked for — Done
     // belongs to the settled read, not the open one. Patched in place it would
@@ -233,7 +251,7 @@ function patchCachedIssue(identifier: string, patch: IssuePatch): Rollback {
     cache.set(
       key,
       issues.flatMap((issue) => {
-        if (issue.identifier !== identifier) return [issue];
+        if (issue.id !== target.id) return [issue];
         const moved = patched(issue, patch);
         return isSettled(moved.state.kind) === wantsSettled ? [moved] : [];
       }),
@@ -248,6 +266,15 @@ function patchCachedIssue(identifier: string, patch: IssuePatch): Rollback {
 
   return () => {
     for (const step of undo) step();
+
+    // **Every stamp, not only the ones this write set.** A write that was
+    // superseded left patches of its own that nothing now reverts — it declined
+    // to, since a later write owned the screen — and those entries are stamped
+    // fresh. Restoring this write's snapshot alone would leave them standing for
+    // a minute with no read to correct them. The data is untouched, so nothing
+    // blanks: every reader repaints what it holds and reads behind it.
+    fetchedAt.clear();
+    detailFetchedAt.clear();
     newIssueGeneration();
   };
 }
@@ -266,34 +293,47 @@ function patchCachedIssue(identifier: string, patch: IssuePatch): Rollback {
 /// click. The reader picked a state this app already holds in full, so there is
 /// nothing to wait for before showing it.
 ///
-/// **Reconciled by `forgetIssues`, which is the moment every cached answer about
-/// issues really does stop being true** — the row, the group it is filed under,
-/// the body in the pane. The freshly-read detail goes back *after* that bump,
-/// since a write stamped with the old generation is refused by the very guard
-/// that makes the clearing stick.
+/// **Sent one at a time per issue, and only the request queues.** Firing both of
+/// two quick picks at once leaves the tracker to decide which lands last, and it
+/// need not be the one clicked last — so the server can end on A while the app
+/// shows B, with nothing left to re-read and correct it. Chaining makes send
+/// order the click order. The optimistic paint stays immediate, since it is
+/// outside the chain.
 ///
-/// Failure rolls the paint back rather than clearing the caches. `forgetIssues`
-/// there was not enough and read as though it were: a list keeps its own rows
-/// when a forced re-read fails, and the write failing offline is exactly the
-/// case where that re-read fails too — so the rejected status stayed on screen
-/// under an error banner.
+/// **Only the last write in a chain settles anything.** An earlier one returning
+/// with another still queued reconciles nothing and reports nothing: the screen
+/// belongs to the later pick, and a card naming a decision the reader has already
+/// replaced is noise.
 ///
-/// **`issue.identifier` is the cache key throughout, and the response's own is
-/// never used for one.** They differ after a team move: a session linked to
-/// `DRA-53` reads a detail that now calls itself `ENG-12`, and `useSessionIssues`
-/// caches it under the link's spelling. Keying the write off the response would
-/// patch an entry nobody reads and file the answer where nobody asks. The wire
-/// gets `issue.id`, the stable half, which is what Rust looks up first anyway.
+/// **`issue.identifier` is the detail cache's key throughout, and the response's
+/// own is never used for one.** They differ after a team move: a session linked
+/// to `DRA-53` reads a detail that now calls itself `ENG-12`, and
+/// `useSessionIssues` files it under the link's spelling. Keying the write off
+/// the response would patch an entry nobody reads and file the answer where
+/// nobody asks. The wire gets `issue.id`, the stable half, which is what Rust
+/// looks up first anyway.
 export async function updateIssue(issue: { identifier: string; id: string }, patch: IssuePatch) {
-  const ticket = (writes.get(issue.identifier) ?? 0) + 1;
-  writes.set(issue.identifier, ticket);
+  outstanding.set(issue.id, (outstanding.get(issue.id) ?? 0) + 1);
 
-  const rollback = patchCachedIssue(issue.identifier, patch);
-  /// Whether this write is still the newest for its issue. A superseded one
-  /// touches nothing — neither the caches nor the notice, since a card for a
-  /// pick the reader has already replaced names a decision they moved on from.
-  const current = () => writes.get(issue.identifier) === ticket;
+  const rollback = patchCachedIssue(issue, patch);
+  const prior = queues.get(issue.id) ?? Promise.resolve();
+  const run = prior.then(() => send(issue, patch, rollback));
 
+  // Swallowed on the *stored* handle only: a rejection left on the chain would
+  // take down every write queued behind it, while `run` itself still carries the
+  // failure to the caller.
+  queues.set(issue.id, run.catch(() => {}));
+
+  await run;
+}
+
+/// The request half, run in turn. Split out so the queueing above reads as
+/// queueing and nothing else.
+async function send(
+  issue: { identifier: string; id: string },
+  patch: IssuePatch,
+  rollback: Rollback,
+) {
   try {
     const next = await invoke<IssueDetail>("update_issue", {
       identifier: issue.identifier,
@@ -304,14 +344,12 @@ export async function updateIssue(issue: { identifier: string; id: string }, pat
       priority: patch.priority ?? null,
     });
 
-    if (!current()) return;
-    writes.delete(issue.identifier);
+    if (!settles(issue.id)) return;
 
     forgetIssues();
     rememberDetail(issue.identifier, next, issueGeneration());
   } catch (e) {
-    if (!current()) return;
-    writes.delete(issue.identifier);
+    if (!settles(issue.id)) return;
 
     rollback();
     pushNotice({
@@ -324,6 +362,8 @@ export async function updateIssue(issue: { identifier: string; id: string }, pat
       // them, and only the sentence tells them apart.
       detail: issueErrorText(asUnavailable(e)),
     });
+  } finally {
+    released(issue.id);
   }
 }
 

--- a/apps/desktop/src/hooks/useIssues.ts
+++ b/apps/desktop/src/hooks/useIssues.ts
@@ -152,6 +152,26 @@ export function forgetIssues() {
 /// the change.
 export type IssuePatch = { state?: IssueState; priority?: IssuePriority };
 
+/// Puts back what the caches held before an optimistic patch, and leaves what it
+/// restored **stale**.
+///
+/// Stale rather than re-stamped, because a failed command does not prove the
+/// write failed: `update_issue` mutates and then re-reads, so a mutation that
+/// landed under a read that did not comes back as an error. Restoring the old
+/// value keeps an unconfirmed status off the screen; clearing the stamp is what
+/// then sends one read to find out which of the two actually happened.
+type Rollback = () => void;
+
+/// The newest write per issue, so a response that has been superseded can be
+/// dropped rather than applied.
+///
+/// Two picks on one issue can complete out of order, and the older completing
+/// last is the damaging one: it would run `forgetIssues` over the newer pick's
+/// paint and then stamp its own stale detail fresh for a minute. Both still go
+/// out — the reconcile reads whatever the tracker ended up with, so a wire that
+/// applies them out of order costs a correction rather than a lie.
+const writes = new Map<string, number>();
+
 /// One issue with the patch applied. Serves `Issue` and `IssueDetail` alike,
 /// since both carry exactly these two fields.
 function patched<T extends { state: IssueState; priority: IssuePriority }>(
@@ -180,17 +200,27 @@ function patched<T extends { state: IssueState; priority: IssuePriority }>(
 /// this is not — but `FRESH_MS` is a minute, so on any list older than that the
 /// race is not a race at all, it happens every time. Stamped, nothing goes out
 /// until `forgetIssues` says so, which is after the write.
-function patchCachedIssue(identifier: string, patch: IssuePatch) {
+function patchCachedIssue(identifier: string, patch: IssuePatch): Rollback {
   const now = Date.now();
+  const undo: (() => void)[] = [];
   const detail = detailCache.get(identifier);
 
   if (detail) {
+    undo.push(() => {
+      detailCache.set(identifier, detail);
+      detailFetchedAt.delete(identifier);
+    });
     detailCache.set(identifier, patched(detail, patch));
     detailFetchedAt.set(identifier, now);
   }
 
   for (const [key, issues] of cache) {
     if (!issues.some((issue) => issue.identifier === identifier)) continue;
+
+    undo.push(() => {
+      cache.set(key, issues);
+      fetchedAt.delete(key);
+    });
 
     // A status write can move a row out of the half its list asked for — Done
     // belongs to the settled read, not the open one. Patched in place it would
@@ -215,6 +245,11 @@ function patchCachedIssue(identifier: string, patch: IssuePatch) {
   // flight, which is holding the generation it started under and would put the
   // pre-write answer back for the same reason.
   newIssueGeneration();
+
+  return () => {
+    for (const step of undo) step();
+    newIssueGeneration();
+  };
 }
 
 /// Moves an issue's status or priority — the one write this app makes to a
@@ -237,11 +272,27 @@ function patchCachedIssue(identifier: string, patch: IssuePatch) {
 /// since a write stamped with the old generation is refused by the very guard
 /// that makes the clearing stick.
 ///
-/// Failure raises a notice and is not thrown, and clears the optimistic paint
-/// with it: `forgetIssues` there is what puts the tracker's own answer back on
-/// screen rather than leaving a status the reader picked and never got.
+/// Failure rolls the paint back rather than clearing the caches. `forgetIssues`
+/// there was not enough and read as though it were: a list keeps its own rows
+/// when a forced re-read fails, and the write failing offline is exactly the
+/// case where that re-read fails too — so the rejected status stayed on screen
+/// under an error banner.
+///
+/// **`issue.identifier` is the cache key throughout, and the response's own is
+/// never used for one.** They differ after a team move: a session linked to
+/// `DRA-53` reads a detail that now calls itself `ENG-12`, and `useSessionIssues`
+/// caches it under the link's spelling. Keying the write off the response would
+/// patch an entry nobody reads and file the answer where nobody asks. The wire
+/// gets `issue.id`, the stable half, which is what Rust looks up first anyway.
 export async function updateIssue(issue: { identifier: string; id: string }, patch: IssuePatch) {
-  patchCachedIssue(issue.identifier, patch);
+  const ticket = (writes.get(issue.identifier) ?? 0) + 1;
+  writes.set(issue.identifier, ticket);
+
+  const rollback = patchCachedIssue(issue.identifier, patch);
+  /// Whether this write is still the newest for its issue. A superseded one
+  /// touches nothing — neither the caches nor the notice, since a card for a
+  /// pick the reader has already replaced names a decision they moved on from.
+  const current = () => writes.get(issue.identifier) === ticket;
 
   try {
     const next = await invoke<IssueDetail>("update_issue", {
@@ -253,10 +304,16 @@ export async function updateIssue(issue: { identifier: string; id: string }, pat
       priority: patch.priority ?? null,
     });
 
+    if (!current()) return;
+    writes.delete(issue.identifier);
+
     forgetIssues();
-    rememberDetail(next.identifier, next, issueGeneration());
+    rememberDetail(issue.identifier, next, issueGeneration());
   } catch (e) {
-    forgetIssues();
+    if (!current()) return;
+    writes.delete(issue.identifier);
+
+    rollback();
     pushNotice({
       sessionId: issue.identifier,
       kind: "issue-failed",

--- a/apps/desktop/src/hooks/useNotices.ts
+++ b/apps/desktop/src/hooks/useNotices.ts
@@ -25,7 +25,13 @@ import { useSyncExternalStore } from "react";
 /// have seen it happen. `worktree-failed` fires regardless of focus too, for
 /// the opposite reason: they have already seen the wrong answer. See `announce`
 /// in [useSessions](./useSessions.ts) for the split the first three make.
-export type NoticeKind = "completed" | "asking" | "worktree" | "pr" | "worktree-failed";
+export type NoticeKind =
+  | "completed"
+  | "asking"
+  | "worktree"
+  | "pr"
+  | "worktree-failed"
+  | "issue-failed";
 
 /// How long each kind stays on screen. Read by the card to time its own progress
 /// bar, which is also what dismisses it — see [NoticeStack](../components/NoticeStack.tsx).
@@ -44,14 +50,24 @@ export const NOTICE_TTL_MS: Record<NoticeKind, number> = {
   // own sentence, which is the only thing naming why the removal was refused,
   // and a reason nobody had time to read is a reason nobody was given.
   "worktree-failed": 15_000,
+  // Linear's own sentence, for the same reason — and this card answers a menu
+  // the reader clicked expecting it to just work, so it has to survive the
+  // moment they spend looking somewhere else.
+  "issue-failed": 15_000,
 };
 
 /// One in-app notice — something happened in a session the reader was not
 /// looking at. A window in the background gets a desktop notification instead
 /// and no notice at all, so nothing here has to survive being unseen.
 export type Notice = {
-  /// The session it reports on. With `kind`, its identity — a second event of
-  /// the same kind replaces the first rather than stacking a duplicate row.
+  /// What it reports on. With `kind`, its identity — a second event of the same
+  /// kind replaces the first rather than stacking a duplicate row.
+  ///
+  /// A session for every kind but `issue-failed`, which holds the issue's
+  /// identifier instead. Widened rather than renamed: the field is the notice's
+  /// *subject*, and the two vocabularies cannot be confused — a session id is a
+  /// UUID and an identifier is `DRA-128`. Only the navigating kinds read it as
+  /// a session, and `issue-failed` is deliberately not one of them.
   ///
   /// The session *alone* used to be the key, on the grounds that a session
   /// cannot both be blocked on a question and have finished its turn. That held

--- a/apps/desktop/src/lib/issue.test.ts
+++ b/apps/desktop/src/lib/issue.test.ts
@@ -114,7 +114,7 @@ const issue = (identifier: string, kind: IssueStateKind): Issue => ({
   identifier,
   title: identifier,
   url: `https://linear.app/x/issue/${identifier}`,
-  state: { name: "Whatever this team calls it", kind, color: "#000" },
+  state: { id: `state-${kind}`, name: "Whatever this team calls it", kind, color: "#000" },
   priority: "none",
   assignee: null,
   labels: [],
@@ -143,7 +143,7 @@ describe("groupIssues", () => {
   /// really the same few states.
   it("gathers teams that name one state differently", () => {
     const a = issue("DRA-1", "started");
-    const b = { ...issue("OPS-1", "started"), state: { name: "Shipping", kind: "started" as const, color: "#000" } };
+    const b = { ...issue("OPS-1", "started"), state: { id: "state-shipping", name: "Shipping", kind: "started" as const, color: "#000" } };
 
     expect(groupIssues([a, b])).toHaveLength(1);
   });

--- a/apps/desktop/src/lib/issue.ts
+++ b/apps/desktop/src/lib/issue.ts
@@ -147,6 +147,15 @@ const GROUPS: { key: IssueStateKind; label: string }[] = [
   { key: "other", label: "Other" },
 ];
 
+/// Whether the work is over, either way it went. The frontend's copy of Rust's
+/// `IssueStateKind::settled`, and it decides the same thing: which half of the
+/// workspace an issue belongs to. Stated twice because neither side can call the
+/// other — the backend splits the two reads, and the frontend has to know when a
+/// status it just wrote moves a row from one to the other.
+export function isSettled(kind: IssueStateKind): boolean {
+  return kind === "completed" || kind === "canceled";
+}
+
 type IssueGrouping = {
   key: IssueStateKind;
   label: string;

--- a/apps/desktop/src/lib/issueColor.test.ts
+++ b/apps/desktop/src/lib/issueColor.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { luminance, readableStateColor } from "@/lib/issueColor";
+
+/// The threshold the module works to, restated here on purpose: a test that
+/// imported the constant would pass whatever it drifted to.
+const FLOOR = 0.3;
+
+describe("readableStateColor", () => {
+  it("leaves dark mode alone", () => {
+    // The whole palette, untouched — the app must not disagree with the tracker
+    // beside it where the colour already reads.
+    expect(readableStateColor("#f2c94c", false)).toBe("#f2c94c");
+    expect(readableStateColor("#e2e2e2", false)).toBe("#e2e2e2");
+  });
+
+  it("darkens what light mode cannot show, and only that", () => {
+    // Linear's own "In Progress" yellow and its pale "Todo" grey, the two the
+    // page actually draws most.
+    for (const pale of ["#f2c94c", "#e2e2e2", "#ffffff"]) {
+      const fixed = readableStateColor(pale, true);
+      expect(fixed).not.toBe(pale);
+      // Exactly at or under the floor, no tolerance. A single-pass correction
+      // left `#f2c94c` at 0.315 — plausible on screen, and still short of 3:1,
+      // which is the whole failure this file exists to catch.
+      expect(luminance(fixed)).toBeLessThanOrEqual(FLOOR);
+    }
+
+    // Already readable: returned as it came, not re-encoded. Round-tripping a
+    // colour that needed nothing is how a "fix" starts changing every glyph.
+    expect(readableStateColor("#5e6ad2", true)).toBe("#5e6ad2");
+    expect(readableStateColor("#000000", true)).toBe("#000000");
+  });
+
+  it("keeps the hue it was given", () => {
+    // Green stays green. Substituting a palette colour of ours would pass a
+    // contrast check and lose the one thing these marks carry the tracker's
+    // colour for.
+    const green = readableStateColor("#4cf25e", true);
+    const [r, g, b] = [1, 3, 5].map((i) => parseInt(green.slice(i, i + 2), 16));
+
+    expect(g).toBeGreaterThan(r);
+    expect(g).toBeGreaterThan(b);
+  });
+
+  it("leaves anything it cannot parse", () => {
+    // A named colour, a short hex, and the empty string Linear sends for a
+    // state with no colour set. Guessing at one is how a glyph goes black.
+    for (const odd of ["", "red", "#fff", "rgb(1,2,3)"]) {
+      expect(readableStateColor(odd, true)).toBe(odd);
+    }
+  });
+});

--- a/apps/desktop/src/lib/issueColor.ts
+++ b/apps/desktop/src/lib/issueColor.ts
@@ -1,0 +1,87 @@
+/// Making the tracker's own colours readable on a light background.
+///
+/// Linear's state palette is picked for a dark surface — "In Progress" is
+/// `#f2c94c` and the default "Todo" is `#e2e2e2` — and both all but disappear on
+/// a light one. This is the one place that is corrected, so a workspace's custom
+/// state colour gets the same treatment as Linear's own.
+///
+/// Its own file rather than a helper inside [IssueStateIcon], because being
+/// wrong here is invisible on screen: a slightly-off exponent still produces a
+/// plausible colour. That is the bar this repo files pure logic under test for.
+///
+/// [IssueStateIcon]: ../components/IssueStateIcon.tsx
+
+/// The most luminous a state mark may be in light mode.
+///
+/// WCAG's floor for a graphical object is 3:1, which against white works out at
+/// a relative luminance of `1.05/3 - 0.05`.
+const MAX_LIGHT_LUMINANCE = 0.3;
+
+/// One sRGB channel with gamma removed. What luminance is summed over.
+function linearize(channel: number): number {
+  const c = channel / 255;
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+/// `#rrggbb` as three bytes, or `null` for anything else — a named colour, a
+/// short hex, an empty string. Unparseable is left alone rather than guessed at.
+function parseHex(color: string): [number, number, number] | null {
+  const match = /^#([0-9a-f]{6})$/i.exec(color.trim());
+  if (!match) return null;
+
+  const n = parseInt(match[1], 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function luminanceOf([r, g, b]: [number, number, number]): number {
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/// WCAG relative luminance, 0 for black and 1 for white. `null` for a colour
+/// this module cannot read.
+export function luminance(color: string): number | null {
+  const rgb = parseHex(color);
+  return rgb && luminanceOf(rgb);
+}
+
+/// How many passes the correction below gets. It converges geometrically, so
+/// three is already past the rounding, and the bound is only here so a colour
+/// that somehow refuses to fall cannot spin.
+const MAX_PASSES = 8;
+
+/// The tracker's colour, dark enough to read on the mode's own background.
+///
+/// **The hue is kept and the lightness is spent.** A workspace that paints "In
+/// Review" green has to read green here — that is the whole reason these marks
+/// carry the tracker's colour at all — so all three channels are scaled by one
+/// factor rather than a colour of ours being substituted.
+///
+/// **Applied until it lands, not once.** Luminance goes *roughly* as the channel
+/// to the 2.4, which makes one correction a good guess and not an answer: sRGB's
+/// curve has a linear toe and an offset, so a single pass left Linear's own
+/// `#f2c94c` at 0.315 against a 0.3 floor — still short of 3:1, and invisibly
+/// so. Each pass re-measures the *rounded* channels, which is what is returned,
+/// so the colour that was checked is the colour that is drawn.
+///
+/// Dark mode is returned untouched: the palette was designed for it, and
+/// correcting a colour that already reads would only make the app disagree with
+/// the tracker beside it for nothing.
+export function readableStateColor(color: string, light: boolean): string {
+  if (!light) return color;
+
+  const rgb = parseHex(color);
+  if (!rgb || luminanceOf(rgb) <= MAX_LIGHT_LUMINANCE) return color;
+
+  let scale = 1;
+  let out = rgb;
+
+  for (let pass = 0; pass < MAX_PASSES; pass += 1) {
+    const l = luminanceOf(out);
+    if (l <= MAX_LIGHT_LUMINANCE) break;
+
+    scale *= (MAX_LIGHT_LUMINANCE / l) ** (1 / 2.4);
+    out = rgb.map((channel) => Math.round(channel * scale)) as [number, number, number];
+  }
+
+  return `#${out.map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
+}

--- a/apps/desktop/src/types/events.ts
+++ b/apps/desktop/src/types/events.ts
@@ -682,7 +682,17 @@ export type IssueDetail = {
  * Markdown, as the tracker holds it. `None` for an issue nobody wrote one
  * for, which the panel says plainly rather than drawing an empty box.
  */
-description: string | null, comments: Array<IssueComment>, tracker: IssueTracker, id: string, identifier: string, title: string, url: string, state: IssueState, priority: IssuePriority, assignee: IssuePerson | null, labels: Array<IssueLabel>, 
+description: string | null, comments: Array<IssueComment>, 
+/**
+ * Every status this issue's own team offers, in workflow order — what the
+ * header's status menu draws.
+ *
+ * On the detail rather than read by a command of its own, because it rides
+ * the read the panel already makes: a menu that has to fetch before it can
+ * open is a menu that opens empty. Per *team*, so an issue moved between
+ * teams offers the states of wherever it now lives.
+ */
+states: Array<IssueState>, tracker: IssueTracker, id: string, identifier: string, title: string, url: string, state: IssueState, priority: IssuePriority, assignee: IssuePerson | null, labels: Array<IssueLabel>, 
 /**
  * Team key (`DRA`) — what the identifier is built from, so a row filtered
  * across teams still says which one it belongs to.
@@ -692,7 +702,16 @@ team: string | null, project: string | null, updatedAt: string, };
 /**
  * The filter row's options, read once per connection rather than per keystroke.
  */
-export type IssueFilters = { teams: Array<IssueGroup>, projects: Array<IssueGroup>, };
+export type IssueFilters = { teams: Array<IssueGroup>, projects: Array<IssueGroup>, 
+/**
+ * Every team's workflow states, keyed by team **key** (`DRA`) — what a
+ * row carries, where `teams` above is keyed by UUID.
+ *
+ * Here rather than on each issue because a workflow belongs to a team: one
+ * answer serves every row that team owns, so the issues page's status menus
+ * cost one read per connection instead of a copy per row.
+ */
+teamStates: { [key in string]: Array<IssueState> }, };
 
 export type IssueGroup = { id: string, name: string, };
 
@@ -767,7 +786,12 @@ identifier: string, title: string, url: string, };
  */
 export type IssueScope = "assigned" | "created" | "all";
 
-export type IssueState = { name: string, kind: IssueStateKind, 
+export type IssueState = { 
+/**
+ * The tracker's own id. What a status write names — a state is addressed
+ * by id and never by name, since two teams can both call one "In Review".
+ */
+id: string, name: string, kind: IssueStateKind, 
 /**
  * The tracker's own colour, so a status reads the same here as it does in
  * the app the reader also has open.


### PR DESCRIPTION
## TLDR for human

- Status and priority menus on an opened issue's header and on the Issues page's list rows — the first write Dray makes to a tracker.
- Optimistic: the glyph moves on the next frame, the write reconciles behind it. Writes are serialized per issue so send order is click order.
- A failed write rolls the paint back and raises a notice card carrying Linear's own sentence.
- Light-mode state colours darkened to WCAG's 3:1 floor, hue kept.
- ⌘⇧F focuses the Issues search, Esc clears it. ⌘-click an issue row opens it in Linear.
- Connect-form copy no longer says the key is read-only, because it no longer is.

---

Fixes DRA-128

### Backend

One `update_issue` command over Linear's `issueUpdate`, re-reading through the existing `get_issue` path. `IssueState` gains an id; `IssueDetail` gains `states` (the issue's own team workflow) and `IssueFilters` gains `teamStates` keyed by team key.

Three things worth a second look:

- **`issueUpdate` answers `success: false` at 200 with no `errors`** for a write it understood and refused — a state belonging to another team, most likely. Without checking it the panel re-reads, finds nothing moved, and silently redraws what was already there.
- **`None` means leave it, `Some(None)` means clear it.** Priority crosses as `Option<IssuePriority>` rather than a number, since "no priority" is a level a reader can pick and Linear spells it `0`.
- **States sort by kind then `position`.** Linear only makes position meaningful *within* a state type, so a single sort on it lists Done above Todo in a workspace that has been reorganised.

The mutation's own `issue` echo is deliberately unread — the panel draws a whole `IssueDetail`, and asking for that field set back would be a fourth copy of it in `linear.rs`.

### The optimistic write

The write is three Linear round trips deep (mutation, read-back, then every list re-reading), and a glyph that does not move until all three land reads as a menu that ignored the click. So `updateIssue` patches the cached issue and bumps the generation, and the menus pass the whole `IssueState` they picked, which is what makes that possible with nothing read back.

Four rules hold it together, and the first three were each a bug first:

- **Patched entries are stamped fresh.** `useIssueList` asks the network for whatever is stale and `FRESH_MS` is a minute, so an entry left with its old stamp fired a read that left *before* the mutation landed and wrote the old status back over the patch. Not a race — the ordinary path on any list older than a minute.
- **Requests are serialized per issue, and only the request queues.** Firing both of two quick picks at once leaves the tracker to decide which lands last, and it need not be the one clicked last: the server could end on A while the app showed B, with nothing left to re-read it. Chaining makes send order click order; the paint stays immediate. Only the last write in a chain reconciles or reports.
- **Failure rolls back rather than clearing.** `forgetIssues()` clears the caches but a list keeps its own rows when a forced re-read fails — and offline is exactly when both fail, so the rejected status sat on screen under an error banner. The rollback restores its snapshot and stales *every* stamp, since a superseded write leaves patches nothing reverts. Restored stale rather than fresh, because `update_issue` mutates and then re-reads: a command can fail with the write already landed, and one read settles which happened.
- **Everything matches on the stable id; an identifier is a cache slot, never an identity.** After a team move one issue occupies two slots — a session panel files it under the link's `DRA-53` while the Issues page files it under `ENG-12` — so the queue key, the row matching and the body scan all key on `id`, and only the response's placement uses the caller's identifier.

A status that moves a row out of the half its list asked for (Done, in the open list) drops the row rather than drawing a second "Done" heading. The half it moves *into* is left to the reconcile: a row appearing late, never a wrong one on screen.

### Two bugs found while wiring the menus up

- **React portals bubble through the React tree, not the DOM.** A click on a menu item reached the row's own `onClick` and opened the pane behind the menu being answered.
- **A `stopPropagation` on the trigger's keydown killed every shortcut in the app.** `useHotkey` listens on `document` in the bubble phase and Radix restores focus to the trigger on close, so from the first time anybody opened one of these, no chord worked again. Nothing needed it.

### Colour

`readableStateColor` darkens any state colour above WCAG's 3:1 floor in light mode, keeping hue — Linear's palette is picked for a dark surface and its "In Progress" yellow sits near 0.62. It **iterates**: sRGB has a linear toe and an offset, so one correction left `#f2c94c` at 0.315 against a 0.30 floor. Plausible on screen, still short of 3:1, and the test is what caught it.

The urgent priority glyph paints with an inline `fill` rather than `currentColor`, since a menu row recolours every descendant on focus and turned the one glyph whose colour *is* the signal white on hover.

### Notices

New `issue-failed` kind. It navigates nowhere — there is no session — so `NAVIGATES` states the set that does rather than `take` calling `onSelect` with an issue identifier. `Notice.sessionId` is widened in its doc rather than renamed: it is the notice's *subject*, and a UUID and `DRA-128` cannot be confused.

### Accessibility

The Issues page row is a `div role="button"` rather than a `button`, since it now carries two menu triggers as well as the "Work on it" control, and three focusable controls nested in a `button` is invalid markup whose keyboard behaviour assistive tech is free to collapse into the row's own action. It matches the shape `IssuePanel`'s row already used, `target === currentTarget` key guard included.

### Docs

`CLAUDE.md`, `COPY-ISSUES.md` and `SKILL.md` all said Dray never writes to the tracker. The connect form said "This key is read-only", which is now false — it reads and writes, and a read-only key still works minus these two menus. The `dray` CLI still writes nothing.

### Tests

634 Rust, 474 frontend. New: team-state ordering, a teamless issue, the clear-vs-leave priority distinction, wire round-trip, and four on the colour function.

Reviewed by a Codex session over three rounds; every finding it raised is fixed, and the two most subtle bugs above — the serialization gap and the partial rollback — are its, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
