### PR TITLE
feat(theme): default to light mode

### DIFF
--- a/apps/desktop/demo.html
+++ b/apps/desktop/demo.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="default" data-mode="dark" data-transparency class="dark">
+<html lang="en" data-theme="default" data-mode="light" data-transparency>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="default" data-mode="dark" data-transparency class="dark">
+<html lang="en" data-theme="default" data-mode="light" data-transparency>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -9,7 +9,7 @@
       // default one. Kept in sync with src/lib/theme.ts by hand — it can't import.
       try {
         var t = localStorage.getItem("ade.theme") || "default";
-        var m = localStorage.getItem("ade.mode") || "dark";
+        var m = localStorage.getItem("ade.mode") || "light";
         var dark =
           m === "dark" ||
           (m === "system" && matchMedia("(prefers-color-scheme: dark)").matches);

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -32,8 +32,8 @@
    The ramp lives on `[data-mode]` rather than on `:root` on purpose. Both selectors
    have the same specificity, so a light document matching `:root` too would take any
    dark token the light block happened to miss — a leak that shows up as one dark
-   card on a light page. index.html hard-codes `data-mode="dark"` in the markup as
-   well as stamping it, so there is no unstamped case for `:root` to have to cover. */
+   card on a light page. index.html hard-codes a `data-mode` in the markup as well as
+   stamping it, so there is no unstamped case for `:root` to have to cover. */
 :root {
   --radius: 0.625rem;
 

--- a/apps/desktop/src/lib/theme.ts
+++ b/apps/desktop/src/lib/theme.ts
@@ -93,7 +93,7 @@ export const THEMES: Theme[] = [
 ];
 
 export const DEFAULT_THEME: ThemeName = "default";
-const DEFAULT_MODE: ThemeMode = "dark";
+const DEFAULT_MODE: ThemeMode = "light";
 
 function theme(name: ThemeName): Theme | undefined {
   return THEMES.find((t) => t.id === name);


### PR DESCRIPTION
Flips the default mode from dark to light in the three places that decide it: `DEFAULT_MODE` in `theme.ts`, the pre-paint fallback in `index.html`, and the static `<html>` attributes in `index.html` and `demo.html`.

Anyone with a stored `ade.mode` keeps their pick — only a fresh install changes.

Fixes DRA-190

🤖 Generated with [Claude Code](https://claude.com/claude-code)