### PR TITLE
Stop shimmering a subagent row once its run went to background

### DIFF
--- a/apps/desktop/src/components/SubagentPanel.tsx
+++ b/apps/desktop/src/components/SubagentPanel.tsx
@@ -146,7 +146,7 @@ function RunRow({
           <span
             className={cn(
               "min-w-0 flex-1 truncate",
-              run.done ? "text-sidebar-foreground" : "shimmer-text",
+              run.done || run.background ? "text-sidebar-foreground" : "shimmer-text",
             )}
           >
             {detail}

--- a/apps/desktop/src/components/chat/SubagentRow.tsx
+++ b/apps/desktop/src/components/chat/SubagentRow.tsx
@@ -26,6 +26,10 @@ export default function SubagentRow({
     run.label ??
     "Subagent";
 
+  // A run in the background is not work the reader is waiting on: the tasks
+  // indicator already says it is up, and a dev server would shimmer forever.
+  const running = !run.done && !run.background;
+
   return (
     <button
       type="button"
@@ -36,12 +40,12 @@ export default function SubagentRow({
           than settling into a resting pose — a still orb next to a finished run
           reads as something that stalled. Same size and pinned theme as
           `WorkingIndicator`, which is the other place it appears inline. */}
-      {!run.done && <Orb state="listening" size={20} aria-hidden />}
+      {running && <Orb state="listening" size={20} aria-hidden />}
 
       <span
         className={cn(
           "min-w-0 max-w-fit truncate",
-          run.done ? "text-muted-foreground" : "shimmer-text",
+          running ? "shimmer-text" : "text-muted-foreground",
         )}
       >
         {detail}

--- a/apps/desktop/src/lib/transcript.test.ts
+++ b/apps/desktop/src/lib/transcript.test.ts
@@ -578,6 +578,18 @@ describe("a call whose background task the child still holds", () => {
     expect(subagentById.get("c2")?.background).toBe(false);
   });
 
+  /// The abandoned stand-in is a result too, and must not count: nothing
+  /// answered, the child died.
+  it("does not read an abandoned run as background", () => {
+    const { subagentById, resultByCallId } = buildTranscript(
+      [callStarted(0, "c1"), spawn(1, "c1", "t1"), completed(2)],
+      false,
+    );
+
+    expect(resultByCallId.get("c1")?.text).toMatch(ABANDONED);
+    expect(subagentById.get("c1")?.background).toBe(false);
+  });
+
   /// And with the task gone, the ordinary rule is back.
   it("is abandoned once the task drains", () => {
     const { resultByCallId } = buildTranscript(

--- a/apps/desktop/src/lib/transcript.test.ts
+++ b/apps/desktop/src/lib/transcript.test.ts
@@ -557,6 +557,27 @@ describe("a call whose background task the child still holds", () => {
     expect(resultByCallId.get("c1")).toBeUndefined();
   });
 
+  /// A background task's call answers at once ("running in background with
+  /// ID …") and its run never completes, so the row must read it off the
+  /// result rather than shimmer for the rest of the session.
+  it("reads as background once the spawning call has answered", () => {
+    const answered = (seq: number, callId: string): AgentEvent =>
+      event(seq, {
+        type: "tool_call_completed",
+        callId,
+        result: { text: "", isError: false, structured: null, exitCode: null, durationMs: null, images: [] },
+      } as AgentEventPayload);
+
+    const { subagentById } = buildTranscript(
+      [callStarted(0, "c1"), spawn(1, "c1", "t1"), answered(2, "c1"), callStarted(3, "c2"), spawn(4, "c2", "t2")],
+      true,
+      new Set(["t1", "t2"]),
+    );
+
+    expect(subagentById.get("c1")?.background).toBe(true);
+    expect(subagentById.get("c2")?.background).toBe(false);
+  });
+
   /// And with the task gone, the ordinary rule is back.
   it("is abandoned once the task drains", () => {
     const { resultByCallId } = buildTranscript(

--- a/apps/desktop/src/lib/transcript.ts
+++ b/apps/desktop/src/lib/transcript.ts
@@ -19,6 +19,10 @@ export type SubagentRun = {
   status: string | null;
   lastTool: string | null;
   done: boolean;
+  /// The spawning call answered while the run was still open, so the harness
+  /// put the work in the background. Not "in flight": a dev server started
+  /// this way never ends, and a row shimmering for it reads as a call stuck.
+  background: boolean;
   usage: Usage | null;
   /// The subagent's own work, excluding its lifecycle events.
   events: AgentEvent[];
@@ -669,6 +673,7 @@ export function buildTranscript(
         status: null,
         lastTool: null,
         done: false,
+        background: false,
         usage: null,
         events: [],
         spawn: null,
@@ -703,13 +708,6 @@ export function buildTranscript(
     }
   }
 
-  // A second pass, because the spawning call is logged before the `task_started`
-  // that creates the run — the tool_use block lands in the assistant message
-  // first.
-  for (const run of subagentById.values()) {
-    run.spawn = callById.get(run.id) ?? null;
-  }
-
   // Applied last, and only where no real result exists. A background subagent
   // can report back after the turn that spawned it, so a call marked above must
   // still lose to the result that eventually arrives — and while the child
@@ -720,6 +718,16 @@ export function buildTranscript(
     const taskId = subagentById.get(callId)?.taskId;
     if (taskId !== null && taskId !== undefined && liveTaskIds.has(taskId)) continue;
     resultByCallId.set(callId, ABANDONED);
+  }
+
+  // A second pass, because the spawning call is logged before the `task_started`
+  // that creates the run — the tool_use block lands in the assistant message
+  // first. After the abandoned marks, so `background` reads the final result
+  // map: a foreground run's call answers only when the run ends, so a result
+  // beside an open run is the harness saying it went to the background.
+  for (const run of subagentById.values()) {
+    run.spawn = callById.get(run.id) ?? null;
+    run.background = !run.done && resultByCallId.has(run.id);
   }
 
   const mainThread = events.filter((event) => !event.subagent);

--- a/apps/desktop/src/lib/transcript.ts
+++ b/apps/desktop/src/lib/transcript.ts
@@ -708,6 +708,17 @@ export function buildTranscript(
     }
   }
 
+  // A second pass, because the spawning call is logged before the `task_started`
+  // that creates the run — the tool_use block lands in the assistant message
+  // first. Before the abandoned marks below, so `background` reads real
+  // results only: a foreground run's call answers when the run ends, so a
+  // result beside an open run is the harness saying it backgrounded the work,
+  // where the abandoned stand-in says nothing answered at all.
+  for (const run of subagentById.values()) {
+    run.spawn = callById.get(run.id) ?? null;
+    run.background = !run.done && resultByCallId.has(run.id);
+  }
+
   // Applied last, and only where no real result exists. A background subagent
   // can report back after the turn that spawned it, so a call marked above must
   // still lose to the result that eventually arrives — and while the child
@@ -718,16 +729,6 @@ export function buildTranscript(
     const taskId = subagentById.get(callId)?.taskId;
     if (taskId !== null && taskId !== undefined && liveTaskIds.has(taskId)) continue;
     resultByCallId.set(callId, ABANDONED);
-  }
-
-  // A second pass, because the spawning call is logged before the `task_started`
-  // that creates the run — the tool_use block lands in the assistant message
-  // first. After the abandoned marks, so `background` reads the final result
-  // map: a foreground run's call answers only when the run ends, so a result
-  // beside an open run is the harness saying it went to the background.
-  for (const run of subagentById.values()) {
-    run.spawn = callById.get(run.id) ?? null;
-    run.background = !run.done && resultByCallId.has(run.id);
   }
 
   const mainThread = events.filter((event) => !event.subagent);


### PR DESCRIPTION
A `local_bash` background task (dev server) never emits `subagent_completed`, so its chat row kept the orb and shimmer for the rest of the session — indistinguishable from a call that is stuck.

`SubagentRun.background` is set once the spawning call has a result while the run is still open: a foreground run's call only answers when the run ends, so a result beside an open run is the harness saying it backgrounded the work. Chat row drops orb and shimmer on it; panel row drops the shimmer. Stop stays available — `stoppable` still reads `done`.

Fixes DRA-198

🤖 Generated with [Claude Code](https://claude.com/claude-code)