### PR TITLE
Split view: open up to four sessions side by side

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,7 @@ A pinned id is the only way to reach a previous generation, since **the CLI list
 
 ## The repo view
 
-**The main column has tabs, and Chat is one of them.** [ViewTabs](apps/desktop/src/components/layout/ViewTabs.tsx); `VIEW_TABS` is set *and* order, so Terminal later is one array entry plus one body, and accelerators (⌘1, ⌘2) read off array position rather than being stored per tab. Bodies use `TabBody`, so the transcript **hides, not unmounts** — scroll position, follow pin and highlighted diffs survive the flip. The tab is per session and **not persisted**. The composer is hidden off Chat, safe to unmount because `useDraft`/`useAttachments` are module-level.
+**The main column has tabs, and Chat is one of them.** [ViewTabs](apps/desktop/src/components/layout/ViewTabs.tsx); `VIEW_TABS` is set *and* order, so Terminal later is one array entry plus one body, and accelerators (⌘⌥1, ⌘⌥2) read off array position rather than being stored per tab — the bare ⌘ digits belong to the split view's panes. Bodies use `TabBody`, so the transcript **hides, not unmounts** — scroll position, follow pin and highlighted diffs survive the flip. The tab is per session and **not persisted**. The composer is hidden off Chat, safe to unmount because `useDraft`/`useAttachments` are module-level.
 
 The right panel's Changes tab stays and answers a different question: the panel is "what did this turn do", the view is the whole repository.
 
@@ -332,7 +332,7 @@ Linear puts uploads *in* the description's markdown, pointing at `uploads.linear
 - **`SessionHeader` takes `standIn`** and `App` passes `"Issues"`, or the header sits at "New session" over a list of issues.
 - **Clicking a row opens it in the pane beside the list**, off the same key the list was read with, in the same `RightPanel` frame. The picked issue is held as a whole row, not an identifier, so the pane is complete before its own detail read lands. `useSessionIssues` serves both, since a page pick is a one-element link list.
 - **Every route to a session goes through `goToSession`**, which closes the page then navigates. Two buttons closed the page and the chords beside them did not, which made ⌘N and ⌘⇧↑/↓ read as inert.
-- **⌘E only ever closes there**, and the guard lives on the chord, not only in `handleTogglePanel` — ⌘E binds **raw** `togglePanel`, so a guard in that function alone lets the chord sail past into a pane not on screen. Same for ⌘1/⌘2.
+- **⌘E only ever closes there**, and the guard lives on the chord, not only in `handleTogglePanel` — ⌘E binds **raw** `togglePanel`, so a guard in that function alone lets the chord sail past into a pane not on screen. Same for ⌘⌥1/⌘⌥2.
 - **Panel tab `issue`, hidden with no link.** Rows are drawn from the session's own `IssueRef`s, so the tab exists the moment something links one. **Linking is the agent's**, through `dray issue link`. The description is drawn here where the PR panel leaves the PR body out, and the difference is who wrote it.
 - **No Start button** — it would create a session, so it must name a project, and the page is workspace-wide. Tagging with `#` in the composer already starts work against an issue from a place that knows the project.
 

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -1245,3 +1245,10 @@
     background: radial-gradient(circle at 100% 0, transparent 8px, var(--card) 8.5px);
   }
 }
+
+/* A sidebar row being dragged. Forced on everything, since the rows, links
+   and buttons the pointer crosses each carry a cursor of their own. */
+body.session-drag,
+body.session-drag * {
+  cursor: grabbing !important;
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -173,6 +173,7 @@ function App() {
     ensureLoaded,
     setOnScreen,
     paneState,
+    indexSide,
   } = useSessions();
 
   // Whether the agent the composer is pointed at can actually be run. Null
@@ -495,14 +496,16 @@ function App() {
       .filter((g) => members(g).length >= 2);
   }, [groups, space, projects, sessionIndexItems]);
 
-  // A deleted or archived member leaves its group. Gated on the live list
-  // having loaded: the index is empty for a moment at launch, and pruning
-  // against that would drop every group.
+  // A deleted or archived member leaves its group. Gated on the *loaded* list
+  // being the live one — not on `showArchived`, which flips before the live
+  // list lands, so a switch back from Settled would prune every group against
+  // the archived list still on screen. `null` covers launch, where the index
+  // is empty for a moment.
   useEffect(() => {
-    if (showArchived || sessionIndexItems.length === 0) return;
+    if (indexSide !== false) return;
     const present = new Set(sessionIndexItems.map((i) => i.sessionId));
     setGroups((prev) => pruneGroups(prev, present));
-  }, [sessionIndexItems, showArchived, setGroups]);
+  }, [sessionIndexItems, indexSide, setGroups]);
 
   // Selecting a member is what activates a group; the selected session is the
   // focused pane, so every control that serves one session keeps doing so.

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -90,6 +90,7 @@ import { useUpdater } from "@/hooks/useUpdater";
 import { appendToDraft } from "@/hooks/useDraft";
 import { issueTag } from "@/lib/issue";
 import { authFailedTurn } from "@/lib/auth";
+import { basename } from "@/lib/format";
 import { focusComposer } from "@/lib/composerFocus";
 import { changeRange, turnChangedTree } from "@/lib/changes";
 import { prBadgeCount, sessionBranch } from "@/lib/pr";
@@ -507,6 +508,14 @@ function App() {
     setGroups((prev) => pruneGroups(prev, present));
   }, [sessionIndexItems, indexSide, setGroups]);
 
+  // Whether the reader has ever made a group. Written once and never cleared:
+  // the sidebar's drag tip retires on it, and a group dissolving later does
+  // not make the drag un-learned.
+  const [splitLearned, setSplitLearned] = useLocalStorage("ade.splitLearned", false);
+  useEffect(() => {
+    if (groups.length > 0 && !splitLearned) setSplitLearned(true);
+  }, [groups, splitLearned, setSplitLearned]);
+
   // Selecting a member is what activates a group; the selected session is the
   // focused pane, so every control that serves one session keeps doing so.
   const activeGroup = groupOf(spaceGroups, selectedSessionId);
@@ -518,6 +527,17 @@ function App() {
       ),
     [activeGroup, sessionIndexItems],
   );
+
+  // What the composer names as its target in a grid: the focused session's
+  // title, with its project in front where the panes span projects and a
+  // title alone could belong to either.
+  const composerTarget = (() => {
+    if (!activeGroup || !selectedSession) return null;
+    const projects = new Set(paneColumns.flat().map((i) => i.projectPath));
+    return projects.size > 1
+      ? `${basename(selectedSession.projectPath)} / ${selectedSession.title}`
+      : selectedSession.title;
+  })();
 
   // Every pane loaded and held: eviction and read-marking treat the whole grid
   // as on screen.
@@ -1417,6 +1437,7 @@ function App() {
           }
           groups={spaceGroups}
           onDropSession={dropSession}
+          splitLearned={splitLearned}
           onNewSession={() => goToSession(handleNewSession)}
           onNewSessionInProject={(path) =>
             goToSession(() => {
@@ -1649,7 +1670,7 @@ function App() {
           busy={busy}
           sessionId={selectedSessionId}
           isNewTask={!selectedSession}
-          target={activeGroup ? selectedSession?.title ?? null : null}
+          target={composerTarget}
           issuesConnected={issuesConnected}
           modelTakesImages={modelTakesImages}
           error={error}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1040,6 +1040,10 @@ function App() {
   const renameSpace = async (from: string, to: string) => {
     if (!(await retagSpace(from, to))) return;
     setDeclaredSpaces((prev) => [...new Set(prev.map((s) => (s === from ? to : s)))]);
+    // Groups are filed by the space's name, so they follow it — left tagged
+    // with the old one they would vanish, and come back under a later space
+    // that happened to take the name.
+    setGroups((prev) => prev.map((g) => (g.space === from ? { ...g, space: to } : g)));
     if (storedSpace === from) setStoredSpace(to);
   };
 
@@ -1049,6 +1053,8 @@ function App() {
   const removeSpace = async (name: string) => {
     if (!(await retagSpace(name, null))) return;
     setDeclaredSpaces((prev) => prev.filter((s) => s !== name));
+    // Its groups go where its projects go: under none, which is every project.
+    setGroups((prev) => prev.map((g) => (g.space === name ? { ...g, space: null } : g)));
     if (storedSpace === name) changeSpace(null);
   };
 
@@ -1217,20 +1223,23 @@ function App() {
   useHotkey("ArrowDown", () => goToSession(() => stepGroup(1)), { alt: true });
   // The bare ⌘ digits go to the panes, since focus is what moves most inside
   // a grid; the view tabs take ⌘⌥ below. Not ⌘⇧, which macOS spends on
-  // screenshots for exactly these digits. Bound only while a grid is up: ⌘1
-  // with none has nothing to point at, and must not eat the key.
+  // screenshots for exactly these digits. Bound only while a grid is *on
+  // screen*: with none ⌘1 has nothing to point at and must not eat the key,
+  // and under the Diff tab or the issues page ⌘⌥W would close a pane the
+  // reader cannot see.
+  const gridShown = !!activeGroup && !issuesOpen && viewTab === "chat";
   const paneIds = activeGroup ? members(activeGroup) : [];
   const focusPane = (n: number) => {
     const id = paneIds[n - 1];
     if (id) void handleSelectSessionIndexItem(id);
   };
-  useHotkey("1", () => focusPane(1), { enabled: !!activeGroup });
-  useHotkey("2", () => focusPane(2), { enabled: !!activeGroup });
-  useHotkey("3", () => focusPane(3), { enabled: !!activeGroup });
-  useHotkey("4", () => focusPane(4), { enabled: !!activeGroup });
+  useHotkey("1", () => focusPane(1), { enabled: gridShown });
+  useHotkey("2", () => focusPane(2), { enabled: gridShown });
+  useHotkey("3", () => focusPane(3), { enabled: gridShown });
+  useHotkey("4", () => focusPane(4), { enabled: gridShown });
   useHotkey("w", () => selectedSessionId && closeSessionPane(selectedSessionId), {
     alt: true,
-    enabled: !!activeGroup,
+    enabled: gridShown,
   });
   // ⌘E for the right pane against ⌘B for the left.
   //

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1229,9 +1229,16 @@ function App() {
   // reader cannot see.
   const gridShown = !!activeGroup && !issuesOpen && viewTab === "chat";
   const paneIds = activeGroup ? members(activeGroup) : [];
+  // Keyboard focus moves with the pane. A click moves it by itself, but a
+  // chord left it on whatever the old pane held — a link, a subagent control
+  // — and Enter there then acted through the *selected* session, since every
+  // opener resolves ownership from the selection. The composer is where the
+  // reader's next keystroke belongs anyway.
   const focusPane = (n: number) => {
     const id = paneIds[n - 1];
-    if (id) void handleSelectSessionIndexItem(id);
+    if (!id) return;
+    void handleSelectSessionIndexItem(id);
+    focusComposer();
   };
   useHotkey("1", () => focusPane(1), { enabled: gridShown });
   useHotkey("2", () => focusPane(2), { enabled: gridShown });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -44,7 +44,21 @@ import Sidebar, {
   filterSessions,
   sortSessions,
 } from "@/components/Sidebar";
+import SplitView, { DragGhost, DropZone } from "@/components/SplitView";
 import SubagentPanel from "@/components/SubagentPanel";
+import { DROP_ATTR, useSessionDrag, type DropTarget } from "@/lib/dragSession";
+import {
+  closePane,
+  dropLabel,
+  GROUPS_KEY,
+  groupName,
+  members,
+  groupOf,
+  openBeside,
+  pruneGroups,
+  stepUnits,
+  type SplitGroup,
+} from "@/lib/groups";
 import ComposerToolbar from "@/components/composer/ComposerToolbar";
 import DictateControl from "@/components/composer/DictateControl";
 import AppShell from "@/components/layout/AppShell";
@@ -69,7 +83,7 @@ import { useSessions } from "@/hooks/useSessions";
 import { useAgentAvailability, useMissingAgent } from "@/hooks/useAgentAvailability";
 import AgentMissingNotice from "@/components/composer/AgentMissingNotice";
 import LoginExpiredNotice from "@/components/composer/LoginExpiredNotice";
-import type { Issue, WorktreeDisposition } from "@/types/events";
+import type { Issue, SessionIndexItem, WorktreeDisposition } from "@/types/events";
 import { useSlashCommands } from "@/hooks/useSlashCommands";
 import { useRecorder } from "@/hooks/useTranscription";
 import { useUpdater } from "@/hooks/useUpdater";
@@ -156,6 +170,9 @@ function App() {
     detachSession,
     deleteSession,
     removeWorktree,
+    ensureLoaded,
+    setOnScreen,
+    paneState,
   } = useSessions();
 
   // Whether the agent the composer is pointed at can actually be run. Null
@@ -456,6 +473,84 @@ function App() {
       ),
     [sessionIndexItems, projects, space, projectFilter],
   );
+
+  // Split groups: frontend-only, filed under the space they were made in. A
+  // member whose project has since left the space is not drawn, and a group
+  // that leaves fewer than two is no group here. Not narrowed by the project
+  // filter — the grid shows the whole group, and the sidebar's run narrows
+  // itself to the rows it draws.
+  const [groups, setGroups] = useLocalStorage<SplitGroup[]>(GROUPS_KEY, []);
+  const spaceGroups = useMemo(() => {
+    const shown = new Set(
+      sessionIndexItems
+        .filter((i) => sessionInSpace(projects, space, i.projectPath))
+        .map((i) => i.sessionId),
+    );
+    return groups
+      .filter((g) => g.space === space)
+      .map((g) => ({
+        ...g,
+        columns: g.columns.map((c) => c.filter((id) => shown.has(id))).filter((c) => c.length),
+      }))
+      .filter((g) => members(g).length >= 2);
+  }, [groups, space, projects, sessionIndexItems]);
+
+  // A deleted or archived member leaves its group. Gated on the live list
+  // having loaded: the index is empty for a moment at launch, and pruning
+  // against that would drop every group.
+  useEffect(() => {
+    if (showArchived || sessionIndexItems.length === 0) return;
+    const present = new Set(sessionIndexItems.map((i) => i.sessionId));
+    setGroups((prev) => pruneGroups(prev, present));
+  }, [sessionIndexItems, showArchived, setGroups]);
+
+  // Selecting a member is what activates a group; the selected session is the
+  // focused pane, so every control that serves one session keeps doing so.
+  const activeGroup = groupOf(spaceGroups, selectedSessionId);
+  const memberKey = activeGroup ? members(activeGroup).join("\n") : "";
+  const paneColumns = useMemo(
+    () =>
+      (activeGroup?.columns ?? []).map((column) =>
+        column.flatMap((id) => sessionIndexItems.find((i) => i.sessionId === id) ?? []),
+      ),
+    [activeGroup, sessionIndexItems],
+  );
+
+  // Every pane loaded and held: eviction and read-marking treat the whole grid
+  // as on screen.
+  useEffect(() => {
+    const ids = memberKey ? memberKey.split("\n") : [];
+    setOnScreen(ids);
+    ids.forEach((id) => void ensureLoaded(id));
+    // Both are rebuilt every render; the key is what changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memberKey]);
+
+  // The dropped session is the one just opened, so it takes the focus. Only
+  // on a drop that opens something: selecting after a refused one would swap
+  // the grid for that session's single view.
+  const dropSession = ({ sessionId: anchor, region }: DropTarget, dropped: string) => {
+    if (!dropLabel(spaceGroups, anchor, dropped, region)) return;
+    setGroups((prev) => openBeside(prev, anchor, dropped, region, space));
+    void handleSelectSessionIndexItem(dropped);
+  };
+
+  const closeSessionPane = (sessionId: string) => {
+    setGroups((prev) => closePane(prev, sessionId));
+    if (sessionId !== selectedSessionId || !activeGroup) return;
+    const next = members(activeGroup).find((id) => id !== sessionId);
+    if (next) void handleSelectSessionIndexItem(next);
+  };
+
+  // The single view's own drop zone; a grid's panes draw theirs.
+  const drag = useSessionDrag();
+  const singleDrop =
+    drag?.over && !activeGroup && drag.over.sessionId === selectedSessionId
+      ? {
+          region: drag.over.region,
+          label: dropLabel(spaceGroups, drag.over.sessionId, drag.sessionId, drag.over.region),
+        }
+      : null;
 
   // The search narrows what is drawn, and only that — the sidebar's own row is
   // where it is typed, but the list it filters is this one, so the ⌘⇧↑/↓ walk
@@ -765,29 +860,39 @@ function App() {
         // — the walk has to step the runs the eye is looking at.
         showArchived ? undefined : { statusBySession, asking: askingSessions },
         showArchived,
+        showArchived ? [] : spaceGroups,
       ),
-    [searchedSessions, projects, showArchived, statusBySession, askingSessions],
+    [searchedSessions, projects, showArchived, statusBySession, askingSessions, spaceGroups],
   );
 
   // Wraps downward only. Falling off the bottom returns to the newest session,
   // which is where a walk through the whole list wants to end up; the top holds
   // instead, since arriving at the oldest session by pressing *up* past the
   // newest one reads as a mistake rather than as a wrap.
-  const stepSession = (delta: number) => {
-    if (ordered.length === 0) return;
-    const from = ordered.findIndex((i) => i.sessionId === selectedSessionId);
+  //
+  // Two chords walk it at two grains. ⌘⇧ steps every row; ⌘⌥ steps `units`,
+  // where a group's run is one step — so from inside a group it lands on the
+  // next group, or on the row past the last one, and enters a group on its
+  // first pane.
+  const stepThrough = (units: SessionIndexItem[][], delta: number) => {
+    if (units.length === 0) return;
+    const from = units.findIndex((u) => u.some((i) => i.sessionId === selectedSessionId));
     // No selection is the empty composer — either direction enters at the top.
     const next =
       from === -1
         ? 0
         : delta > 0
-          ? (from + 1) % ordered.length
+          ? (from + 1) % units.length
           : Math.max(from - 1, 0);
-    const item = ordered[next];
+    const item = units[next][0];
     if (item.sessionId !== selectedSessionId) {
       void handleSelectSessionIndexItem(item.sessionId);
     }
   };
+  const stepSession = (delta: number) =>
+    stepThrough(ordered.map((i) => [i]), delta);
+  const stepGroup = (delta: number) =>
+    stepThrough(stepUnits(ordered, spaceGroups, (i) => i.sessionId), delta);
 
   // A click on a markdown path in the transcript, which is the one route in.
   // Off the counter rather than off `docs.length`, since reopening a file that
@@ -1105,6 +1210,25 @@ function App() {
   // ⌘↑/↓ is the webview's own jump-to-start/end of the input.
   useHotkey("ArrowUp", () => goToSession(() => stepSession(-1)), { shift: true });
   useHotkey("ArrowDown", () => goToSession(() => stepSession(1)), { shift: true });
+  useHotkey("ArrowUp", () => goToSession(() => stepGroup(-1)), { alt: true });
+  useHotkey("ArrowDown", () => goToSession(() => stepGroup(1)), { alt: true });
+  // The bare ⌘ digits go to the panes, since focus is what moves most inside
+  // a grid; the view tabs take ⌘⌥ below. Not ⌘⇧, which macOS spends on
+  // screenshots for exactly these digits. Bound only while a grid is up: ⌘1
+  // with none has nothing to point at, and must not eat the key.
+  const paneIds = activeGroup ? members(activeGroup) : [];
+  const focusPane = (n: number) => {
+    const id = paneIds[n - 1];
+    if (id) void handleSelectSessionIndexItem(id);
+  };
+  useHotkey("1", () => focusPane(1), { enabled: !!activeGroup });
+  useHotkey("2", () => focusPane(2), { enabled: !!activeGroup });
+  useHotkey("3", () => focusPane(3), { enabled: !!activeGroup });
+  useHotkey("4", () => focusPane(4), { enabled: !!activeGroup });
+  useHotkey("w", () => selectedSessionId && closeSessionPane(selectedSessionId), {
+    alt: true,
+    enabled: !!activeGroup,
+  });
   // ⌘E for the right pane against ⌘B for the left.
   //
   // Bound to the raw toggle rather than to `handleTogglePanel`, deliberately:
@@ -1152,9 +1276,13 @@ function App() {
   // No-ops without a session, where there is no row to switch — and on the
   // issues page, where the row is not drawn: switching an invisible tab looks
   // like nothing happening and then shows up as the wrong view on the way back.
-  useHotkey("1", () => !issuesOpen && setViewTab("chat"));
-  useHotkey("2", () => !issuesOpen && setViewTab("changes"));
-  useHotkey("3", () => !issuesOpen && setViewTab("browser"));
+  //
+  // Under ⌘⌥, with the bare ⌘ digits given to the panes: inside a grid the
+  // focus moves many times a minute, where a view is a mode changed a few
+  // times a session. `code`, since Option turns a digit's `key` into a symbol.
+  useHotkey("1", () => !issuesOpen && setViewTab("chat"), { alt: true, code: "Digit1" });
+  useHotkey("2", () => !issuesOpen && setViewTab("changes"), { alt: true, code: "Digit2" });
+  useHotkey("3", () => !issuesOpen && setViewTab("browser"), { alt: true, code: "Digit3" });
   // ⌘, — every macOS app's preferences chord, and the only way into settings
   // while the sidebar is collapsed and its gear gone with it. Safe to take for
   // `useHotkey`'s usual pair of reasons: it claims the chord, and the app's
@@ -1268,6 +1396,8 @@ function App() {
           onSelect={(sessionId) =>
             goToSession(() => void handleSelectSessionIndexItem(sessionId))
           }
+          groups={spaceGroups}
+          onDropSession={dropSession}
           onNewSession={() => goToSession(handleNewSession)}
           onNewSessionInProject={(path) =>
             goToSession(() => {
@@ -1321,7 +1451,10 @@ function App() {
           <SessionHeader
             session={selectedSession}
             branch={prBranch}
-            standIn={issuesOpen ? "Issues" : null}
+            // The group's name over a grid: each pane's header already names
+            // its session, and the focused one's repeated up here read as a
+            // second line of the same row.
+            standIn={issuesOpen ? "Issues" : activeGroup ? groupName(activeGroup) : null}
             className="flex-1"
           />
 
@@ -1497,6 +1630,7 @@ function App() {
           busy={busy}
           sessionId={selectedSessionId}
           isNewTask={!selectedSession}
+          target={activeGroup ? selectedSession?.title ?? null : null}
           issuesConnected={issuesConnected}
           modelTakesImages={modelTakesImages}
           error={error}
@@ -1596,6 +1730,30 @@ function App() {
           make: the transcript keeps its scroll position and its highlighted
           diffs, and the repo view keeps its selection and its reads. */}
       <TabBody active={!issuesOpen && viewTab === "chat"}>
+      {activeGroup ? (
+        <SplitView
+          columns={paneColumns}
+          focusedId={selectedSessionId}
+          paneState={paneState}
+          groups={spaceGroups}
+          onFocus={(id) => void handleSelectSessionIndexItem(id)}
+          onClose={closeSessionPane}
+          active={!issuesOpen && viewTab === "chat"}
+          chat={{
+            onOpenSubagent: openSubagent,
+            onOpenSession: (id) => void handleSelectSessionIndexItem(id),
+            onOpenSubagentPanel: openSubagentPanel,
+            onRespondPermission: handleRespondPermission,
+            onAnswerQuestions: handleAnswerQuestions,
+          }}
+        />
+      ) : (
+      // The single view is one drop target: a row let go here opens beside
+      // the selected session, on whichever side it was let go.
+      <div
+        className="relative flex min-h-0 flex-1 flex-col"
+        {...{ [DROP_ATTR]: selectedSessionId ?? undefined }}
+      >
       <Chat
         session={selectedSession}
         streamingBlock={
@@ -1616,6 +1774,9 @@ function App() {
         crowded={!collapsed && (panelShown || (issuesOpen && !!pickedIssue))}
         active={!issuesOpen && viewTab === "chat"}
       />
+      {singleDrop && <DropZone region={singleDrop.region} label={singleDrop.label} />}
+      </div>
+      )}
       </TabBody>
 
       {selectedSession && (
@@ -1658,6 +1819,7 @@ function App() {
       }}
       onDeleteWorktree={(id) => removeWorktree(id)}
     />
+    <DragGhost />
     <QuitDialog />
     <LinkDialog />
     {/* Mounted here rather than in the sidebar, which unmounts whole when it

--- a/apps/desktop/src/components/Chat.tsx
+++ b/apps/desktop/src/components/Chat.tsx
@@ -74,6 +74,9 @@ type ChatProps = {
   /// two toggles, and the rail overlays the transcript at every width anyway — so
   /// this is about how crowded the pane *is*, not whether the rail fits.
   crowded?: boolean;
+  /// Whether the checkpoint rail may draw at all. Off for a split pane that
+  /// shares its column: at half height the rail sits over the text.
+  rail?: boolean;
   /// Whether the chat tab is the one on screen. The transcript is hidden rather
   /// than unmounted when another view tab is picked, so ⌘↓ has to be told to
   /// stop listening — otherwise it scrolls a pane nobody can see.
@@ -155,6 +158,7 @@ export default function Chat({
   apiRetry = null,
   queuedMessages = [],
   crowded = false,
+  rail = true,
   active = true,
 }: ChatProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -199,7 +203,7 @@ export default function Chat({
     [turns],
   );
 
-  const showRail = checkpoints.length >= RAIL_MIN;
+  const showRail = rail && checkpoints.length >= RAIL_MIN;
   const [activeTurn, setActiveTurn] = useState<string | null>(null);
 
   // Told apart by the type `block_start` declared, not by content — thinking

--- a/apps/desktop/src/components/Chat.tsx
+++ b/apps/desktop/src/components/Chat.tsx
@@ -591,6 +591,9 @@ export default function Chat({
                   key={ask.requestId}
                   questions={ask.questions}
                   onAnswer={(answers) => onAnswerQuestions(ask.requestId, answers)}
+                  // The pane the composer serves is the one whose card may
+                  // take the caret.
+                  autoFocus={active}
                 />
               ) : (
                 <PermissionRequest

--- a/apps/desktop/src/components/Chat.tsx
+++ b/apps/desktop/src/components/Chat.tsx
@@ -43,10 +43,14 @@ type ChatProps = {
   /// Answers a permission request. The agent is blocked until this fires, so it
   /// is the one callback here whose absence stalls a session rather than
   /// degrading a view.
-  onRespondPermission: (requestId: string, optionId: string) => void;
+  onRespondPermission: (sessionId: string, requestId: string, optionId: string) => void;
   /// Answers an `AskUserQuestion`. Blocks the agent the same way, and an empty
   /// map is a real answer — the reader skipped every question.
-  onAnswerQuestions: (requestId: string, answers: Record<string, string>) => void;
+  onAnswerQuestions: (
+    sessionId: string,
+    requestId: string,
+    answers: Record<string, string>,
+  ) => void;
   /// Whether this session has a turn in flight, so the transcript can show the
   /// agent is still working.
   busy?: boolean;
@@ -590,7 +594,9 @@ export default function Chat({
                 <QuestionRequest
                   key={ask.requestId}
                   questions={ask.questions}
-                  onAnswer={(answers) => onAnswerQuestions(ask.requestId, answers)}
+                  onAnswer={(answers) =>
+                    onAnswerQuestions(session.sessionId, ask.requestId, answers)
+                  }
                   // The pane the composer serves is the one whose card may
                   // take the caret.
                   autoFocus={active}
@@ -605,7 +611,9 @@ export default function Chat({
                   }
                   argument={toolArgument(ask.input)}
                   options={ask.options}
-                  onRespond={(optionId) => onRespondPermission(ask.requestId, optionId)}
+                  onRespond={(optionId) =>
+                    onRespondPermission(session.sessionId, ask.requestId, optionId)
+                  }
                 />
               ),
             )}

--- a/apps/desktop/src/components/ChatInput.tsx
+++ b/apps/desktop/src/components/ChatInput.tsx
@@ -113,6 +113,13 @@ type ChatInputProps = {
   /// padding, the toolbar moves above — reading order runs settings first, then
   /// the box they apply to — and the send button gives way to a keyboard hint.
   isNewTask?: boolean;
+  /// The title of the session this box sends into, named in the placeholder.
+  /// Only while a split view is up: one composer under four transcripts is
+  /// one box that can send into the wrong session, so the box says where
+  /// before anything is typed — and in the placeholder rather than a row of
+  /// its own, which grew the card. Single view leaves it unset; the header
+  /// above already names the session.
+  target?: string | null;
   /// A backend failure, shown above the composer. Lives here rather than in the
   /// shell so it inherits the form's `max-w-3xl` column and lines up with the
   /// input; the transcript is the wrong home for it, since most of these fail
@@ -192,6 +199,7 @@ export default function ChatInput({
   busy = false,
   sessionId = null,
   isNewTask = false,
+  target = null,
   error = null,
   onDismissError,
   archived = false,
@@ -836,7 +844,9 @@ export default function ChatInput({
                       ? issuesConnected
                         ? "Describe a task. #issues. @files. /skills and commands."
                         : "Describe a task. @files. /skills and commands."
-                      : "Send follow-up"
+                      : target
+                        ? target
+                        : "Send follow-up"
                   }
                   onChange={(e) => {
                     setMessage(e.currentTarget.value);

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -46,7 +46,9 @@ import {
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { burstConfetti } from "@/lib/confetti";
 import type { ManualCheck } from "@/hooks/useUpdater";
+import { startSessionDrag, type DropTarget } from "@/lib/dragSession";
 import { isToday, relativeTime } from "@/lib/format";
+import { groupName, members, type SplitGroup } from "@/lib/groups";
 import { sessionBranch } from "@/lib/pr";
 import { IS_MAC } from "@/lib/platform";
 import { cn } from "@/lib/utils";
@@ -96,6 +98,12 @@ type SidebarProps = {
   onToggleCollapsed: () => void;
   onOpenSettings: () => void;
   onSelect: (sessionId: string) => void;
+  /// The split groups of the active space, drawn as runs of their own ahead
+  /// of everything else. Each holds only sessions in `items`.
+  groups: SplitGroup[];
+  /// A row dropped on the transcript column: `anchor` is the session it landed
+  /// beside. Absent in the settled list, where nothing is dragged.
+  onDropSession?: (target: DropTarget, dropped: string) => void;
   onNewSession: () => void;
   /// Opens the issues page in the main column. It is not a session, so it does
   /// not move the selection — coming back from it lands on the session that was
@@ -243,6 +251,7 @@ export function sessionRows(items: SessionIndexItem[]): SessionListRow[] {
 /// either leaves the render guessing which sort of group it is holding.
 type SessionGroup =
   | { kind: "pinned"; rows: SessionListRow[] }
+  | { kind: "group"; id: number; rows: SessionListRow[] }
   | {
       kind: "project";
       projectPath: string;
@@ -374,11 +383,28 @@ export function sessionGroups(
   projects: Project[] = [],
   live?: LiveSessions,
   settled = false,
+  splits: SplitGroup[] = [],
 ): SessionGroup[] {
+  // A split group is drawn as its own run, in grid order, and its members
+  // nowhere else — not under their project, not under Pinned. Rows only, no
+  // rails: a member's children stay under the project, since dragging a parent
+  // into a grid did not open its children there. Pulled out first, so a pinned
+  // member draws in its group rather than twice.
+  const byId = new Map(items.map((i) => [i.sessionId, i]));
+  const inSplit = new Set(splits.flatMap((g) => members(g)));
+  const splitRuns: SessionGroup[] = splits.flatMap((g) => {
+    const rows = members(g)
+      .map((id) => byId.get(id))
+      .filter((i): i is SessionIndexItem => Boolean(i))
+      .map((item) => ({ item, depth: 0, guides: [], opens: false }));
+    return rows.length ? [{ kind: "group" as const, id: g.id, rows }] : [];
+  });
+  const ungrouped = items.filter((i) => !inSplit.has(i.sessionId));
+
   // A pin is what the reader keeps in reach while they work, so it says nothing
   // in a history — every row there is already done with. Settled draws its pins
   // under their own projects like any other row.
-  const [pinned, rest] = settled ? [[], items] : splitPinned(items);
+  const [pinned, rest] = settled ? [[], ungrouped] : splitPinned(ungrouped);
 
   // Every subtree the walk emits opens with its own root, so a depth-0 row is
   // where one nest ends and the next begins.
@@ -472,9 +498,11 @@ export function sessionGroups(
   );
 
   const pinnedRows = sessionRows(pinned);
-  return pinnedRows.length
-    ? [{ kind: "pinned", rows: pinnedRows }, ...groups]
-    : groups;
+  return [
+    ...splitRuns,
+    ...(pinnedRows.length ? [{ kind: "pinned" as const, rows: pinnedRows }] : []),
+    ...groups,
+  ];
 }
 
 /// The order alone, for callers that only step through it.
@@ -493,8 +521,9 @@ export function sortSessions(
   projects: Project[] = [],
   live?: LiveSessions,
   settled = false,
+  splits: SplitGroup[] = [],
 ): SessionIndexItem[] {
-  return sessionGroups(items, projects, live, settled).flatMap((group) =>
+  return sessionGroups(items, projects, live, settled, splits).flatMap((group) =>
     group.rows.map((row) => row.item),
   );
 }
@@ -783,6 +812,8 @@ export default function Sidebar({
   collapsed,
   onToggleCollapsed,
   onSelect,
+  groups: splits,
+  onDropSession,
   onNewSession,
   onOpenIssues,
   issuesOpen,
@@ -828,9 +859,10 @@ export default function Sidebar({
         : { statusBySession, asking: askingSessions },
     [showArchived, statusBySession, askingSessions],
   );
+  // No split runs in the settled list, for the reason it draws no Pinned group.
   const groups = useMemo(
-    () => sessionGroups(items, projects, live, showArchived),
-    [items, projects, live, showArchived],
+    () => sessionGroups(items, projects, live, showArchived, showArchived ? [] : splits),
+    [items, projects, live, showArchived, splits],
   );
   const rowCount = useMemo(
     () => groups.reduce((n, group) => n + group.rows.length, 0),
@@ -847,6 +879,7 @@ export default function Sidebar({
     const drawn = new Map<string, number>();
     return groups.map((group) => {
       if (group.kind === "pinned") return "pinned";
+      if (group.kind === "group") return `group ${group.id}`;
       const nth = drawn.get(group.projectPath) ?? 0;
       drawn.set(group.projectPath, nth + 1);
       return `${group.projectPath} ${nth}`;
@@ -1108,7 +1141,9 @@ export default function Sidebar({
             const heading =
               group.kind === "pinned"
                 ? "Pinned"
-                : opensProject && projectFilter === null
+                : group.kind === "group"
+                  ? groupName(group)
+                  : opensProject && projectFilter === null
                   ? projectName(group.projectPath)
                   : null;
 
@@ -1131,7 +1166,7 @@ export default function Sidebar({
                     aria-hidden
                     className={cn(
                       "shrink-0",
-                      group.kind === "pinned" || opensProject ? "h-4" : "h-3",
+                      group.kind !== "project" || opensProject ? "h-4" : "h-3",
                     )}
                   />
                 )}
@@ -1183,6 +1218,11 @@ export default function Sidebar({
                       group.kind === "pinned" && depth > 0 && !item.pinned
                     }
                     onSelect={onSelect}
+                    onDragStart={
+                      onDropSession && !showArchived
+                        ? (e) => startSessionDrag(e, item.sessionId, item.title, onDropSession)
+                        : undefined
+                    }
                     onSetFlags={onSetFlags}
                     onFork={onFork}
                     onDelete={onDelete}
@@ -1199,7 +1239,12 @@ export default function Sidebar({
             Pinning it to the sidebar's bottom edge would keep it on screen
             forever, which is a permanent line of chrome for a one-time hint.
             Hidden with only one row: there's nothing to jump or switch to. */}
-        {rowCount > 1 && <ShortcutHint selected={selectedSessionId !== null} />}
+        {rowCount > 1 && (
+          <ShortcutHint
+            selected={selectedSessionId !== null}
+            grouped={!showArchived && splits.length > 0}
+          />
+        )}
       </div>
 
       {/* Outside the scroll container, unlike the shortcut hint above it: that
@@ -1225,20 +1270,39 @@ export default function Sidebar({
 /// With nothing selected both arrows land on the same place — the newest session
 /// — so showing the pair would offer a choice that isn't one. One arrow, and the
 /// verb changes with it: entering the list is a jump, walking it is a switch.
-function ShortcutHint({ selected }: { selected: boolean }) {
+function ShortcutHint({ selected, grouped }: { selected: boolean; grouped: boolean }) {
   return (
-    <div className="flex min-h-7 items-center justify-between pr-0.5 pl-2 text-ui text-muted-foreground/60">
-      {selected ? "Switch tasks" : "Jump to task"}
-      {/* Held back from the stock keycap: everywhere else a `Kbd` labels a
-          control the eye is already on, but this one is the row, so the default
-          fill makes a hint the loudest thing in the list. */}
-      <KbdGroup className="[&_kbd]:bg-muted/40 [&_kbd]:text-muted-foreground/60">
+    <>
+      <HintRow label={selected ? "Switch tasks" : "Jump to task"}>
         <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
         {/* Spelled out on every platform, unlike the ⌘ beside it. ⇧ is the one
             modifier glyph that doesn't read as itself — an arrow, in a hint
             that ends in arrow keys — so no keycap in the app draws it. */}
         <Kbd>Shift</Kbd>
         <Kbd>{selected ? "↑↓" : "↓"}</Kbd>
+      </HintRow>
+      {/* Only while a group exists: the chord steps groups as one row each,
+          and with none it is ⌘⇧ under another name. */}
+      {grouped && (
+        <HintRow label="Switch groups">
+          <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+          <Kbd>{IS_MAC ? "⌥" : "Alt"}</Kbd>
+          <Kbd>↑↓</Kbd>
+        </HintRow>
+      )}
+    </>
+  );
+}
+
+function HintRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-7 items-center justify-between pr-0.5 pl-2 text-ui text-muted-foreground/60">
+      {label}
+      {/* Held back from the stock keycap: everywhere else a `Kbd` labels a
+          control the eye is already on, but this one is the row, so the default
+          fill makes a hint the loudest thing in the list. */}
+      <KbdGroup className="[&_kbd]:bg-muted/40 [&_kbd]:text-muted-foreground/60">
+        {children}
       </KbdGroup>
     </div>
   );
@@ -1703,6 +1767,7 @@ function SessionRow({
   faded = false,
   marksLive = true,
   onSelect,
+  onDragStart,
   nested = false,
   inheritsPin = false,
   onSetFlags,
@@ -1728,6 +1793,8 @@ function SessionRow({
   /// which asks for no repos — see the call site.
   marksLive?: boolean;
   onSelect: (sessionId: string) => void;
+  /// Wires the row for dragging onto the transcript column. See `startSessionDrag`.
+  onDragStart?: (e: React.PointerEvent<HTMLDivElement>) => void;
   /// This row has a parent in the same list, so 'Detach from parent' is a real
   /// offer. Kept apart from `depth` only because a cyclic index draws a row at
   /// the top level that still has a link worth cutting.
@@ -1773,6 +1840,7 @@ function SessionRow({
         role="button"
         tabIndex={0}
         onClick={() => void onSelect(item.sessionId)}
+        onPointerDown={onDragStart}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -104,6 +104,8 @@ type SidebarProps = {
   /// A row dropped on the transcript column: `anchor` is the session it landed
   /// beside. Absent in the settled list, where nothing is dragged.
   onDropSession?: (target: DropTarget, dropped: string) => void;
+  /// The reader has made a group at some point, so the drag needs no teaching.
+  splitLearned: boolean;
   onNewSession: () => void;
   /// Opens the issues page in the main column. It is not a session, so it does
   /// not move the selection — coming back from it lands on the session that was
@@ -814,6 +816,7 @@ export default function Sidebar({
   onSelect,
   groups: splits,
   onDropSession,
+  splitLearned,
   onNewSession,
   onOpenIssues,
   issuesOpen,
@@ -1243,6 +1246,7 @@ export default function Sidebar({
           <ShortcutHint
             selected={selectedSessionId !== null}
             grouped={!showArchived && splits.length > 0}
+            splittable={!!onDropSession && !showArchived && !splitLearned}
           />
         )}
       </div>
@@ -1270,7 +1274,18 @@ export default function Sidebar({
 /// With nothing selected both arrows land on the same place — the newest session
 /// — so showing the pair would offer a choice that isn't one. One arrow, and the
 /// verb changes with it: entering the list is a jump, walking it is a switch.
-function ShortcutHint({ selected, grouped }: { selected: boolean; grouped: boolean }) {
+function ShortcutHint({
+  selected,
+  grouped,
+  splittable,
+}: {
+  selected: boolean;
+  grouped: boolean;
+  /// Whether to teach the drag: the live list, and the reader has never made
+  /// a group. Off for good after the first one — a tip for something already
+  /// learned is chrome.
+  splittable: boolean;
+}) {
   return (
     <>
       <HintRow label={selected ? "Switch tasks" : "Jump to task"}>
@@ -1290,20 +1305,41 @@ function ShortcutHint({ selected, grouped }: { selected: boolean; grouped: boole
           <Kbd>↑↓</Kbd>
         </HintRow>
       )}
+      {/* Needs a session selected, since that is what a drop lands beside. */}
+      {splittable && selected && (
+        // At full strength, unlike the chords above it: those are reminders
+        // of something already learned, this is an invitation to try a thing.
+        <HintRow label="Drag a task onto the chat to open in split view" className="text-muted-foreground" />
+      )}
     </>
   );
 }
 
-function HintRow({ label, children }: { label: string; children: React.ReactNode }) {
+function HintRow({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children?: React.ReactNode;
+  className?: string;
+}) {
   return (
-    <div className="flex min-h-7 items-center justify-between pr-0.5 pl-2 text-ui text-muted-foreground/60">
+    <div
+      className={cn(
+        "flex min-h-7 items-center justify-between pr-0.5 pl-2 text-ui text-muted-foreground/60",
+        className,
+      )}
+    >
       {label}
       {/* Held back from the stock keycap: everywhere else a `Kbd` labels a
           control the eye is already on, but this one is the row, so the default
           fill makes a hint the loudest thing in the list. */}
-      <KbdGroup className="[&_kbd]:bg-muted/40 [&_kbd]:text-muted-foreground/60">
-        {children}
-      </KbdGroup>
+      {children && (
+        <KbdGroup className="[&_kbd]:bg-muted/40 [&_kbd]:text-muted-foreground/60">
+          {children}
+        </KbdGroup>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/SplitView.tsx
+++ b/apps/desktop/src/components/SplitView.tsx
@@ -118,7 +118,7 @@ export default function SplitView({
                     active={active && focused}
                   />
                 </div>
-                {hint && hint !== sideways && (
+                {hint && hint.region !== "left" && hint.region !== "right" && (
                   <DropZone region={hint.region} label={hint.label} />
                 )}
               </div>

--- a/apps/desktop/src/components/SplitView.tsx
+++ b/apps/desktop/src/components/SplitView.tsx
@@ -58,17 +58,33 @@ export default function SplitView({
     // A top border, since the main header draws none of its own and the pane
     // headers under it would otherwise read as a second line of the same row.
     <div className="flex h-full min-h-0 border-t border-hairline">
-      {columns.map((column, ci) => (
+      {columns.map((column, ci) => {
+        // A left or right drop makes a column, so its preview is drawn on the
+        // column at full height rather than inside the pane the pointer is on
+        // — in a stacked column that box would be half the height of what
+        // the drop makes.
+        const hintFor = (item: SessionIndexItem) =>
+          drag && drag.over?.sessionId === item.sessionId
+            ? {
+                region: drag.over.region,
+                label: dropLabel(groups, item.sessionId, drag.sessionId, drag.over.region),
+              }
+            : null;
+        const sideways = column
+          .map(hintFor)
+          .find((h) => h && (h.region === "left" || h.region === "right"));
+        return (
         <div
           key={column.map((i) => i.sessionId).join()}
-          className={cn("flex min-w-0 flex-1 flex-col", ci > 0 && "border-l border-hairline-strong")}
+          className={cn(
+            "relative flex min-w-0 flex-1 flex-col",
+            ci > 0 && "border-l border-hairline-strong",
+          )}
         >
+          {sideways && <DropZone region={sideways.region} label={sideways.label} />}
           {column.map((item, ri) => {
             const focused = item.sessionId === focusedId;
-            const hint =
-              drag && drag.over?.sessionId === item.sessionId
-                ? { region: drag.over.region, label: dropLabel(groups, item.sessionId, drag.sessionId, drag.over.region) }
-                : null;
+            const hint = hintFor(item);
             return (
               <div
                 key={item.sessionId}
@@ -102,12 +118,15 @@ export default function SplitView({
                     active={active && focused}
                   />
                 </div>
-                {hint && <DropZone region={hint.region} label={hint.label} />}
+                {hint && hint !== sideways && (
+                  <DropZone region={hint.region} label={hint.label} />
+                )}
               </div>
             );
           })}
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/apps/desktop/src/components/SplitView.tsx
+++ b/apps/desktop/src/components/SplitView.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+
+import Chat from "@/components/Chat";
+import GitBranchIcon from "@/components/icons/GitBranchIcon";
+import { Button } from "@/components/ui/button";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { PaneState } from "@/hooks/useSessions";
+import { DROP_ATTR, useSessionDrag } from "@/lib/dragSession";
+import { basename } from "@/lib/format";
+import { dropLabel, type Region, type SplitGroup } from "@/lib/groups";
+import { IS_MAC } from "@/lib/platform";
+import { sessionBranch } from "@/lib/pr";
+import { cn } from "@/lib/utils";
+import type { SessionIndexItem } from "@/types/events";
+
+type SplitViewProps = {
+  /// Left to right, each top to bottom.
+  columns: SessionIndexItem[][];
+  /// The pane the main header, right panel and composer serve.
+  focusedId: string | null;
+  paneState: (sessionId: string) => PaneState;
+  /// The active space's groups, for the drop zones' sentences.
+  groups: SplitGroup[];
+  onFocus: (sessionId: string) => void;
+  onClose: (sessionId: string) => void;
+  /// Whether the view is on screen, for the focused pane's own chords.
+  active: boolean;
+  chat: Pick<
+    React.ComponentProps<typeof Chat>,
+    | "onOpenSubagent"
+    | "onOpenSession"
+    | "onOpenSubagentPanel"
+    | "onRespondPermission"
+    | "onAnswerQuestions"
+  >;
+};
+
+/// Up to four transcripts in columns. One composer serves the focused pane —
+/// the selected session — so a click anywhere in a pane focuses it, and the
+/// pane header is what says which one that is.
+export default function SplitView({
+  columns,
+  focusedId,
+  paneState,
+  groups,
+  onFocus,
+  onClose,
+  active,
+  chat,
+}: SplitViewProps) {
+  const drag = useSessionDrag();
+  const metaHeld = useMetaHeld();
+  // Grid order, which is what ⌘1–4 count in.
+  const numbers = new Map(columns.flat().map((item, i) => [item.sessionId, i + 1]));
+  return (
+    // A top border, since the main header draws none of its own and the pane
+    // headers under it would otherwise read as a second line of the same row.
+    <div className="flex h-full min-h-0 border-t border-hairline">
+      {columns.map((column, ci) => (
+        <div
+          key={column.map((i) => i.sessionId).join()}
+          className={cn("flex min-w-0 flex-1 flex-col", ci > 0 && "border-l border-hairline-strong")}
+        >
+          {column.map((item, ri) => {
+            const focused = item.sessionId === focusedId;
+            const hint =
+              drag && drag.over?.sessionId === item.sessionId
+                ? { region: drag.over.region, label: dropLabel(groups, item.sessionId, drag.sessionId, drag.over.region) }
+                : null;
+            return (
+              <div
+                key={item.sessionId}
+                {...{ [DROP_ATTR]: item.sessionId }}
+                // Pointerdown bubbles here before the click it precedes, so a
+                // button inside the transcript acts on an already-focused pane.
+                // Close stops it: closing a pane must not first make it the one
+                // the composer serves.
+                onPointerDown={() => !focused && onFocus(item.sessionId)}
+                className={cn(
+                  "relative flex min-h-0 flex-1 flex-col",
+                  ri > 0 && "border-t border-hairline-strong",
+                )}
+              >
+                <PaneHeader
+                  item={item}
+                  focused={focused}
+                  number={numbers.get(item.sessionId) ?? 0}
+                  showNumber={metaHeld && !focused}
+                  onClose={() => onClose(item.sessionId)}
+                />
+                <div className="min-h-0 flex-1">
+                  <Chat
+                    {...paneState(item.sessionId)}
+                    {...chat}
+                    // Narrowest the transcript gets, so the rail always gives way.
+                    crowded
+                    // The rail only where the pane has the column's whole
+                    // height: halved, it sits over the text.
+                    rail={column.length === 1}
+                    active={active && focused}
+                  />
+                </div>
+                {hint && <DropZone region={hint.region} label={hint.label} />}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/// The dragged row's title, following the pointer.
+export function DragGhost() {
+  const drag = useSessionDrag();
+  if (!drag) return null;
+  return (
+    <div
+      className="pointer-events-none fixed z-50 max-w-64 truncate rounded-md border border-hairline-strong bg-popover px-2.5 py-1 text-ui text-popover-foreground shadow-md"
+      style={{ left: drag.x + 12, top: drag.y + 12 }}
+    >
+      {drag.title}
+    </div>
+  );
+}
+
+/// Where the region's pane would go, drawn over the pane the pointer is on.
+const REGION_BOX: Record<Region, string> = {
+  center: "inset-0",
+  top: "inset-x-0 top-0 h-1/2",
+  bottom: "inset-x-0 bottom-0 h-1/2",
+  left: "inset-y-0 left-0 w-1/2",
+  right: "inset-y-0 right-0 w-1/2",
+};
+
+/// Drawn over a pane while a row is held above it: the space the drop would
+/// take, and what letting go does. No label means no room, and nothing is
+/// drawn — a zone that lights up and then does nothing is worse than none.
+export function DropZone({ region, label }: { region: Region; label: string | null }) {
+  if (!label) return null;
+  return (
+    // Square and flush: the zone is the pane the drop would make, and a pane is
+    // a sharp box with no inset. Fill with some opacity and a solid edge — a
+    // blur or a dashed rim read as a dialog over the transcript.
+    <div
+      className={cn(
+        "pointer-events-none absolute z-10 flex items-center justify-center border border-ring bg-ring/15 text-ui font-medium text-foreground",
+        REGION_BOX[region],
+      )}
+    >
+      {label}
+    </div>
+  );
+}
+
+/// Title, project and branch — the row the main header draws, minus the tabs,
+/// with a close beside it. The focused pane's header takes a fill, which is
+/// what says where the composer sends.
+function PaneHeader({
+  item,
+  focused,
+  number,
+  showNumber,
+  onClose,
+}: {
+  item: SessionIndexItem;
+  focused: boolean;
+  /// This pane's place in ⌘1–4.
+  number: number;
+  /// The accelerator is held, so the close button gives its slot to the
+  /// keycap that reaches this pane — the one moment the number is useful.
+  showNumber: boolean;
+  onClose: () => void;
+}) {
+  const branch = sessionBranch(item);
+  return (
+    <div
+      className={cn(
+        "relative flex h-8 shrink-0 items-center gap-2 border-b border-hairline px-3 text-ui",
+        // Softened in the default light palette alone, where the full token
+        // reads as darker than the selected sidebar row it is borrowed from.
+        focused
+          ? "bg-sidebar-accent text-foreground [[data-theme=default][data-mode=light]_&]:bg-sidebar-accent/60"
+          : "text-muted-foreground",
+      )}
+    >
+      {/* The mark that says where the composer sends: one solid bar at the
+          start of the header, where the eye lands first. */}
+      {focused && <span aria-hidden className="absolute inset-y-0 left-0 w-0.5 bg-primary" />}
+      <span className="flex min-w-0 items-center gap-1.5">
+        <span className="shrink-0 text-muted-foreground">{basename(item.projectPath)}</span>
+        <span aria-hidden className="shrink-0 text-muted-foreground/50">
+          /
+        </span>
+        <span className={cn("truncate", focused && "font-medium")}>{item.title}</span>
+      </span>
+      {branch && (
+        <span className="flex min-w-0 shrink items-center gap-1 text-muted-foreground">
+          <GitBranchIcon className="size-3.5 shrink-0" />
+          <span className="truncate">{branch}</span>
+        </span>
+      )}
+      {showNumber ? (
+        // The digit alone: ⌘ is the key being held to see this.
+        <Kbd className="ml-auto shrink-0">{number}</Kbd>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              // Ghost's hover fill is the muted veil, which the focused
+              // header's own fill already is — so there it hovers in
+              // foreground instead, or the button never shows a hover at all.
+              className={cn(
+                "ml-auto shrink-0",
+                focused && "hover:bg-foreground/10 dark:hover:bg-foreground/15",
+              )}
+              aria-label="Close pane"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={onClose}
+            >
+              <X />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <KbdGroup>
+              <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+              <Kbd>{IS_MAC ? "⌥" : "Alt"}</Kbd>
+              <Kbd>W</Kbd>
+            </KbdGroup>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}
+
+/// Whether the platform accelerator is down right now. Cleared on blur as
+/// well as keyup: ⌘Tab out of the app loses the keyup, and the keycaps would
+/// otherwise stay up until the next press.
+function useMetaHeld(): boolean {
+  const [held, setHeld] = useState(false);
+  useEffect(() => {
+    const key = IS_MAC ? "Meta" : "Control";
+    const down = (e: KeyboardEvent) => e.key === key && setHeld(true);
+    const up = (e: KeyboardEvent) => e.key === key && setHeld(false);
+    const clear = () => setHeld(false);
+    document.addEventListener("keydown", down);
+    document.addEventListener("keyup", up);
+    window.addEventListener("blur", clear);
+    return () => {
+      document.removeEventListener("keydown", down);
+      document.removeEventListener("keyup", up);
+      window.removeEventListener("blur", clear);
+    };
+  }, []);
+  return held;
+}

--- a/apps/desktop/src/components/SplitView.tsx
+++ b/apps/desktop/src/components/SplitView.tsx
@@ -94,6 +94,10 @@ export default function SplitView({
                 // Close stops it: closing a pane must not first make it the one
                 // the composer serves.
                 onPointerDown={() => !focused && onFocus(item.sessionId)}
+                // Keyboard focus entering a pane is the same claim: Tab onto
+                // a link here, then Enter, must act through this session.
+                // React's onFocus bubbles, so any control inside answers.
+                onFocus={() => !focused && onFocus(item.sessionId)}
                 className={cn(
                   "relative flex min-h-0 flex-1 flex-col",
                   ri > 0 && "border-t border-hairline-strong",

--- a/apps/desktop/src/components/chat/QuestionRequest.tsx
+++ b/apps/desktop/src/components/chat/QuestionRequest.tsx
@@ -26,12 +26,16 @@ import type { Question } from "@/types/events";
 export default function QuestionRequest({
   questions,
   onAnswer,
+  autoFocus = true,
 }: {
   questions: Question[];
   /// Keyed by each question's verbatim text, because that is the key the
   /// harness matches on. A question the user skipped is absent rather than
   /// empty.
   onAnswer: (answers: Record<string, string>) => void;
+  /// Whether the card takes focus on mount. False for a split pane that is
+  /// not the focused one — see the effect below.
+  autoFocus?: boolean;
 }) {
   // One-shot, like the permission card: the reply can only be consumed once, so
   // a second submit during the round trip has nothing to answer.
@@ -69,7 +73,12 @@ export default function QuestionRequest({
   // `editor` dialogs carry no choices at all, so a choice-only query found
   // nothing and left focus in the composer. Typing then edited a prompt while
   // the agent sat blocked behind the card, and Enter sent it.
+  //
+  // Only for the transcript that has the focus: in a split view every pane
+  // draws its own cards, and one in a pane the composer is not serving would
+  // pull the caret out of the reader's typing.
   useEffect(() => {
+    if (!autoFocus) return;
     const form = formRef.current;
     const target =
       form?.querySelector<HTMLInputElement>(
@@ -77,6 +86,8 @@ export default function QuestionRequest({
       ) ?? form?.querySelector<HTMLTextAreaElement>("[data-slot=questionnaire-input]");
 
     target?.focus();
+    // Once per mount, deliberately — see above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/apps/desktop/src/components/chat/QuestionRequest.tsx
+++ b/apps/desktop/src/components/chat/QuestionRequest.tsx
@@ -77,8 +77,12 @@ export default function QuestionRequest({
   // Only for the transcript that has the focus: in a split view every pane
   // draws its own cards, and one in a pane the composer is not serving would
   // pull the caret out of the reader's typing.
+  // Once, on the first render where it may: a card mounted in an unfocused
+  // pane takes the caret when that pane is focused, and never again after.
+  const tookFocus = useRef(false);
   useEffect(() => {
-    if (!autoFocus) return;
+    if (!autoFocus || tookFocus.current) return;
+    tookFocus.current = true;
     const form = formRef.current;
     const target =
       form?.querySelector<HTMLInputElement>(
@@ -86,9 +90,7 @@ export default function QuestionRequest({
       ) ?? form?.querySelector<HTMLTextAreaElement>("[data-slot=questionnaire-input]");
 
     target?.focus();
-    // Once per mount, deliberately — see above.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [autoFocus]);
 
   return (
     // Narrower than the transcript it sits in. Options are a few words each, so

--- a/apps/desktop/src/components/layout/ViewTabs.tsx
+++ b/apps/desktop/src/components/layout/ViewTabs.tsx
@@ -46,6 +46,7 @@ export default function ViewTabs({
           <TooltipContent side="bottom" className="px-1.5">
             <KbdGroup>
               <Kbd>{IS_MAC ? "⌘" : "Ctrl"}</Kbd>
+              <Kbd>{IS_MAC ? "⌥" : "Alt"}</Kbd>
               <Kbd>{i + 1}</Kbd>
             </KbdGroup>
           </TooltipContent>

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -97,6 +97,65 @@ export type StreamingBlock = {
 /// composer remounting under a session switch while git is still working.
 const removingWorktrees = new Set<string>();
 
+/// One shared empty set, so a session with no tasks keeps its transcript memo.
+const NO_TASKS: ReadonlySet<string> = new Set();
+
+/// What a transcript pane draws for one session. The selected session's fields
+/// on the hook's return are this, spread.
+export type PaneState = {
+  session: SessionSnapshot | null;
+  streamingBlock: StreamingBlock | null;
+  busy: boolean;
+  working: Working | null;
+  backgroundTaskCount: number;
+  liveTaskIds: ReadonlySet<string>;
+  compacting: boolean;
+  apiRetry: ApiRetryState | null;
+  queuedMessages: QueuedPrompt[];
+};
+
+// Two events with nothing between them, so whichever came last says whether a
+// compaction is still running. Gated on `busy` for the same reason as the task
+// set: a `started` with no `completed` after it is the shape a killed session
+// leaves in the log forever.
+function compactingOf(session: SessionSnapshot | null, busy: boolean): boolean {
+  if (!busy || !session) return false;
+  for (let i = session.events.length - 1; i >= 0; i--) {
+    const p = session.events[i].payload;
+    if (p.type === "context_compacted") return false;
+    if (p.type === "context_compaction_started") return true;
+  }
+  return false;
+}
+
+// The retry in flight, if the last thing that happened was one. Derived by
+// walking back rather than tracked, for the reason `compactingOf` is: the event
+// is persisted, so the log already answers it.
+//
+// The rule is "an `api_retry` is the newest thing here", which self-clears
+// against every way a retry can end without naming them. The harness gives no
+// closing event — a retry that works is just the request going through — so
+// anything else arriving is the proof it went through. `usage_update` is
+// skipped as the one payload that fires without meaning progress.
+//
+// Gated on `busy` like the one above: an `api_retry` at the tail of a log is
+// exactly what a session killed mid-retry leaves behind forever.
+function apiRetryOf(session: SessionSnapshot | null, busy: boolean): ApiRetryState | null {
+  if (!busy || !session) return null;
+  for (let i = session.events.length - 1; i >= 0; i--) {
+    const p = session.events[i].payload;
+    if (p.type === "usage_update") continue;
+    if (p.type !== "api_retry") return null;
+    return {
+      attempt: p.attempt,
+      maxRetries: p.maxRetries,
+      status: p.status,
+      reason: p.reason,
+    };
+  }
+  return null;
+}
+
 export function useSessions() {
 
     // The sticky defaults. Live state below seeds from these and writes back on
@@ -1652,6 +1711,33 @@ sessionsRef.current = sessions;
 const asksBySessionRef = useRef(asksBySession);
 asksBySessionRef.current = asksBySession;
 
+/// Every session a split view has on screen beside the selected one. Read by
+/// the listeners below, which are registered once — so a ref, written by `App`
+/// whenever the active group changes.
+const onScreenRef = useRef<Set<string>>(new Set());
+const setOnScreen = (ids: string[]) => {
+  onScreenRef.current = new Set(ids);
+};
+const onScreen = (sessionId: string) =>
+  sessionId === selectedSessionIdRef.current || onScreenRef.current.has(sessionId);
+
+/// Loads a transcript without selecting it, for a split pane. Guarded so the
+/// panes re-rendering mid-read don't issue a second one.
+const loadingRef = useRef(new Set<string>());
+const ensureLoaded = async (sessionId: string) => {
+  if (sessionsRef.current.some((s) => s.sessionId === sessionId)) return;
+  if (loadingRef.current.has(sessionId)) return;
+  loadingRef.current.add(sessionId);
+  try {
+    const snapshot = await invoke<SessionSnapshot | null>("get_session_by_id", { sessionId });
+    if (snapshot) upsertSession(withEarlyEvents(snapshot));
+  } catch (e) {
+    console.error("failed to load a split pane", e);
+  } finally {
+    loadingRef.current.delete(sessionId);
+  }
+};
+
 // When each loaded transcript was last on screen. Stamped on arrival and on
 // leaving, so the idle clock starts the moment the reader looks away.
 const lastViewedRef = useRef(new Map<string, number>());
@@ -1687,8 +1773,7 @@ const evictSessions = (force?: { sessionId: string; status?: SessionStatus }) =>
     const kept = prev.filter((s) => {
       const forced = s.sessionId === force?.sessionId;
       const selected =
-        s.sessionId === selectedSessionIdRef.current ||
-        s.sessionId === selectionRequestRef.current;
+        onScreen(s.sessionId) || s.sessionId === selectionRequestRef.current;
       const status =
         forced && force.status ? force.status : statusBySessionRef.current[s.sessionId];
       const asking = (asksBySessionRef.current[s.sessionId]?.length ?? 0) > 0;
@@ -1779,7 +1864,7 @@ const announce = (sessionId: string, kind: NoticeKind, label: string): boolean =
     notifyOS(sessionId, kind, label, item?.title ?? "");
     return false;
   }
-  if (sessionId === selectedSessionIdRef.current) return true;
+  if (onScreen(sessionId)) return true;
 
   // The sound is the signal; the card is a thing to click. Fired side by side
   // rather than one from the other, so dropping either leaves the other
@@ -1796,10 +1881,12 @@ const announce = (sessionId: string, kind: NoticeKind, label: string): boolean =
 useEffect(
   () =>
     onFocusChange((focused) => {
-      const sessionId = selectedSessionIdRef.current;
-      if (!focused || !sessionId) return;
-      if (statusBySessionRef.current[sessionId] === "completed") {
-        markSessionRead(sessionId);
+      if (!focused) return;
+      const shown = [selectedSessionIdRef.current, ...onScreenRef.current];
+      for (const sessionId of shown) {
+        if (sessionId && statusBySessionRef.current[sessionId] === "completed") {
+          markSessionRead(sessionId);
+        }
       }
     }),
   [],
@@ -1969,53 +2056,44 @@ const backgroundTasks: BackgroundTask[] = useMemo(
   [tasksBySession, selectedSessionId],
 );
 // The join the transcript uses to keep a task's spawning call pending after
-// the turn ends. Memoised so the transcript memo holds while nothing changed.
-const liveTaskIds = useMemo(
-  () => new Set(backgroundTasks.map((t) => t.taskId)),
-  [backgroundTasks],
+// the turn ends. One set per session, memoised together so every pane's
+// transcript memo holds while nothing changed.
+const liveTaskIdsBySession = useMemo(
+  () =>
+    Object.fromEntries(
+      Object.entries(tasksBySession).map(([id, tasks]) => [
+        id,
+        new Set(tasks.map((t) => t.taskId)),
+      ]),
+    ) as Record<string, Set<string>>,
+  [tasksBySession],
 );
+const liveTaskIds = liveTaskIdsBySession[selectedSessionId ?? ""] ?? NO_TASKS;
 
-// Two events with nothing between them, so whichever came last says whether a
-// compaction is still running. Gated on `busy` for the same reason as the task
-// set above: a `started` with no `completed` after it is the shape a killed
-// session leaves in the log forever.
-const compacting: boolean = (() => {
-  if (!busy || !selectedSession) return false;
-  for (let i = selectedSession.events.length - 1; i >= 0; i--) {
-    const p = selectedSession.events[i].payload;
-    if (p.type === "context_compacted") return false;
-    if (p.type === "context_compaction_started") return true;
-  }
-  return false;
-})();
+const compacting = compactingOf(selectedSession, busy);
+const apiRetry = apiRetryOf(selectedSession, busy);
 
-// The retry in flight, if the last thing that happened was one. Derived by
-// walking back rather than tracked, for the reason `compacting` is: the event
-// is persisted, so the log already answers it.
-//
-// The rule is "an `api_retry` is the newest thing here", which self-clears
-// against every way a retry can end without naming them. The harness gives no
-// closing event — a retry that works is just the request going through — so
-// anything else arriving is the proof it went through. `usage_update` is
-// skipped as the one payload that fires without meaning progress.
-//
-// Gated on `busy` like the two above: an `api_retry` at the tail of a log is
-// exactly what a session killed mid-retry leaves behind forever.
-const apiRetry: ApiRetryState | null = (() => {
-  if (!busy || !selectedSession) return null;
-  for (let i = selectedSession.events.length - 1; i >= 0; i--) {
-    const p = selectedSession.events[i].payload;
-    if (p.type === "usage_update") continue;
-    if (p.type !== "api_retry") return null;
-    return {
-      attempt: p.attempt,
-      maxRetries: p.maxRetries,
-      status: p.status,
-      reason: p.reason,
-    };
-  }
-  return null;
-})();
+/// The live state one split pane draws — what the selected session's own
+/// fields above answer, for any loaded session.
+const paneState = (sessionId: string): PaneState => {
+  const session = sessions.find((s) => s.sessionId === sessionId) ?? null;
+  const status =
+    statusBySession[sessionId]
+    ?? sessionIndexItems.find((i) => i.sessionId === sessionId)?.status
+    ?? "idle";
+  const paneBusy = status === "in_progress";
+  return {
+    session,
+    streamingBlock: streamingContentBlock[sessionId] ?? null,
+    busy: paneBusy,
+    working: paneBusy ? workingBySession[sessionId] ?? null : null,
+    backgroundTaskCount: tasksBySession[sessionId]?.length ?? 0,
+    liveTaskIds: liveTaskIdsBySession[sessionId] ?? NO_TASKS,
+    compacting: compactingOf(session, paneBusy),
+    apiRetry: apiRetryOf(session, paneBusy),
+    queuedMessages: queuedBySession[sessionId] ?? [],
+  };
+};
 
 // How full the model's context is. Derived from the log rather than tracked,
 // because both things that move it are already persisted there — a turn's own
@@ -2058,6 +2136,6 @@ const contextUsage: { used: number; max: number } | null = (() => {
   return used !== null && max !== null ? { used, max } : null;
 })();
 
-return {harness, setHarness, sessions, selectedSessionId, selectedSession, streamingContentBlock, sessionIndexItems, statusBySession, askingSessions, showArchived, setShowArchived, models, refreshModels, loadingModels, modelId, effort, permissionMode, projects, projectPath, branches, branch, useWorktree, busy, working, backgroundTasks, liveTaskIds, tasksBySession, compacting, apiRetry, contextUsage, error, setError, handleModelChange, setPermissionMode, handleAttachProject, handleSelectProject, handleRemoveProject, setProjectSpace, retagSpace, canAnnounce, handleSelectBranch, pendingBranch, setPendingBranch, runCheckout, setUseWorktree, handleSendMsg, handleInterrupt, handleStopTask, queuedMessages, handleCancelQueued, handleRespondPermission, handleAnswerQuestions, handleSelectSessionIndexItem, handleNewSession, setSessionFlags, forkSession, unlinkIssue, detachSession, deleteSession, removeWorktree};
+return {harness, setHarness, sessions, selectedSessionId, selectedSession, streamingContentBlock, sessionIndexItems, statusBySession, askingSessions, showArchived, setShowArchived, models, refreshModels, loadingModels, modelId, effort, permissionMode, projects, projectPath, branches, branch, useWorktree, busy, working, backgroundTasks, liveTaskIds, tasksBySession, compacting, apiRetry, contextUsage, error, setError, handleModelChange, setPermissionMode, handleAttachProject, handleSelectProject, handleRemoveProject, setProjectSpace, retagSpace, canAnnounce, handleSelectBranch, pendingBranch, setPendingBranch, runCheckout, setUseWorktree, handleSendMsg, handleInterrupt, handleStopTask, queuedMessages, handleCancelQueued, handleRespondPermission, handleAnswerQuestions, handleSelectSessionIndexItem, handleNewSession, setSessionFlags, forkSession, unlinkIssue, detachSession, deleteSession, removeWorktree, ensureLoaded, setOnScreen, paneState};
 
 }

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -170,6 +170,9 @@ export function useSessions() {
     // Which side of the archived split the sidebar is showing. Not persisted:
     // archived is the exception view, so every launch starts on the active list.
     const [showArchived, setShowArchived] = useState(false);
+    /// Which archived side `sessionIndexItems` was read for; `null` until the
+    /// first read lands. See the fetch effect for why `showArchived` cannot serve.
+    const [indexSide, setIndexSide] = useState<boolean | null>(null);
     // One entry per harness, never one list plus a note saying whose it is.
     //
     // A single list held the *previous* harness's answer until the next landed,
@@ -1311,9 +1314,18 @@ const deleteSession = async (sessionId: string) => {
 // Refetched on every toggle rather than filtered from one cached list: the two
 // views are disjoint, so holding both would mean tracking which of them a flag
 // write belongs to.
+//
+// `indexSide` says which side the loaded list belongs to, written in the same
+// batch as the list. `showArchived` alone lies for the read's duration: the
+// toggle flips it at once while the list still holds the other side, and a
+// reader pruning "sessions no longer listed" against that would prune them
+// all.
 useEffect(() => {
   invoke<SessionIndexItem[]>("list_session_index_items", { archived: showArchived })
-    .then(setSessionIndexItems)
+    .then((items) => {
+      setSessionIndexItems(items);
+      setIndexSide(showArchived);
+    })
     .catch((e) => setError(String(e)));
 }, [showArchived])
 
@@ -2136,6 +2148,6 @@ const contextUsage: { used: number; max: number } | null = (() => {
   return used !== null && max !== null ? { used, max } : null;
 })();
 
-return {harness, setHarness, sessions, selectedSessionId, selectedSession, streamingContentBlock, sessionIndexItems, statusBySession, askingSessions, showArchived, setShowArchived, models, refreshModels, loadingModels, modelId, effort, permissionMode, projects, projectPath, branches, branch, useWorktree, busy, working, backgroundTasks, liveTaskIds, tasksBySession, compacting, apiRetry, contextUsage, error, setError, handleModelChange, setPermissionMode, handleAttachProject, handleSelectProject, handleRemoveProject, setProjectSpace, retagSpace, canAnnounce, handleSelectBranch, pendingBranch, setPendingBranch, runCheckout, setUseWorktree, handleSendMsg, handleInterrupt, handleStopTask, queuedMessages, handleCancelQueued, handleRespondPermission, handleAnswerQuestions, handleSelectSessionIndexItem, handleNewSession, setSessionFlags, forkSession, unlinkIssue, detachSession, deleteSession, removeWorktree, ensureLoaded, setOnScreen, paneState};
+return {harness, setHarness, sessions, selectedSessionId, selectedSession, streamingContentBlock, sessionIndexItems, statusBySession, askingSessions, showArchived, setShowArchived, models, refreshModels, loadingModels, modelId, effort, permissionMode, projects, projectPath, branches, branch, useWorktree, busy, working, backgroundTasks, liveTaskIds, tasksBySession, compacting, apiRetry, contextUsage, error, setError, handleModelChange, setPermissionMode, handleAttachProject, handleSelectProject, handleRemoveProject, setProjectSpace, retagSpace, canAnnounce, handleSelectBranch, pendingBranch, setPendingBranch, runCheckout, setUseWorktree, handleSendMsg, handleInterrupt, handleStopTask, queuedMessages, handleCancelQueued, handleRespondPermission, handleAnswerQuestions, handleSelectSessionIndexItem, handleNewSession, setSessionFlags, forkSession, unlinkIssue, detachSession, deleteSession, removeWorktree, ensureLoaded, setOnScreen, paneState, indexSide};
 
 }

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -1725,8 +1725,24 @@ asksBySessionRef.current = asksBySession;
 /// the listeners below, which are registered once — so a ref, written by `App`
 /// whenever the active group changes.
 const onScreenRef = useRef<Set<string>>(new Set());
+/// Panes arriving get what selecting a session gets — a finished one is read
+/// the moment it is looked at, window focus permitting — and every pane
+/// entering or leaving is stamped, so a peer's idle clock starts when it
+/// leaves the screen rather than reading as never viewed.
 const setOnScreen = (ids: string[]) => {
-  onScreenRef.current = new Set(ids);
+  const next = new Set(ids);
+  const prev = onScreenRef.current;
+  const now = Date.now();
+  for (const id of prev) if (!next.has(id)) lastViewedRef.current.set(id, now);
+  for (const id of next) {
+    if (prev.has(id)) continue;
+    lastViewedRef.current.set(id, now);
+    const status =
+      statusBySessionRef.current[id]
+      ?? sessionIndexItemsRef.current.find((i) => i.sessionId === id)?.status;
+    if (isWindowFocused() && status === "completed") markSessionRead(id);
+  }
+  onScreenRef.current = next;
 };
 const onScreen = (sessionId: string) =>
   sessionId === selectedSessionIdRef.current || onScreenRef.current.has(sessionId);

--- a/apps/desktop/src/hooks/useSessions.ts
+++ b/apps/desktop/src/hooks/useSessions.ts
@@ -817,30 +817,28 @@ const handleStopTask = async (taskId: string) => {
 //
 // `optionId` is opaque on purpose: the standing rule behind it lives in the
 // backend, so the frontend can neither widen a grant nor invent one.
-const handleRespondPermission = async (requestId: string, optionId: string) => {
-  if (!selectedSessionId) return;
+// Both take the session that drew the card, never the selection: in a split
+// view a card in one pane can be answered while another pane is selected,
+// and a reply filed under the wrong session leaves the asking one blocked.
+const handleRespondPermission = async (
+  sessionId: string,
+  requestId: string,
+  optionId: string,
+) => {
   try {
-    await invoke("respond_permission", {
-      sessionId: selectedSessionId,
-      requestId,
-      optionId,
-    });
+    await invoke("respond_permission", { sessionId, requestId, optionId });
   } catch (e) {
     setError(String(e));
   }
 };
 
 const handleAnswerQuestions = async (
+  sessionId: string,
   requestId: string,
   answers: Record<string, string>,
 ) => {
-  if (!selectedSessionId) return;
   try {
-    await invoke("answer_questions", {
-      sessionId: selectedSessionId,
-      requestId,
-      answers,
-    });
+    await invoke("answer_questions", { sessionId, requestId, answers });
   } catch (e) {
     setError(String(e));
   }

--- a/apps/desktop/src/lib/dragSession.test.ts
+++ b/apps/desktop/src/lib/dragSession.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { regionAt } from "@/lib/dragSession";
+
+describe("regionAt", () => {
+  it("maps the middle to centre and each edge band to its side", () => {
+    expect(regionAt(50, 50, 100, 100)).toBe("center");
+    expect(regionAt(10, 50, 100, 100)).toBe("left");
+    expect(regionAt(90, 50, 100, 100)).toBe("right");
+    expect(regionAt(50, 10, 100, 100)).toBe("top");
+    expect(regionAt(50, 90, 100, 100)).toBe("bottom");
+  });
+
+  it("gives a corner to the nearer edge", () => {
+    expect(regionAt(5, 20, 100, 100)).toBe("left");
+    expect(regionAt(20, 95, 100, 100)).toBe("bottom");
+  });
+});

--- a/apps/desktop/src/lib/dragSession.ts
+++ b/apps/desktop/src/lib/dragSession.ts
@@ -1,0 +1,110 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { useSyncExternalStore } from "react";
+
+import { channel } from "@/lib/channel";
+import type { Region } from "@/lib/groups";
+
+/// Marks a pane a sidebar row can be dropped on; the value is the session
+/// the drop lands on.
+export const DROP_ATTR = "data-drop-session";
+
+export type DropTarget = { sessionId: string; region: Region };
+
+export type SessionDrag = {
+  sessionId: string;
+  title: string;
+  x: number;
+  y: number;
+  /// The pane under the pointer and where on it, read off `DROP_ATTR`.
+  over: DropTarget | null;
+};
+
+/// Pointer-based, not HTML5 drag: Tauri's file-drop handler takes native drag
+/// events before the webview sees them, and attachments depend on that
+/// handler, so `dragover`/`drop` never fire for an internal drag.
+let drag: SessionDrag | null = null;
+const changed = channel<void>();
+
+export function useSessionDrag(): SessionDrag | null {
+  return useSyncExternalStore(changed.subscribe, () => drag);
+}
+
+/// How far the pointer moves before a press becomes a drag, so a click stays
+/// a click.
+const THRESHOLD_PX = 6;
+
+/// How much of a pane's width or height, from each edge, is that edge's zone.
+const EDGE = 0.25;
+
+/// Which of the five zones a point in a box falls in. The nearer edge wins a
+/// corner; the middle is the centre.
+export function regionAt(x: number, y: number, width: number, height: number): Region {
+  const fx = x / width;
+  const fy = y / height;
+  const dx = Math.min(fx, 1 - fx);
+  const dy = Math.min(fy, 1 - fy);
+  if (dx >= EDGE && dy >= EDGE) return "center";
+  if (dx < dy) return fx < 0.5 ? "left" : "right";
+  return fy < 0.5 ? "top" : "bottom";
+}
+
+function targetAt(x: number, y: number): DropTarget | null {
+  const el = document.elementFromPoint(x, y)?.closest(`[${DROP_ATTR}]`);
+  const sessionId = el?.getAttribute(DROP_ATTR);
+  if (!el || !sessionId) return null;
+  const rect = el.getBoundingClientRect();
+  return { sessionId, region: regionAt(x - rect.left, y - rect.top, rect.width, rect.height) };
+}
+
+/// Wires a row's `onPointerDown`. `onDrop` fires on release over a pane other
+/// than the row's own session.
+export function startSessionDrag(
+  e: ReactPointerEvent<HTMLElement>,
+  sessionId: string,
+  title: string,
+  onDrop: (target: DropTarget, dropped: string) => void,
+) {
+  if (e.button !== 0) return;
+  // A press that becomes a drag would otherwise start a text selection at the
+  // row and extend it across whatever the pointer crosses. Cancelling
+  // pointerdown suppresses the mouse events that selection rides on; click
+  // still fires.
+  e.preventDefault();
+  const el = e.currentTarget;
+  const { pointerId, clientX: startX, clientY: startY } = e;
+  let live = false;
+
+  const move = (ev: PointerEvent) => {
+    if (!live) {
+      if (Math.hypot(ev.clientX - startX, ev.clientY - startY) < THRESHOLD_PX) return;
+      live = true;
+      el.setPointerCapture(pointerId);
+    }
+    drag = { sessionId, title, x: ev.clientX, y: ev.clientY, over: targetAt(ev.clientX, ev.clientY) };
+    changed.emit();
+  };
+
+  const end = (ev: PointerEvent) => {
+    el.removeEventListener("pointermove", move);
+    el.removeEventListener("pointerup", end);
+    el.removeEventListener("pointercancel", end);
+    if (!live) return;
+
+    el.releasePointerCapture(pointerId);
+    // The click that follows a captured pointerup would select the row that
+    // was dragged. Swallowed at capture, and the listener retired on the next
+    // task so a later real click is not eaten.
+    const swallow = (c: Event) => c.stopPropagation();
+    el.addEventListener("click", swallow, { capture: true });
+    setTimeout(() => el.removeEventListener("click", swallow, { capture: true }), 0);
+
+    const over = ev.type === "pointerup" ? targetAt(ev.clientX, ev.clientY) : null;
+    drag = null;
+    changed.emit();
+    if (over && over.sessionId !== sessionId) onDrop(over, sessionId);
+  };
+
+  el.addEventListener("pointermove", move);
+  el.addEventListener("pointerup", end);
+  el.addEventListener("pointercancel", end);
+}

--- a/apps/desktop/src/lib/dragSession.ts
+++ b/apps/desktop/src/lib/dragSession.ts
@@ -79,6 +79,9 @@ export function startSessionDrag(
       if (Math.hypot(ev.clientX - startX, ev.clientY - startY) < THRESHOLD_PX) return;
       live = true;
       el.setPointerCapture(pointerId);
+      // Every element under the pointer carries its own cursor, so the drag's
+      // is forced from a body class rather than set on one element.
+      document.body.classList.add("session-drag");
     }
     drag = { sessionId, title, x: ev.clientX, y: ev.clientY, over: targetAt(ev.clientX, ev.clientY) };
     changed.emit();
@@ -91,6 +94,7 @@ export function startSessionDrag(
     if (!live) return;
 
     el.releasePointerCapture(pointerId);
+    document.body.classList.remove("session-drag");
     // The click that follows a captured pointerup would select the row that
     // was dragged. Swallowed at capture, and the listener retired on the next
     // task so a later real click is not eaten.

--- a/apps/desktop/src/lib/groups.test.ts
+++ b/apps/desktop/src/lib/groups.test.ts
@@ -42,7 +42,7 @@ describe("dropLabel", () => {
   it("names each outcome and says nothing where there is no room", () => {
     const groups = [group(1, ["a", "b"], ["c"])];
     expect(dropLabel(groups, "x", "y", "right")).toBe("Open on the right");
-    expect(dropLabel(groups, "x", "y", "center")).toBe("Open here");
+    expect(dropLabel(groups, "x", "y", "center")).toBeNull();
     expect(dropLabel(groups, "c", "y", "center")).toBe("Replace");
     expect(dropLabel(groups, "c", "y", "top")).toBe("Open above");
     expect(dropLabel(groups, "a", "y", "bottom")).toBeNull();
@@ -52,15 +52,12 @@ describe("dropLabel", () => {
 });
 
 describe("openBeside", () => {
-  it("makes a group of two from a single view, and a replaced single view makes none", () => {
+  it("makes a group of two from a single view, and a centre drop there is no drop", () => {
     expect(openBeside([], "a", "b", "right", "work")).toEqual([
       { id: 1, columns: [["a"], ["b"]], space: "work" },
     ]);
-    expect(openBeside([], "a", "b", "center", "work")).toEqual([]);
-  });
-
-  it("replacing a single view leaves the dropped session's own group standing", () => {
-    // Opening a session is not taking it out of its grid.
+    // Replacing a single view is a click; refused whole, so the dropped
+    // session's own group stands.
     const groups = [group(1, ["b"], ["c"])];
     expect(openBeside(groups, "a", "b", "center", null)).toBe(groups);
   });

--- a/apps/desktop/src/lib/groups.test.ts
+++ b/apps/desktop/src/lib/groups.test.ts
@@ -59,6 +59,12 @@ describe("openBeside", () => {
     expect(openBeside([], "a", "b", "center", "work")).toEqual([]);
   });
 
+  it("replacing a single view leaves the dropped session's own group standing", () => {
+    // Opening a session is not taking it out of its grid.
+    const groups = [group(1, ["b"], ["c"])];
+    expect(openBeside(groups, "a", "b", "center", null)).toBe(groups);
+  });
+
   it("builds on the anchor's group", () => {
     expect(openBeside([group(1, ["a"], ["b"])], "b", "c", "bottom", null)[0].columns).toEqual([
       ["a"],

--- a/apps/desktop/src/lib/groups.test.ts
+++ b/apps/desktop/src/lib/groups.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  closePane,
+  dropLabel,
+  members,
+  openBeside,
+  place,
+  pruneGroups,
+  stepUnits,
+  type SplitGroup,
+} from "@/lib/groups";
+
+const group = (id: number, ...columns: string[][]): SplitGroup => ({
+  id,
+  columns,
+  space: null,
+});
+
+describe("place", () => {
+  it("opens beside, above and below, and replaces at the centre", () => {
+    expect(place([["a"]], "a", "b", "right")).toEqual([["a"], ["b"]]);
+    expect(place([["a"]], "a", "b", "left")).toEqual([["b"], ["a"]]);
+    expect(place([["a"]], "a", "b", "bottom")).toEqual([["a", "b"]]);
+    expect(place([["a"], ["b"]], "b", "c", "top")).toEqual([["a"], ["c", "b"]]);
+    expect(place([["a"], ["b"]], "b", "c", "center")).toEqual([["a"], ["c"]]);
+  });
+
+  it("refuses a third column, a third row, and a drop onto itself", () => {
+    expect(place([["a"], ["b"]], "a", "c", "left")).toBeNull();
+    expect(place([["a", "b"]], "a", "c", "bottom")).toBeNull();
+    expect(place([["a"]], "a", "a", "right")).toBeNull();
+  });
+
+  it("moves a session already in the grid rather than duplicating it", () => {
+    expect(place([["a"], ["b"]], "a", "b", "bottom")).toEqual([["a", "b"]]);
+    expect(place([["a", "b"], ["c"]], "c", "a", "center")).toEqual([["b"], ["a"]]);
+  });
+});
+
+describe("dropLabel", () => {
+  it("names each outcome and says nothing where there is no room", () => {
+    const groups = [group(1, ["a", "b"], ["c"])];
+    expect(dropLabel(groups, "x", "y", "right")).toBe("Open on the right");
+    expect(dropLabel(groups, "x", "y", "center")).toBe("Open here");
+    expect(dropLabel(groups, "c", "y", "center")).toBe("Replace");
+    expect(dropLabel(groups, "c", "y", "top")).toBe("Open above");
+    expect(dropLabel(groups, "a", "y", "bottom")).toBeNull();
+    expect(dropLabel(groups, "a", "y", "left")).toBeNull();
+    expect(dropLabel(groups, "x", "x", "right")).toBeNull();
+  });
+});
+
+describe("openBeside", () => {
+  it("makes a group of two from a single view, and a replaced single view makes none", () => {
+    expect(openBeside([], "a", "b", "right", "work")).toEqual([
+      { id: 1, columns: [["a"], ["b"]], space: "work" },
+    ]);
+    expect(openBeside([], "a", "b", "center", "work")).toEqual([]);
+  });
+
+  it("builds on the anchor's group", () => {
+    expect(openBeside([group(1, ["a"], ["b"])], "b", "c", "bottom", null)[0].columns).toEqual([
+      ["a"],
+      ["b", "c"],
+    ]);
+  });
+
+  it("moves a session out of its old group, dissolving one left with a single member", () => {
+    const groups = [group(1, ["a"], ["b"]), group(2, ["c"], ["d"])];
+    expect(openBeside(groups, "c", "a", "top", null)).toEqual([
+      { id: 2, columns: [["a", "c"], ["d"]], space: null },
+    ]);
+  });
+
+  it("leaves a group from another space alone and moves the anchor out of it", () => {
+    const elsewhere = { id: 1, columns: [["a", "b"], ["c"]], space: "work" };
+    expect(openBeside([elsewhere], "a", "d", "right", null)).toEqual([
+      { id: 1, columns: [["b"], ["c"]], space: "work" },
+      { id: 2, columns: [["a"], ["d"]], space: null },
+    ]);
+  });
+
+  it("refuses where there is no room", () => {
+    const full = [group(1, ["a", "b"], ["c", "d"])];
+    expect(openBeside(full, "a", "e", "bottom", null)).toBe(full);
+    expect(openBeside(full, "a", "e", "left", null)).toBe(full);
+  });
+
+  it("numbers past the highest id standing", () => {
+    expect(openBeside([group(3, ["a"], ["b"])], "c", "d", "right", null)[1].id).toBe(4);
+  });
+});
+
+describe("closePane", () => {
+  it("removes the pane, drops an emptied column, and dissolves a group of one", () => {
+    expect(closePane([group(1, ["a", "b"], ["c"])], "c")[0].columns).toEqual([["a", "b"]]);
+    expect(closePane([group(1, ["a"], ["b"])], "b")).toEqual([]);
+  });
+});
+
+describe("pruneGroups", () => {
+  it("answers the same array when every member is present", () => {
+    const groups = [group(1, ["a"], ["b"])];
+    expect(pruneGroups(groups, new Set(["a", "b", "c"]))).toBe(groups);
+  });
+
+  it("drops missing members and any group that falls below two", () => {
+    const groups = [group(1, ["a", "b"], ["c"]), group(2, ["d"], ["e"])];
+    expect(pruneGroups(groups, new Set(["a", "c", "d"]))).toEqual([
+      { id: 1, columns: [["a"], ["c"]], space: null },
+    ]);
+  });
+});
+
+describe("stepUnits", () => {
+  it("folds a group's run into one step and leaves other rows single", () => {
+    const groups = [group(1, ["a"], ["b"]), group(2, ["c", "d"])];
+    const rows = ["a", "b", "c", "d", "e", "f"];
+    expect(stepUnits(rows, groups, (r) => r)).toEqual([["a", "b"], ["c", "d"], ["e"], ["f"]]);
+  });
+});
+
+describe("members", () => {
+  it("reads left to right, top to bottom", () => {
+    expect(members(group(1, ["a", "c"], ["b", "d"]))).toEqual(["a", "c", "b", "d"]);
+  });
+});

--- a/apps/desktop/src/lib/groups.ts
+++ b/apps/desktop/src/lib/groups.ts
@@ -1,0 +1,186 @@
+/// Where split groups are stored. Frontend-only, like the space list: a group
+/// is a way of looking at sessions, so losing one costs the view and never the
+/// work.
+export const GROUPS_KEY = "ade.splitGroups";
+
+/// A grid is at most two columns of at most two panes — four transcripts, and
+/// past that a pane is too narrow to read one in.
+const MAX_COLUMNS = 2;
+const MAX_ROWS = 2;
+
+export type SplitGroup = {
+  /// Names the group — "Group 3" — and survives other groups dissolving.
+  id: number;
+  /// Left to right, each top to bottom. Every column holds at least one pane.
+  columns: string[][];
+  /// The space it was made in. A group made with every project up lives there
+  /// alone and is not drawn inside any one space.
+  space: string | null;
+};
+
+/// Where on a pane a row is let go. `center` replaces the pane; the edges open
+/// beside it — above and below within its column, left and right as a column
+/// of their own.
+export type Region = "center" | "top" | "bottom" | "left" | "right";
+
+export const groupName = (group: { id: number }) => `Group ${group.id}`;
+
+/// Grid order: left to right, top to bottom. The sidebar's run reads the same.
+export const members = (group: SplitGroup): string[] => group.columns.flat();
+
+export function groupOf(
+  groups: SplitGroup[],
+  sessionId: string | null,
+): SplitGroup | undefined {
+  return sessionId
+    ? groups.find((g) => members(g).includes(sessionId))
+    : undefined;
+}
+
+/// The columns with one session taken out and any column it emptied dropped.
+function without(columns: string[][], sessionId: string): string[][] {
+  return columns
+    .map((c) => c.filter((id) => id !== sessionId))
+    .filter((c) => c.length > 0);
+}
+
+/// The columns with `dropped` landed on `anchor`'s pane at `region`, or `null`
+/// where there is no room. A session already in the grid is *moved*: taken
+/// out first, then placed, so dragging a pane's row onto another pane
+/// rearranges rather than duplicates.
+export function place(
+  columns: string[][],
+  anchor: string,
+  dropped: string,
+  region: Region,
+): string[][] | null {
+  if (anchor === dropped) return null;
+  const cols = without(columns, dropped);
+  const ci = cols.findIndex((c) => c.includes(anchor));
+  if (ci === -1) return null;
+  const col = cols[ci];
+  const ri = col.indexOf(anchor);
+
+  switch (region) {
+    case "center":
+      return cols.map((c, i) =>
+        i === ci ? c.map((id) => (id === anchor ? dropped : id)) : c,
+      );
+    case "top":
+    case "bottom": {
+      if (col.length >= MAX_ROWS) return null;
+      const next = [...col];
+      next.splice(region === "top" ? ri : ri + 1, 0, dropped);
+      return cols.map((c, i) => (i === ci ? next : c));
+    }
+    case "left":
+    case "right": {
+      if (cols.length >= MAX_COLUMNS) return null;
+      const next = [...cols];
+      next.splice(region === "left" ? ci : ci + 1, 0, [dropped]);
+      return next;
+    }
+  }
+}
+
+const REGION_LABELS: Record<Region, string> = {
+  center: "Replace",
+  top: "Open above",
+  bottom: "Open below",
+  left: "Open on the left",
+  right: "Open on the right",
+};
+
+/// What dropping `dropped` on `anchor`'s pane at `region` would do, as the
+/// sentence the drop zone draws, or `null` where nothing would happen. `groups`
+/// is the active space's own; a group elsewhere is not on screen to drop into.
+export function dropLabel(
+  groups: SplitGroup[],
+  anchor: string,
+  dropped: string,
+  region: Region,
+): string | null {
+  const target = groupOf(groups, anchor);
+  if (!place(target?.columns ?? [[anchor]], anchor, dropped, region)) return null;
+  // Replacing a single view is opening the session, which a click already does.
+  return region === "center" && !target ? "Open here" : REGION_LABELS[region];
+}
+
+/// Puts `dropped` on `anchor`'s pane at `region`: into the anchor's group in
+/// this space, or into a new group of the two. A session sits in one group at
+/// most, so both leave any other first — which can dissolve that one. The
+/// anchor's group in *another* space counts as another: it is not on screen
+/// here, and building on it would open nothing the reader can see.
+export function openBeside(
+  groups: SplitGroup[],
+  anchor: string,
+  dropped: string,
+  region: Region,
+  space: string | null,
+): SplitGroup[] {
+  const here = (g: SplitGroup) => g.space === space;
+  if (!dropLabel(groups.filter(here), anchor, dropped, region)) return groups;
+
+  const target = groups.find((g) => here(g) && members(g).includes(anchor));
+  let rest = groups;
+  for (const id of [dropped, anchor]) {
+    const old = groupOf(rest, id);
+    if (old && old !== target) rest = closePane(rest, id);
+  }
+
+  const columns = place(target?.columns ?? [[anchor]], anchor, dropped, region);
+  if (!columns) return groups;
+  if (target) {
+    return rest
+      .map((g) => (g === target ? { ...g, columns } : g))
+      .filter((g) => members(g).length >= 2);
+  }
+  // A single view replaced is a navigation, not a group.
+  if (region === "center") return rest;
+  const id = Math.max(0, ...rest.map((g) => g.id)) + 1;
+  return [...rest, { id, columns, space }];
+}
+
+/// The sidebar's order with each group's run folded into one step, for a chord
+/// that walks groups rather than rows. Only *consecutive* members fold — a
+/// group's run is drawn together, so that is every member — and a row in no
+/// group is a step of its own.
+export function stepUnits<T>(rows: T[], groups: SplitGroup[], id: (row: T) => string): T[][] {
+  const units: T[][] = [];
+  const unitOf = (row: T) => groupOf(groups, id(row))?.id ?? id(row);
+  for (const row of rows) {
+    const last = units[units.length - 1];
+    if (last && unitOf(last[0]) === unitOf(row)) last.push(row);
+    else units.push([row]);
+  }
+  return units;
+}
+
+/// Takes one session out of its group. A group left with one member is no
+/// group, so it goes too.
+export function closePane(groups: SplitGroup[], sessionId: string): SplitGroup[] {
+  return groups
+    .map((g) =>
+      members(g).includes(sessionId) ? { ...g, columns: without(g.columns, sessionId) } : g,
+    )
+    .filter((g) => members(g).length >= 2);
+}
+
+/// Drops members the index no longer lists — deleted or archived. Answers the
+/// same array where nothing changed, so a caller can skip the write.
+export function pruneGroups(groups: SplitGroup[], present: Set<string>): SplitGroup[] {
+  let changed = false;
+  const next = groups
+    .map((g) => {
+      const kept = g.columns.map((c) => c.filter((id) => present.has(id))).filter((c) => c.length);
+      if (members({ ...g, columns: kept }).length === members(g).length) return g;
+      changed = true;
+      return { ...g, columns: kept };
+    })
+    .filter((g) => {
+      if (members(g).length >= 2) return true;
+      changed = true;
+      return false;
+    });
+  return changed ? next : groups;
+}

--- a/apps/desktop/src/lib/groups.ts
+++ b/apps/desktop/src/lib/groups.ts
@@ -101,9 +101,11 @@ export function dropLabel(
   region: Region,
 ): string | null {
   const target = groupOf(groups, anchor);
+  // Replacing a single view is opening the session, which a click already
+  // does — so it is no drop at all.
+  if (!target && region === "center") return null;
   if (!place(target?.columns ?? [[anchor]], anchor, dropped, region)) return null;
-  // Replacing a single view is opening the session, which a click already does.
-  return region === "center" && !target ? "Open here" : REGION_LABELS[region];
+  return REGION_LABELS[region];
 }
 
 /// Puts `dropped` on `anchor`'s pane at `region`: into the anchor's group in
@@ -122,11 +124,6 @@ export function openBeside(
   if (!dropLabel(groups.filter(here), anchor, dropped, region)) return groups;
 
   const target = groups.find((g) => here(g) && members(g).includes(anchor));
-  // A single view replaced is a navigation, not a group — and decided before
-  // anything leaves a group, or opening a session this way would quietly
-  // take it out of the grid it lives in.
-  if (!target && region === "center") return groups;
-
   let rest = groups;
   for (const id of [dropped, anchor]) {
     const old = groupOf(rest, id);

--- a/apps/desktop/src/lib/groups.ts
+++ b/apps/desktop/src/lib/groups.ts
@@ -122,6 +122,11 @@ export function openBeside(
   if (!dropLabel(groups.filter(here), anchor, dropped, region)) return groups;
 
   const target = groups.find((g) => here(g) && members(g).includes(anchor));
+  // A single view replaced is a navigation, not a group — and decided before
+  // anything leaves a group, or opening a session this way would quietly
+  // take it out of the grid it lives in.
+  if (!target && region === "center") return groups;
+
   let rest = groups;
   for (const id of [dropped, anchor]) {
     const old = groupOf(rest, id);
@@ -135,8 +140,6 @@ export function openBeside(
       .map((g) => (g === target ? { ...g, columns } : g))
       .filter((g) => members(g).length >= 2);
   }
-  // A single view replaced is a navigation, not a group.
-  if (region === "center") return rest;
   const id = Math.max(0, ...rest.map((g) => g.id)) + 1;
   return [...rest, { id, columns, space }];
 }

--- a/apps/desktop/src/lib/sessionOrder.test.ts
+++ b/apps/desktop/src/lib/sessionOrder.test.ts
@@ -48,7 +48,11 @@ const project = (path: string) => ({ path }) as unknown as Project;
 /// What the heading over each run says — the project's own path, or the one
 /// word the pinned group is drawn under.
 const label = (group: ReturnType<typeof sessionGroups>[number]) =>
-  group.kind === "pinned" ? "Pinned" : group.projectPath;
+  group.kind === "pinned"
+    ? "Pinned"
+    : group.kind === "group"
+      ? `Group ${group.id}`
+      : group.projectPath;
 
 /// Each run as its heading and the rows drawn under it.
 const shape = (groups: ReturnType<typeof sessionGroups>) =>
@@ -486,7 +490,7 @@ describe("sessionGroups by state", () => {
     groups.map(
       (g) =>
         [
-          g.kind === "pinned" ? "Pinned" : g.state,
+          g.kind === "project" ? g.state : label(g),
           g.rows.map((r) => r.item.sessionId),
         ] as const,
     );
@@ -866,5 +870,43 @@ describe("filterSessions", () => {
     const found = filterSessions(items, "parser");
 
     expect(ids(sortSessions(found))).toEqual(["first", "second"]);
+  });
+});
+
+describe("split groups", () => {
+  it("draws a group as its own run first, in grid order, with its members nowhere else", () => {
+    const items = [
+      pin("pinned-member", "2026-01-03T00:00:00Z"),
+      item("newer", "2026-01-02T00:00:00Z", null, "/other"),
+      item("older", "2026-01-01T00:00:00Z"),
+      item("child", "2026-01-04T00:00:00Z", "older"),
+    ];
+    const splits = [{ id: 2, columns: [["older"], ["pinned-member"]], space: null }];
+
+    // The pinned member sits in its group rather than under Pinned; the child
+    // of a member stays under the project, since dragging a parent into the
+    // grid did not open it there.
+    expect(shape(sessionGroups(items, [], undefined, false, splits))).toEqual([
+      ["Group 2", ["older", "pinned-member"]],
+      ["/repo", ["child"]],
+      ["/other", ["newer"]],
+    ]);
+    expect(ids(sortSessions(items, [], undefined, false, splits))).toEqual([
+      "older",
+      "pinned-member",
+      "child",
+      "newer",
+    ]);
+  });
+
+  it("skips a member the list no longer holds and a group left with none", () => {
+    const items = [item("a", "2026-01-01T00:00:00Z")];
+    const splits = [
+      { id: 1, columns: [["gone"], ["a"]], space: null },
+      { id: 2, columns: [["x"], ["y"]], space: null },
+    ];
+    expect(shape(sessionGroups(items, [], undefined, false, splits))).toEqual([
+      ["Group 1", ["a"]],
+    ]);
   });
 });


### PR DESCRIPTION
## TLDR for human
- Drag a sidebar row onto the transcript to open it beside, above or below the selected session, or to replace it; up to four panes in two columns.
- Groups live in local storage under the space they were made in, named Group N, and dissolve at one member. A group draws as its own run at the top of the sidebar.
- One composer serves the focused pane, which is the selected session; the placeholder names it and the pane header carries a primary bar.
- Chords: ⌘1–4 focus a pane, ⌘⌥W closes it, ⌘⌥↑/↓ steps groups as one row each. View tabs moved to ⌘⌥1–3.
---

Frontend only. Pointer-based drag rather than HTML5, since Tauri's file-drop handler takes native drag events before the webview sees them and attachments depend on it. Eviction and read-marking treat every pane on screen as viewed.

Fixes DRA-182

🤖 Generated with [Claude Code](https://claude.com/claude-code)