### PR TITLE
fix(panel): hide Subagents tab when session has none

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -775,7 +775,16 @@ function App() {
     setPanelOpen(true);
   };
 
-  const tabs = tabOrder({ pr: hasPrTab, docs: hasDocsTab, issue: hasIssueTab });
+  // A live background task counts even where no run is built for it yet, or the
+  // chat's background-tasks indicator offers a tab that isn't in the row.
+  const hasSubagentsTab = subagents.length > 0 || backgroundTasks.length > 0;
+
+  const tabs = tabOrder({
+    pr: hasPrTab,
+    docs: hasDocsTab,
+    issue: hasIssueTab,
+    subagents: hasSubagentsTab,
+  });
 
   // One rule, read rather than written back: an explicit pick wins wherever it
   // still names a tab this session draws, and otherwise the derived default
@@ -1622,6 +1631,7 @@ function App() {
             pr={hasPrTab}
             docs={hasDocsTab}
             issue={hasIssueTab}
+            subagents={hasSubagentsTab}
             refresh={panelRefresh}
             cwd={selectedSession.cwd}
           >

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -155,12 +155,16 @@ export function tabOrder({
   pr,
   docs,
   issue,
+  subagents,
 }: {
   pr: boolean;
   /// At least one markdown file is open in the pane — see
   /// [useDocs](../hooks/useDocs.ts). Absent otherwise, for the PR tab's reason.
   docs: boolean;
   issue: boolean;
+  /// This session has spawned at least one subagent or background task. Absent
+  /// otherwise, for the PR tab's reason — most sessions never spawn one.
+  subagents: boolean;
 }): readonly PanelTab[] {
   const tabs: PanelTab[] = pr ? ["pr", "changes", "browser"] : ["changes", "browser"];
   // After Changes, which is what keeps Issue immediately before Subagents.
@@ -168,7 +172,7 @@ export function tabOrder({
   // Immediately before Subagents wherever it is drawn, so the row's order is
   // the same one ⌘⇧[ steps whether or not a session has an issue on it.
   if (issue) tabs.push("issue");
-  tabs.push("subagents");
+  if (subagents) tabs.push("subagents");
 
   return tabs;
 }
@@ -191,6 +195,9 @@ type RightPanelProps = {
   /// PR tab's reason: a tab whose only content is "there is nothing here" is one
   /// the eye skips past on every session that will never have one.
   issue?: boolean;
+  /// This session has spawned at least one subagent or background task. Absent
+  /// otherwise, for the same reason.
+  subagents?: boolean;
   /// Re-reads whatever the active tab is showing, drawn at the far end of the
   /// tab row. One button rather than one per panel: it means the same thing
   /// everywhere, so it belongs to the frame and always sits in the same place.
@@ -256,13 +263,14 @@ export default function RightPanel({
   pr = false,
   docs = false,
   issue = false,
+  subagents = false,
   refresh,
   cwd,
   actions,
   heading,
   children,
 }: RightPanelProps) {
-  const tabs = tabOrder({ pr, docs, issue });
+  const tabs = tabOrder({ pr, docs, issue, subagents });
 
   return (
     <aside


### PR DESCRIPTION
The right panel always drew a Subagents tab, even for the many sessions that never spawn one — so the tab sat there with nothing behind it but "No subagents in this session."

Now it is drawn only when the session has a subagent run or a live background task, the same rule the PR, Docs and Issue tabs already follow. A live background task counts even where no run is built for it yet, or the chat's background-tasks indicator would offer a tab that isn't in the row.

Typecheck and the 575 frontend tests pass.

Fixes DRA-195

🤖 Generated with [Claude Code](https://claude.com/claude-code)