### PR TITLE
Dim unfocused panes while composing in split view

### DIFF
--- a/apps/desktop/src/components/SplitView.tsx
+++ b/apps/desktop/src/components/SplitView.tsx
@@ -6,7 +6,7 @@ import GitBranchIcon from "@/components/icons/GitBranchIcon";
 import { Button } from "@/components/ui/button";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { useDraft } from "@/hooks/useDraft";
+import { useHasDraft } from "@/hooks/useDraft";
 import type { PaneState } from "@/hooks/useSessions";
 import { DROP_ATTR, useSessionDrag } from "@/lib/dragSession";
 import { basename } from "@/lib/format";
@@ -56,9 +56,10 @@ export default function SplitView({
   // Composing into the focused pane, so every other transcript gives way. The
   // draft store is read here directly rather than threaded down from the
   // composer — it is module-level and keyed by session, which is the whole
-  // reason it exists.
-  const [draft] = useDraft(focusedId);
-  const composing = draft.length > 0;
+  // reason it exists. The *emptiness* alone, never the text: this component
+  // holds every mounted transcript, so subscribing to the string would rerender
+  // all four on every keystroke.
+  const composing = useHasDraft(focusedId);
   // Grid order, which is what ⌘1–4 count in.
   const numbers = new Map(columns.flat().map((item, i) => [item.sessionId, i + 1]));
   return (

--- a/apps/desktop/src/components/SplitView.tsx
+++ b/apps/desktop/src/components/SplitView.tsx
@@ -6,6 +6,7 @@ import GitBranchIcon from "@/components/icons/GitBranchIcon";
 import { Button } from "@/components/ui/button";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useDraft } from "@/hooks/useDraft";
 import type { PaneState } from "@/hooks/useSessions";
 import { DROP_ATTR, useSessionDrag } from "@/lib/dragSession";
 import { basename } from "@/lib/format";
@@ -52,6 +53,12 @@ export default function SplitView({
 }: SplitViewProps) {
   const drag = useSessionDrag();
   const metaHeld = useMetaHeld();
+  // Composing into the focused pane, so every other transcript gives way. The
+  // draft store is read here directly rather than threaded down from the
+  // composer — it is module-level and keyed by session, which is the whole
+  // reason it exists.
+  const [draft] = useDraft(focusedId);
+  const composing = draft.length > 0;
   // Grid order, which is what ⌘1–4 count in.
   const numbers = new Map(columns.flat().map((item, i) => [item.sessionId, i + 1]));
   return (
@@ -110,7 +117,16 @@ export default function SplitView({
                   showNumber={metaHeld && !focused}
                   onClose={() => onClose(item.sessionId)}
                 />
-                <div className="min-h-0 flex-1">
+                {/* Dimmed rather than veiled: a scrim is one more element to
+                    keep in step with the palette, and opacity recedes the
+                    transcript against whatever is behind it. The header keeps
+                    full strength, since it is what names the pane. */}
+                <div
+                  className={cn(
+                    "min-h-0 flex-1 transition-opacity duration-150 ease-out",
+                    composing && !focused && "opacity-35",
+                  )}
+                >
                   <Chat
                     {...paneState(item.sessionId)}
                     {...chat}

--- a/apps/desktop/src/hooks/useDraft.ts
+++ b/apps/desktop/src/hooks/useDraft.ts
@@ -56,6 +56,19 @@ export function appendToDraft(sessionId: string | null, text: string) {
   writeDraft(sessionId, current + join + trimmed);
 }
 
+/// Whether a session's draft holds anything, without subscribing to what it
+/// holds.
+///
+/// A keystroke changes the string on every press, where this answer changes
+/// twice in a whole prompt — so a consumer that only asks "is the box empty"
+/// is not re-rendered by typing. `SplitView` is one, and it holds every
+/// mounted transcript, none of which are memoized.
+export function useHasDraft(sessionId: string | null): boolean {
+  // Safe against `useSyncExternalStore`'s reference check for `useDraft`'s own
+  // reason, one type over: equal booleans compare equal.
+  return useSyncExternalStore(changed.subscribe, () => readDraft(sessionId).length > 0);
+}
+
 /// The composer's text for one session, kept apart from every other session's.
 ///
 /// Switching sessions must not carry a half-typed prompt across, and coming


### PR DESCRIPTION
One composer under four transcripts is one box that can send into the wrong session. The placeholder names the target pane, but typing takes it away — exactly when "which session is this going to" starts being worth asking.

Every pane except the focused one fades to 35% while the composer holds text, over 150ms. `SplitView` reads `useDraft(focusedId)` directly: the draft store is module-level and keyed by session, which is the whole reason it exists, so nothing needs threading down from the composer.

Dimmed rather than veiled — a scrim is one more element to keep in step with the palette, where opacity recedes the transcript against whatever is behind it. Pane headers keep full strength, since they are what name each pane.

Tried and dropped along the way: a tint over the *focused* pane, which sits over the text most likely being read while composing; the pane header moved to the bottom of each pane; and the `project / title` string drawn above the input once it had content, which the dimming already answers.

Fixes DRA-194

🤖 Generated with [Claude Code](https://claude.com/claude-code)