### PR TITLE
Block install on the turn, not background tasks

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -137,7 +137,6 @@ function App() {
     busy,
     backgroundTasks,
     liveTaskIds,
-    tasksBySession,
     compacting,
     apiRetry,
     working,
@@ -240,13 +239,14 @@ function App() {
   } = useUpdater();
 
   // Every session the app has started this run, not the open one: the install
-  // relaunches the app, so any live child is one this would kill mid-turn — or
-  // mid-task, since a background task outlives its turn. A session from a
-  // previous run cannot still be running — no child survives a restart — so
-  // the two live maps answer this on their own.
-  const anyRunning =
-    Object.values(statusBySession).some((s) => s === "in_progress") ||
-    Object.values(tasksBySession).some((tasks) => tasks.length > 0);
+  // relaunches the app, so any live child is one this would kill mid-turn. A
+  // session from a previous run cannot still be running — no child survives a
+  // restart — so the live map answers this on its own.
+  //
+  // The turn alone, never outstanding background tasks: a `local_bash` task
+  // never ends, so a session running a dev server blocked the update for the
+  // rest of its life with nothing saying why. Same reading Stop and fork take.
+  const anyRunning = Object.values(statusBySession).some((s) => s === "in_progress");
 
   const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
 

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -775,7 +775,7 @@ function UpdatesRow({
         <Tooltip>
           <TooltipTrigger asChild>{button}</TooltipTrigger>
           <TooltipContent side="top">
-            Waiting for the running task to finish.
+            Waiting for the running turn to finish.
           </TooltipContent>
         </Tooltip>
       ) : (

--- a/apps/desktop/src/components/UpdateRow.tsx
+++ b/apps/desktop/src/components/UpdateRow.tsx
@@ -113,7 +113,7 @@ export default function UpdateRow({
         <Tooltip>
           <TooltipTrigger asChild>{button}</TooltipTrigger>
           <TooltipContent side="top">
-            Waiting for the running task to finish.
+            Waiting for the running turn to finish.
           </TooltipContent>
         </Tooltip>
       ) : (


### PR DESCRIPTION
The Install button waited on `anyRunning`, which read `statusBySession` **or** `tasksBySession`. That second half is the old `has_outstanding_work` reading, and a `local_bash` task never ends on its own — so a session running a dev server or a `Monitor` blocked the update for the rest of its life, with the tooltip saying only "waiting for the running task to finish".

The install relaunches the app and kills every child regardless, so the question worth asking is the narrow one: is a turn in flight. Same reading Stop and fork take since DRA-185.

Both tooltips — sidebar row and Settings — now say turn.

Fixes DRA-196

🤖 Generated with [Claude Code](https://claude.com/claude-code)
