### PR TITLE
Resolve the code theme against the app palette

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -765,7 +765,7 @@ The `github` fixture sits outside that tree at `src-tauri/src/fixtures/pr_graphq
 
 Every surface showing code — `Edit` diffs, ranged `Read` slices, markdown fences — go through **one** Shiki highlighter, the shared instance inside `@pierre/diffs`: [DiffView](apps/desktop/src/components/chat/DiffView.tsx), [CodeView](apps/desktop/src/components/chat/CodeView.tsx), and [codePlugin.ts](apps/desktop/src/lib/codePlugin.ts) replacing `@streamdown/code`'s runtime. Sharing is not just deduplication: the stock Streamdown plugin build a *second* Shiki with its own registries, which cannot see `pierre-*` at all.
 
-**Themes are `{light, dark}` pairs, never one name** ([codeTheme.ts](apps/desktop/src/lib/codeTheme.ts)) — the app's mode can change under a mounted view. [useCodeTheme](apps/desktop/src/hooks/useCodeTheme.ts) is `useSyncExternalStore`, not `useLocalStorage`, because several diffs are mounted at once and per-component state desync them.
+**Themes are `{light, dark}` pairs, never one name** ([codeTheme.ts](apps/desktop/src/lib/codeTheme.ts)) — the app's mode can change under a mounted view. **The shipped default is `auto`, which mean the app theme, so `codeThemePair` take one** — resolving without it drew every palette's code in Pierre's colours and switched on mode alone (DRA-183). `AUTO_THEMES` hold the map; a palette with no Shiki counterpart take the nearest, never a grey. [useCodeTheme](apps/desktop/src/hooks/useCodeTheme.ts) is `useSyncExternalStore`, not `useLocalStorage`, because several diffs are mounted at once and per-component state desync them.
 
 Three failure modes, all presenting as _code that renders but is blank or grey_ rather than as an error:
 

--- a/apps/desktop/src/hooks/useCodeTheme.ts
+++ b/apps/desktop/src/hooks/useCodeTheme.ts
@@ -37,11 +37,16 @@ function setCodeTheme(id: CodeThemeId) {
 ///
 /// `pair` is what both consumers want: Shiki takes light and dark together and
 /// picks a side by the mode it's told, so neither has to branch on it.
+///
+/// The app theme is read here rather than at each call site because the default
+/// choice is `auto`, which *is* the app theme — resolving without it left every
+/// palette's code blocks in Pierre's colours, switching on mode alone.
 export function useCodeTheme(): {
   id: CodeThemeId;
   pair: CodeThemePair;
   setCodeTheme: (id: CodeThemeId) => void;
 } {
+  const { theme } = useTheme();
   const id = useSyncExternalStore(
     changed.subscribe,
     () => current,
@@ -50,7 +55,7 @@ export function useCodeTheme(): {
 
   return {
     id,
-    pair: codeThemePair(id),
+    pair: codeThemePair(id, theme),
     setCodeTheme: useCallback(setCodeTheme, []),
   };
 }

--- a/apps/desktop/src/lib/codeTheme.test.ts
+++ b/apps/desktop/src/lib/codeTheme.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { CODE_THEMES, codeThemePair } from "./codeTheme";
+import { THEMES } from "./theme";
+
+describe("codeThemePair", () => {
+  it("resolves auto against the app theme, not mode alone", () => {
+    // The defect this table fixes: every palette drew its code in Pierre's colours.
+    expect(codeThemePair("auto", "catppuccin")).toEqual(codeThemePair("catppuccin"));
+    expect(codeThemePair("auto", "gruvbox")).toEqual(codeThemePair("gruvbox"));
+    expect(codeThemePair("auto", "one-dark-pro")).toEqual(codeThemePair("one"));
+    expect(codeThemePair("auto", "default")).toEqual(codeThemePair("pierre"));
+  });
+
+  it("answers a pair for every app theme", () => {
+    for (const { id } of THEMES) {
+      const pair = codeThemePair("auto", id);
+      expect(pair.light).toBeTruthy();
+      expect(pair.dark).toBeTruthy();
+    }
+  });
+
+  // App reruns `warmHighlighter` and DiffWorkerPool pushes `setRenderOptions` on a
+  // new pair, so a fresh object per render would rewarm the highlighter every frame.
+  it("returns a stable object for an unchanged choice", () => {
+    expect(codeThemePair("auto", "gruvbox")).toBe(codeThemePair("auto", "gruvbox"));
+  });
+
+  it("falls back for an id no longer shipped", () => {
+    expect(codeThemePair("moonlight" as never)).toEqual(codeThemePair("pierre"));
+  });
+
+  it("names only ids the picker holds", () => {
+    const ids = new Set(CODE_THEMES.map((t) => t.id));
+    for (const { id } of THEMES) {
+      const pair = codeThemePair("auto", id);
+      expect([...ids].some((i) => codeThemePair(i) === pair)).toBe(true);
+    }
+  });
+});

--- a/apps/desktop/src/lib/codeTheme.ts
+++ b/apps/desktop/src/lib/codeTheme.ts
@@ -10,6 +10,8 @@
 // and pnpm doesn't hoist it, so importing the name directly doesn't resolve.
 import type { BundledTheme } from "streamdown";
 
+import { DEFAULT_THEME, type ThemeName } from "@/lib/theme";
+
 /// `@pierre/theming` registers these alongside Shiki's bundled set, so the
 /// shared highlighter resolves them by name like any other — but they are
 /// absent from `BundledTheme`, which only covers what Shiki itself ships.
@@ -32,6 +34,7 @@ export type CodeThemeId =
   | "rose-pine"
   | "catppuccin"
   | "nord"
+  | "night-owl"
   | "gruvbox"
   | "tokyo-night"
   | "solarized";
@@ -42,9 +45,9 @@ type CodeThemeEntry = {
   pair: CodeThemePair;
 };
 
-/// The pair used when the user hasn't chosen, and the one `auto` resolves to.
-/// Pierre's own themes: they ship with the diff renderer and were drawn for it,
-/// so the diff chrome and the syntax colors come from one hand.
+/// The pair used when the user hasn't chosen and the app theme has no syntax
+/// counterpart. Pierre's own themes: they ship with the diff renderer and were drawn
+/// for it, so the diff chrome and the syntax colors come from one hand.
 const DEFAULT_PAIR: CodeThemePair = { light: "pierre-light", dark: "pierre-dark" };
 
 /// The picker's contents. Every entry is a real light/dark pair — a theme with
@@ -75,6 +78,11 @@ export const CODE_THEMES: CodeThemeEntry[] = [
   // has to a light mode, so pair it with a neutral rather than inventing one.
   { id: "nord", label: "Nord", pair: { light: "min-light", dark: "nord" } },
   {
+    id: "night-owl",
+    label: "Night Owl",
+    pair: { light: "night-owl-light", dark: "night-owl" },
+  },
+  {
     id: "gruvbox",
     label: "Gruvbox",
     pair: { light: "gruvbox-light-medium", dark: "gruvbox-dark-medium" },
@@ -89,8 +97,35 @@ export const CODE_THEMES: CodeThemeEntry[] = [
 
 export const DEFAULT_CODE_THEME: CodeThemeId = "auto";
 
+/// What `auto` resolves to, per app theme. Three of the app's palettes are ports of
+/// editor themes Shiki bundles too, so the code block is drawn in the same hand as the
+/// chrome around it. An app theme absent here falls through to Pierre's, which is what
+/// `default`'s own palette is drawn against.
+///
+/// **Cobalt2 is an approximation and the only one.** Shiki bundles no Cobalt2, and a
+/// diff keeps its theme's `editor.background` (a markdown fence doesn't — App.css
+/// forces that transparent), so the *background family* is what a mismatch shows
+/// first. Night Owl is the one navy in the bundle; its accents are purple and peach
+/// where Cobalt2's are yellow and cyan, so this matches the page and not the syntax.
+/// A true one means shipping the tmTheme through `registerCustomTheme`, which the
+/// diff **worker** has no path for — so diffs would fall back while fences didn't.
+const AUTO_THEMES: Partial<Record<ThemeName, CodeThemeId>> = {
+  catppuccin: "catppuccin",
+  gruvbox: "gruvbox",
+  "one-dark-pro": "one",
+  cobalt2: "night-owl",
+};
+
 /// The pair for an id, falling back to the default for an id from a newer build
 /// or a hand-edited store.
-export function codeThemePair(id: CodeThemeId): CodeThemePair {
-  return CODE_THEMES.find((t) => t.id === id)?.pair ?? DEFAULT_PAIR;
+///
+/// `appTheme` is here for `auto` alone, which means "match the app theme" and so
+/// cannot be answered without it. It defaults so a caller with no theme to hand — a
+/// test, a preview swatch — still gets the shipped default rather than nothing.
+export function codeThemePair(
+  id: CodeThemeId,
+  appTheme: ThemeName = DEFAULT_THEME,
+): CodeThemePair {
+  const resolved = id === "auto" ? (AUTO_THEMES[appTheme] ?? "pierre") : id;
+  return CODE_THEMES.find((t) => t.id === resolved)?.pair ?? DEFAULT_PAIR;
 }


### PR DESCRIPTION
Every code block — diffs and markdown fences alike — drew Pierre's colours whatever palette was up. `auto` is the shipped default and `codeThemePair` resolved it without ever asking what the app theme was, so the only thing that changed was the light/dark side.

`AUTO_THEMES` maps app theme → code theme, and `useCodeTheme` reads the palette off `useTheme`. Catppuccin, Gruvbox and One Dark Pro hit the Shiki themes they were ported from; `default` stays on Pierre, which its palette was drawn against.

Cobalt2 is the one approximation. Shiki bundles no Cobalt2, and a diff keeps its theme's `editor.background` where a fence does not, so background family is what a mismatch shows first — Night Owl is the one navy in the bundle. A true one means shipping the tmTheme through `registerCustomTheme`, which the diff **worker** has no path for, so diffs would fall back while fences did not.

Pair identity stays stable across renders, or `warmHighlighter` reruns and the worker pool pushes `setRenderOptions` every frame. Pinned by test.

Fixes DRA-183