### PR TITLE
fix(browser): stop pane opening on arriving at a tabbed session

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -582,7 +582,7 @@ function App() {
   const activeDoc = docs.find((doc) => doc.path === activeDocPath) ?? null;
 
   const browserTabs = useBrowserTabs(selectedSessionId);
-  const hasBrowserTabs = browserTabs.length > 0;
+  const hasBrowserTabs = browserTabs && browserTabs.length > 0;
   // The main column's Browser view is the panel's browser expanded. Arriving
   // on it closes the pane, every time and whatever tab the pane was on: the
   // reader came for the full width. Nothing keeps it closed — ⌘E brings it
@@ -858,16 +858,20 @@ function App() {
 
   // The first browser tab appearing — an agent opening a page — brings the
   // pane up on Browser, once. Not while the full view is up, where the same
-  // page is already the whole column.
-  const lastHadTabs = useRef(hasBrowserTabs);
+  // page is already the whole column. Only a change within one session
+  // counts, and only from a *known* empty list: arriving at a session that
+  // already holds a tab, or its first read landing, is the reader looking,
+  // not the agent acting, and both used to pop the pane open (DRA-184).
+  const lastTabs = useRef({ id: selectedSessionId, had: hasBrowserTabs });
   useEffect(() => {
-    const was = lastHadTabs.current;
-    lastHadTabs.current = hasBrowserTabs;
-    if (!was && hasBrowserTabs && !fullBrowserOpen) {
+    const was = lastTabs.current;
+    lastTabs.current = { id: selectedSessionId, had: hasBrowserTabs };
+    if (was.id !== selectedSessionId || was.had !== false) return;
+    if (hasBrowserTabs && !fullBrowserOpen) {
       setPanelTab("browser");
       setPanelOpen(true);
     }
-  }, [hasBrowserTabs, fullBrowserOpen, setPanelTab, setPanelOpen]);
+  }, [selectedSessionId, hasBrowserTabs, fullBrowserOpen, setPanelTab, setPanelOpen]);
 
   // Every way of arriving at a session, so none of them can forget to leave the
   // issues page. The two sidebar buttons closed it and the chords beside them

--- a/apps/desktop/src/components/browser/BrowserPane.tsx
+++ b/apps/desktop/src/components/browser/BrowserPane.tsx
@@ -87,7 +87,7 @@ export default function BrowserPane({
   onExpand?: () => void;
   onCollapse?: () => void;
 }) {
-  const tabs = useBrowserTabs(sessionId);
+  const tabs = useBrowserTabs(sessionId) ?? [];
   const pending = usePendingTab(sessionId);
   const current = pending ? null : (tabs.find((t) => t.active) ?? null);
   const viewport = useViewport(sessionId);

--- a/apps/desktop/src/lib/browser.ts
+++ b/apps/desktop/src/lib/browser.ts
@@ -126,11 +126,13 @@ function fetchTabs(sessionId: string) {
     .catch(() => fetched.delete(sessionId));
 }
 
-export function useBrowserTabs(sessionId: string | null): BrowserTab[] {
+/// `null` until the session's first read answers, so a caller acting on a
+/// tab *appearing* can tell one from the list just being learned.
+export function useBrowserTabs(sessionId: string | null): BrowserTab[] | null {
   start();
   if (sessionId) fetchTabs(sessionId);
   return useSyncExternalStore(subscribe, () =>
-    sessionId ? (tabsBySession.get(sessionId) ?? EMPTY) : EMPTY,
+    sessionId ? (tabsBySession.get(sessionId) ?? null) : EMPTY,
   );
 }
 


### PR DESCRIPTION
Selecting a session whose browser holds a tab, or launching onto one, popped the right pane open on Browser. The "first tab appearing brings the pane up" effect keyed on the tab count alone, and the tab store answers an empty list until a session's first read lands, so a switch read as a tab appearing.

`useBrowserTabs` now answers `null` until that read lands, and the effect opens the pane only on a known-empty to non-empty change within one session. An agent opening the first tab still brings the pane up; switching sessions or launching does not.

Fixes DRA-184

🤖 Generated with [Claude Code](https://claude.com/claude-code)