### PR TITLE
fix(pr): draw comment previews as plain text

### DIFF
--- a/apps/desktop/src/lib/pr.test.ts
+++ b/apps/desktop/src/lib/pr.test.ts
@@ -380,6 +380,30 @@ describe("firstLine, markup", () => {
     expect(firstLine("[Open the run](https://ci.test/1)")).toBe("Open the run");
   });
 
+  it("skips a link the bot wrote across several lines", () => {
+    expect(firstLine('<a href="https://x.test">\nGreptile\n</a>\n2 issues found.')).toBe(
+      "2 issues found.",
+    );
+  });
+
+  it("ends a tag at the real `>`, not one inside an attribute", () => {
+    expect(firstLine('<img alt="Build > tests" src="x.svg"> passed')).toBe("passed");
+  });
+
+  // Greptile's own summary, the body this was written against: a retrigger
+  // badge wrapped in an anchor, then the one thing worth reading.
+  it("finds the score under a bot's badge", () => {
+    expect(
+      firstLine(
+        '<h2><a href="https://app.greptile.com/api/retrigger?id=1"><img alt="Retrigger" src="r.svg" align="right"></a>Confidence Score: 4/5</h2>',
+      ),
+    ).toBe("Confidence Score: 4/5");
+  });
+
+  it("leaves a bare `<` in prose alone", () => {
+    expect(firstLine("fails when x < y and y > z")).toBe("fails when x < y and y > z");
+  });
+
   it("decodes the entities that HTML body carries", () => {
     expect(firstLine("<p>Ann &amp; Bob said &quot;ship&quot;</p>")).toBe('Ann & Bob said "ship"');
   });

--- a/apps/desktop/src/lib/pr.test.ts
+++ b/apps/desktop/src/lib/pr.test.ts
@@ -363,6 +363,30 @@ describe("firstLine, markup", () => {
   it("drops emphasis marks that render as nothing in a plain preview", () => {
     expect(firstLine("**Deploy** failed on `main`")).toBe("Deploy failed on main");
   });
+
+  it("keeps the words out of a bot's HTML and none of the tags", () => {
+    expect(firstLine("<h2>Greptile overview</h2>")).toBe("Greptile overview");
+  });
+
+  it("skips a heading that is only a bot's own link and shows what it said", () => {
+    expect(
+      firstLine(
+        '<h2><a href="https://app.greptile.com/api/retrigger?id=1">Greptile</a></h2>\n<p>2 issues found.</p>',
+      ),
+    ).toBe("2 issues found.");
+  });
+
+  it("falls back to a link where the body is nothing else", () => {
+    expect(firstLine("[Open the run](https://ci.test/1)")).toBe("Open the run");
+  });
+
+  it("decodes the entities that HTML body carries", () => {
+    expect(firstLine("<p>Ann &amp; Bob said &quot;ship&quot;</p>")).toBe('Ann & Bob said "ship"');
+  });
+
+  it("skips a line that was only a tag", () => {
+    expect(firstLine("<details>\n<summary>Findings</summary>")).toBe("Findings");
+  });
 });
 
 describe("prBadgeCount", () => {

--- a/apps/desktop/src/lib/pr.ts
+++ b/apps/desktop/src/lib/pr.ts
@@ -379,26 +379,56 @@ export function isSettling(pr: PullRequest | null): boolean {
   return pr.mergeable === "UNKNOWN" || pr.checks.some((c) => c.state === "pending");
 }
 
-/// The first line worth showing, for a collapsed comment's preview.
+const ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  "#39": "'",
+  nbsp: " ",
+};
+
+/// A markdown or HTML link, whole. An image is deliberately not one: its alt
+/// text is a badge's state (`Ready`, `Failed`), which is the comment's news.
+const LINKS = /<a\b[^>]*>[\s\S]*?<\/a>|(?<!!)\[[^\]]*\]\([^)]*\)/gi;
+
+/// One line of a comment body as plain text.
 ///
 /// The preview is plain text in a truncating span, so the markup that would
-/// have been rendered has to come off first: a heading's `#` marks say nothing
-/// at one line long, and a link's `(https://…)` half is usually longer than the
-/// words around it and is not clickable here anyway.
-export function firstLine(body: string): string {
+/// have been rendered has to come off: a heading's `#` marks say nothing at one
+/// line long, and a link's `(https://…)` half is usually longer than the words
+/// around it and is not clickable here anyway. Bots write HTML as often as
+/// markdown — a Greptile comment opens `<h2><a href="…">` — and a tag drawn
+/// literally spends the whole row saying nothing.
+function plain(line: string): string {
   return (
-    body
-      .split("\n")
-      .map((line) =>
-        line
-          .replace(/^#{1,6}\s+/, "")
-          // `[text](url)` keeps its text; a bare image `![alt](url)` keeps its
-          // alt, which is the only word in it a reader can use.
-          .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
-          .replace(/[*_`]/g, "")
-          .trim(),
-      )
-      .find((line) => line.length > 0) ?? ""
+    line
+      // A tag becomes a space, or the words either side of it run together.
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&(amp|lt|gt|quot|#39|nbsp);/g, (_, name: string) => ENTITIES[name])
+      .replace(/\s+/g, " ")
+      .trim()
+      .replace(/^#{1,6}\s+/, "")
+      .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+      .replace(/[*_`]/g, "")
+      .trim()
+  );
+}
+
+/// The first line worth showing, for a collapsed comment's preview.
+///
+/// A line that is nothing but links is skipped: bots open with a logo or a
+/// "re-run" button, and its words ("Greptile") name the author the row already
+/// names rather than saying what the comment found. Link text inside a sentence
+/// stays, since there the words are the sentence. A body that is *only* links
+/// falls back to them, a name being better than a blank row.
+export function firstLine(body: string): string {
+  const lines = body.split("\n").map((line) => ({
+    text: plain(line),
+    prose: plain(line.replace(LINKS, " ")),
+  }));
+  return (
+    lines.find((l) => l.prose.length > 0)?.text ?? lines.find((l) => l.text.length > 0)?.text ?? ""
   );
 }
 

--- a/apps/desktop/src/lib/pr.ts
+++ b/apps/desktop/src/lib/pr.ts
@@ -388,9 +388,23 @@ const ENTITIES: Record<string, string> = {
   nbsp: " ",
 };
 
+/// A tag's attributes. Quoted, so a tag does not end at the first `>` — an
+/// `alt="Build > tests"` would otherwise leave the rest of the tag on screen.
+const ATTRS = String.raw`[^>"']*(?:(?:"[^"]*"|'[^']*')[^>"']*)*`;
+
+/// A tag. It must open with a letter, `/` or `!`, so a bare `<` in prose
+/// ("if x < y") stays the word it is rather than eating the sentence to the
+/// next `>`.
+const TAG = new RegExp(`<[a-zA-Z/!]${ATTRS}>`, "g");
+
 /// A markdown or HTML link, whole. An image is deliberately not one: its alt
 /// text is a badge's state (`Ready`, `Failed`), which is the comment's news.
-const LINKS = /<a\b[^>]*>[\s\S]*?<\/a>|(?<!!)\[[^\]]*\]\([^)]*\)/gi;
+const LINKS = new RegExp(`<a\\b${ATTRS}>[\\s\\S]*?</a>|(?<!!)\\[[^\\]]*\\]\\([^)]*\\)`, "gi");
+
+/// How much of a body the preview reads. It draws one truncated line, so the
+/// tail of a long comment can say nothing — and a cap bounds the scanning these
+/// patterns do over text somebody else wrote.
+const PREVIEW_LIMIT = 4000;
 
 /// One line of a comment body as plain text.
 ///
@@ -404,7 +418,7 @@ function plain(line: string): string {
   return (
     line
       // A tag becomes a space, or the words either side of it run together.
-      .replace(/<[^>]+>/g, " ")
+      .replace(TAG, " ")
       .replace(/&(amp|lt|gt|quot|#39|nbsp);/g, (_, name: string) => ENTITIES[name])
       .replace(/\s+/g, " ")
       .trim()
@@ -423,9 +437,14 @@ function plain(line: string): string {
 /// stays, since there the words are the sentence. A body that is *only* links
 /// falls back to them, a name being better than a blank row.
 export function firstLine(body: string): string {
-  const lines = body.split("\n").map((line) => ({
+  const head = body.slice(0, PREVIEW_LIMIT);
+  // Links are blanked where they stand, newlines kept, rather than each line
+  // being searched on its own — an anchor wrapped across lines would otherwise
+  // leave its text on a line of its own looking like prose.
+  const blanked = head.replace(LINKS, (m) => m.replace(/[^\n]/g, " ")).split("\n");
+  const lines = head.split("\n").map((line, i) => ({
     text: plain(line),
-    prose: plain(line.replace(LINKS, " ")),
+    prose: plain(blanked[i]),
   }));
   return (
     lines.find((l) => l.prose.length > 0)?.text ?? lines.find((l) => l.text.length > 0)?.text ?? ""


### PR DESCRIPTION
A collapsed comment row draws the body's first line as plain text, and a bot writes HTML as often as markdown — Greptile opens `<h2><a href="https://app.greptile.com/api/retrigger?id=…">`, which is what the row showed.

`firstLine` now strips tags (each to a space, or the words either side run together) and decodes the five common entities, before the markdown stripping already there.

A heading that is only the bot's own link says nothing either, so a line whose whole content is links is skipped. Link text inside a sentence stays, an image's alt text stays (it is a badge's state), and a body that is only a link falls back to it.

Fixes DRA-193

🤖 Generated with [Claude Code](https://claude.com/claude-code)