### PR TITLE
Split view: ⌘ digits run clockwise round the grid

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -55,6 +55,7 @@ import {
   members,
   groupOf,
   openBeside,
+  paneOrder,
   pruneGroups,
   stepUnits,
   type SplitGroup,
@@ -1252,7 +1253,7 @@ function App() {
   // and under the Diff tab or the issues page ⌘⌥W would close a pane the
   // reader cannot see.
   const gridShown = !!activeGroup && !issuesOpen && viewTab === "chat";
-  const paneIds = activeGroup ? members(activeGroup) : [];
+  const paneIds = activeGroup ? paneOrder(activeGroup) : [];
   // Keyboard focus moves with the pane. A click moves it by itself, but a
   // chord left it on whatever the old pane held — a link, a subagent control
   // — and Enter there then acted through the *selected* session, since every

--- a/apps/desktop/src/lib/groups.test.ts
+++ b/apps/desktop/src/lib/groups.test.ts
@@ -5,6 +5,7 @@ import {
   dropLabel,
   members,
   openBeside,
+  paneOrder,
   place,
   pruneGroups,
   stepUnits,
@@ -127,5 +128,20 @@ describe("stepUnits", () => {
 describe("members", () => {
   it("reads left to right, top to bottom", () => {
     expect(members(group(1, ["a", "c"], ["b", "d"]))).toEqual(["a", "c", "b", "d"]);
+  });
+});
+
+describe("paneOrder", () => {
+  it("runs clockwise from the top left", () => {
+    expect(paneOrder(group(1, ["a", "b"], ["c", "d"]))).toEqual(["a", "c", "d", "b"]);
+  });
+
+  it("puts the lone right pane second and the bottom left third", () => {
+    expect(paneOrder(group(1, ["a", "b"], ["c"]))).toEqual(["a", "c", "b"]);
+  });
+
+  it("reads top to bottom in one column and left to right in one row", () => {
+    expect(paneOrder(group(1, ["a", "b"]))).toEqual(["a", "b"]);
+    expect(paneOrder(group(1, ["a"], ["b"]))).toEqual(["a", "b"]);
   });
 });

--- a/apps/desktop/src/lib/groups.ts
+++ b/apps/desktop/src/lib/groups.ts
@@ -28,6 +28,15 @@ export const groupName = (group: { id: number }) => `Group ${group.id}`;
 /// Grid order: left to right, top to bottom. The sidebar's run reads the same.
 export const members = (group: SplitGroup): string[] => group.columns.flat();
 
+/// What the ⌘ digits walk: clockwise from the top left — the top row left to
+/// right, then the bottom row right to left. `members`' reading order puts ⌘2
+/// *under* ⌘1 in a 2×2, where the eye walks round the grid rather than down a
+/// column.
+export const paneOrder = (group: SplitGroup): string[] => [
+  ...group.columns.map((c) => c[0]),
+  ...[...group.columns].reverse().flatMap((c) => c.slice(1)),
+];
+
 export function groupOf(
   groups: SplitGroup[],
   sessionId: string | null,


### PR DESCRIPTION
The pane chords walked `members` order — left column top to bottom, then right — so in a 2×2 ⌘2 landed *under* ⌘1 rather than beside it.

Now clockwise from the top left: top row left to right, then bottom row right to left. A 2×2 is TL, TR, BR, BL; with three panes and one on the right, that pane is ⌘2 and the bottom left is ⌘3.

`paneOrder` in `lib/groups.ts`, read by the digit hotkeys in `App.tsx`. `members` is untouched, so the sidebar's run and every membership check still read in reading order.

Fixes DRA-189

🤖 Generated with [Claude Code](https://claude.com/claude-code)