### PR TITLE
feat(composer): continue markdown lists on Shift+Enter

### DIFF
--- a/apps/desktop/src/components/ChatInput.tsx
+++ b/apps/desktop/src/components/ChatInput.tsx
@@ -22,6 +22,7 @@ import { useRecentCommands } from "@/hooks/useRecentCommands";
 import { SEGMENT_COLOR, highlightSegments, splitMention } from "@/lib/highlight";
 import { applyIssue, issueSpan } from "@/lib/issue";
 import { registerComposer } from "@/lib/composerFocus";
+import { continueList } from "@/lib/list";
 import { applyMention, mentionSpan } from "@/lib/mention";
 import {
   applyCommand,
@@ -870,9 +871,23 @@ export default function ChatInput({
                     // works with the composer unfocused too.
 
                     // Shift+Enter is the only way to get a newline; plain Enter sends.
-                    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                      if (!e.shiftKey) {
+                        e.preventDefault();
+                        submit();
+                        return;
+                      }
+
+                      // A newline inside a list carries the marker with it. Only
+                      // with the selection collapsed: over a range the native
+                      // newline replaces the selection, which this cannot.
+                      const el = e.currentTarget;
+                      if (el.selectionStart !== el.selectionEnd) return;
+                      const next = continueList(message, el.selectionStart);
+                      if (!next) return;
                       e.preventDefault();
-                      submit();
+                      pendingCaretRef.current = next.caret;
+                      setMessage(next.text);
                     }
                   }}
                   // `py-1` puts one line at 28px — the buttons' own height — so the

--- a/apps/desktop/src/lib/list.test.ts
+++ b/apps/desktop/src/lib/list.test.ts
@@ -57,6 +57,10 @@ describe("continueList renumbering", () => {
     );
   });
 
+  it("steps over a nested bullet under a numbered parent", () => {
+    expect(continueList("1. a\n  - child\n2. b", 4)?.text).toBe("1. a\n2. \n  - child\n3. b");
+  });
+
   it("leaves bullets below alone", () => {
     expect(continueList("- a\n- b", 3)?.text).toBe("- a\n- \n- b");
   });

--- a/apps/desktop/src/lib/list.test.ts
+++ b/apps/desktop/src/lib/list.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { continueList } from "./list";
+
+describe("continueList", () => {
+  it("carries a bullet onto the next line", () => {
+    expect(continueList("- one", 5)).toEqual({ text: "- one\n- ", caret: 8 });
+  });
+
+  it("keeps the marker and indent the reader chose", () => {
+    expect(continueList("  * one", 7)).toEqual({ text: "  * one\n  * ", caret: 12 });
+  });
+
+  it("increments an ordered item, keeping its delimiter", () => {
+    expect(continueList("1. one", 6)).toEqual({ text: "1. one\n2. ", caret: 10 });
+    expect(continueList("9) one", 6)).toEqual({ text: "9) one\n10) ", caret: 11 });
+  });
+
+  it("splits an item at the caret and leaves the rest under the new marker", () => {
+    expect(continueList("- one two", 5)).toEqual({ text: "- one\n-  two", caret: 8 });
+  });
+
+  it("reads the caret's line, not the first", () => {
+    expect(continueList("intro\n- one", 11)).toEqual({ text: "intro\n- one\n- ", caret: 14 });
+  });
+
+  it("takes the marker back off an empty item instead of adding a line", () => {
+    expect(continueList("- one\n- ", 8)).toEqual({ text: "- one\n", caret: 6 });
+  });
+
+  it("keeps the marker where the empty item has text after the caret", () => {
+    expect(continueList("- one\n- two", 8)).toEqual({ text: "- one\n- \n- two", caret: 11 });
+  });
+
+  it("does nothing outside a list", () => {
+    expect(continueList("plain", 5)).toBeNull();
+    expect(continueList("-no gap", 7)).toBeNull();
+    expect(continueList("a - b", 5)).toBeNull();
+  });
+});
+
+describe("continueList renumbering", () => {
+  it("renumbers the items below an insertion", () => {
+    expect(continueList("1. a\n2. b\n3. c", 4)).toEqual({
+      text: "1. a\n2. \n3. b\n4. c",
+      caret: 8,
+    });
+  });
+
+  it("renumbers the items below a removal", () => {
+    expect(continueList("1. a\n2. \n3. b", 8)).toEqual({ text: "1. a\n\n2. b", caret: 5 });
+  });
+
+  it("steps over a nested list and stops at prose", () => {
+    expect(continueList("1. a\n  1. x\n2. b\ndone\n3. c", 4)?.text).toBe(
+      "1. a\n2. \n  1. x\n3. b\ndone\n3. c",
+    );
+  });
+
+  it("leaves bullets below alone", () => {
+    expect(continueList("- a\n- b", 3)?.text).toBe("- a\n- \n- b");
+  });
+});

--- a/apps/desktop/src/lib/list.ts
+++ b/apps/desktop/src/lib/list.ts
@@ -1,0 +1,77 @@
+/// Carrying a markdown list marker onto the next line, the way every editor
+/// does it — the one piece of markdown the composer has to *know* about, since
+/// a textarea will happily let the reader retype `- ` on every line.
+///
+/// Caret arithmetic and nothing else, so it sits beside `slash.ts` and
+/// `mention.ts` rather than in the composer: the rules are worth a test and the
+/// component is not testable here.
+
+/// A list item at the caret's line: indent, marker, the gap after it, and
+/// whatever body has been typed so far. `[ \t]` rather than `\s`, or the class
+/// eats the newline that ends the line above.
+const ITEM = /^([ \t]*)([-*+]|\d+[.)])([ \t]+)(.*)$/;
+
+/// The numbered half of `ITEM`, for the lines below the one being edited.
+const ORDERED = /^([ \t]*)(\d+)[.)][ \t]+/;
+
+/// The lines from `from` on, renumbered from `next` while they stay in the same
+/// list — same indent, one after another. A deeper item is a nested list and is
+/// stepped over untouched; anything else ends the list. Without this an item
+/// added in the middle leaves two `2.`s, which markdown renders fine and the
+/// reader does not.
+function renumber(text: string, from: number, indent: string, next: number): string {
+  const lines = text.slice(from).split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = ORDERED.exec(lines[i]);
+    if (!match) break;
+    if (match[1].length > indent.length) continue;
+    if (match[1] !== indent) break;
+    lines[i] = `${indent}${next}${lines[i].slice(match[1].length + match[2].length)}`;
+    next += 1;
+  }
+  return text.slice(0, from) + lines.join("\n");
+}
+
+/// Where the line after `at` begins, or the text's end when there is none.
+function nextLine(text: string, at: number): number {
+  const cut = text.indexOf("\n", at);
+  return cut === -1 ? text.length : cut + 1;
+}
+
+/// What the newline about to be inserted should produce, or `null` where the
+/// caret is not in a list and the textarea's own newline is right.
+///
+/// Two answers, and the second is why this can't be a prefix-only insert: an
+/// item with nothing typed in it is the reader leaving the list, so the marker
+/// is *taken back off* and no line is added. Ending a list otherwise means
+/// deleting a bullet the app just wrote, which is the thing the feature exists
+/// to stop.
+///
+/// The body is read up to the caret alone, so splitting an item mid-word
+/// carries the marker and leaves the rest of the line under it — same as
+/// pressing Return in the middle of any other list.
+export function continueList(text: string, caret: number): { text: string; caret: number } | null {
+  const start = text.lastIndexOf("\n", caret - 1) + 1;
+  const match = ITEM.exec(text.slice(start, caret));
+  if (!match) return null;
+
+  const [, indent, marker, gap, body] = match;
+  const digits = /^(\d+)([.)])$/.exec(marker);
+  const number = digits ? Number(digits[1]) : 0;
+
+  // Only where the rest of the line is empty too — a caret parked at `- |item`
+  // is someone editing, not someone finishing.
+  const rest = text.slice(caret);
+  if (!body && (rest === "" || rest.startsWith("\n"))) {
+    let out = text.slice(0, start) + rest;
+    if (digits) out = renumber(out, nextLine(out, start), indent, number);
+    return { text: out, caret: start };
+  }
+
+  const next = digits ? `${number + 1}${digits[2]}` : marker;
+  const insert = `\n${indent}${next}${gap}`;
+  let out = text.slice(0, caret) + insert + rest;
+  if (digits) out = renumber(out, nextLine(out, caret + insert.length), indent, number + 2);
+
+  return { text: out, caret: caret + insert.length };
+}

--- a/apps/desktop/src/lib/list.ts
+++ b/apps/desktop/src/lib/list.ts
@@ -22,10 +22,14 @@ const ORDERED = /^([ \t]*)(\d+)[.)][ \t]+/;
 function renumber(text: string, from: number, indent: string, next: number): string {
   const lines = text.slice(from).split("\n");
   for (let i = 0; i < lines.length; i += 1) {
+    // Any item deeper in is nested, bullet or number — judged on `ITEM`
+    // first, or a `- child` under a numbered parent ends the walk early and
+    // leaves the parent below it unrenumbered.
+    const item = ITEM.exec(lines[i]);
+    if (!item) break;
+    if (item[1].length > indent.length) continue;
     const match = ORDERED.exec(lines[i]);
-    if (!match) break;
-    if (match[1].length > indent.length) continue;
-    if (match[1] !== indent) break;
+    if (!match || match[1] !== indent) break;
     lines[i] = `${indent}${next}${lines[i].slice(match[1].length + match[2].length)}`;
     next += 1;
   }


### PR DESCRIPTION
Shift+Enter inside a `- `, `* `, `+ ` or `1. ` item carries the marker onto the next line. Numbered items increment, and the items below an insertion or removal renumber (same indent only; nested lists stepped over, prose ends the list). Shift+Enter on an empty item removes the marker instead of adding a line.

Pure caret arithmetic in `src/lib/list.ts`, 12 tests. One branch in `ChatInput`'s `onKeyDown`, collapsed selection only.

Fixes DRA-181

🤖 Generated with [Claude Code](https://claude.com/claude-code)